### PR TITLE
PLAT-11563 Adding authToken field in authentication endpoints

### DIFF
--- a/authenticator/authenticator-api-public-deprecated.yaml
+++ b/authenticator/authenticator-api-public-deprecated.yaml
@@ -270,9 +270,16 @@ definitions:
       token:
         type: string
         description: |
-          The token which should be passed. This should be considered opaque data by
-          the client. It is not intended to conatain any data interpretable by the
+          Token that can be passed as header, it can be considered a refresh token along with the
+          idm/tokens ("authorizationToken").
+          This should be considered opaque data by the client. It is not intended to contain any data interpretable by the
           client. The format is secret and subject to change without notice.
+      authorizationToken:
+        type: string
+        description: |
+          Short lived access token built from a user session. It can be used for the same purposes as the sessionToken
+          and It should be passed as an header named "Authorization". At least one between SessionToken or Authorization
+          header must me provided on subsequent API calls.
   ExtensionAppAuthenticateRequest:
       type: object
       description: Request body for extension app authentication

--- a/authenticator/authenticator-api-public.yaml
+++ b/authenticator/authenticator-api-public.yaml
@@ -266,9 +266,16 @@ definitions:
       token:
         type: string
         description: |
-          The token which should be passed. This should be considered opaque data by
-          the client. It is not intended to conatain any data interpretable by the
+          Token that can be passed as header, it can be considered a refresh token along with the
+          idm/tokens ("authorizationToken").
+          This should be considered opaque data by the client. It is not intended to contain any data interpretable by the
           client. The format is secret and subject to change without notice.
+      authorizationToken:
+        type: string
+        description: |
+          Short lived access token built from a user session. It can be used for the same purposes as the sessionToken
+          and It should be passed as an header named "Authorization". At least one between SessionToken or Authorization
+          header must me provided on subsequent API calls.
   ExtensionAppAuthenticateRequest:
       type: object
       description: Request body for extension app authentication

--- a/login/login-api-public.yaml
+++ b/login/login-api-public.yaml
@@ -264,9 +264,16 @@ definitions:
       token:
         type: string
         description: |
-          The token which should be passed. This should be considered opaque data by
-          the client. It is not intended to contain any data interpretable by the
+          Token that can be passed as header, it can be considered a refresh token along with the
+          idm/tokens ("authorizationToken").
+          This should be considered opaque data by the client. It is not intended to conatain any data interpretable by the
           client. The format is secret and subject to change without notice.
+      authorizationToken:
+        type: string
+        description: |
+          Short lived access token built from a user session. It can be used for the same purposes as the sessionToken
+          and It should be passed as an header named "Authorization". At least one between SessionToken or Authorization
+          header must me provided on subsequent API calls. 
   AuthenticateRequest:
       type: object
       description: Request body for pubkey authentication


### PR DESCRIPTION
We would like to start using the common jwt/authorization token in the public APIs, to do so we need our BDKs to be able to retrieve this token during the authentication process.
To avoid making extra calls to the idm/tokens endpoint a new field called authorizationToken is been added in the payload for both login/pubkey/authenticate (used in RSA authentication) and sessionauth/v1/authenticate (used for Certificate authentication).
The authorization token will have the following format "Bearer authTokenValue" so that can be directly used as it is in the Authorization header for any subsequential calls to our public APIs.
For now this token will be introduced only for users authentication and not for apps which will be handled in the future.