### PR TITLE
Add Bearer token as optional security scheme for public apis

### DIFF
--- a/agent/agent-api-public-deprecated.yaml
+++ b/agent/agent-api-public-deprecated.yaml
@@ -25,6 +25,20 @@ info:
     To know more about the endpoints, refer to Create Messages/Events
     Stream and Read Messages/Events Stream. Unless otherwise specified,
     all events were added in 1.46.
+    
+securityDefinitions:
+  BearerAuth:
+    type: apiKey
+    in: header
+    name: Authorization
+
+security: [
+  # empty to make it optional
+  {},
+  {
+    BearerAuth: []
+  }
+]
 
 paths:
   '/v4/datafeed/create':

--- a/agent/agent-api-public-deprecated.yaml
+++ b/agent/agent-api-public-deprecated.yaml
@@ -32,13 +32,10 @@ securityDefinitions:
     in: header
     name: Authorization
 
-security: [
+security:
   # empty to make it optional
-  {},
-  {
-    BearerAuth: []
-  }
-]
+  - { }
+  - BearerAuth: [ ]
 
 paths:
   '/v4/datafeed/create':

--- a/agent/agent-api-public.yaml
+++ b/agent/agent-api-public.yaml
@@ -32,13 +32,10 @@ securityDefinitions:
     in: header
     name: Authorization
 
-security: [
+security:
   # empty to make it optional
-  {},
-  {
-    BearerAuth: []
-  }
-]
+  - { }
+  - BearerAuth: [ ]
 
 paths:
   '/v4/datafeed/create':

--- a/agent/agent-api-public.yaml
+++ b/agent/agent-api-public.yaml
@@ -26,6 +26,20 @@ info:
     Stream and Read Messages/Events Stream. Unless otherwise specified,
     all events were added in 1.46.
 
+securityDefinitions:
+  BearerAuth:
+    type: apiKey
+    in: header
+    name: Authorization
+
+security: [
+  # empty to make it optional
+  {},
+  {
+    BearerAuth: []
+  }
+]
+
 paths:
   '/v4/datafeed/create':
     post:

--- a/pod/pod-api-public-deprecated.yaml
+++ b/pod/pod-api-public-deprecated.yaml
@@ -22,13 +22,10 @@ securityDefinitions:
     in: header
     name: Authorization
 
-security: [
+security:
   # empty to make it optional
-  {},
-  {
-    BearerAuth: []
-  }
-]
+  - { }
+  - BearerAuth: [ ]
 
 paths:
   '/v1/companycert/list':

--- a/pod/pod-api-public-deprecated.yaml
+++ b/pod/pod-api-public-deprecated.yaml
@@ -15,6 +15,21 @@ info:
     system even if ome subset of the request would have succeeded.
     - If this contract cannot be met for any reason then this is an error
     and the response code will be 50X.
+    
+securityDefinitions:
+  BearerAuth:
+    type: apiKey
+    in: header
+    name: Authorization
+
+security: [
+  # empty to make it optional
+  {},
+  {
+    BearerAuth: []
+  }
+]
+
 paths:
   '/v1/companycert/list':
     get:

--- a/pod/pod-api-public.yaml
+++ b/pod/pod-api-public.yaml
@@ -22,13 +22,10 @@ securityDefinitions:
     in: header
     name: Authorization
 
-security: [
+security:
   # empty to make it optional
-  {},
-  {
-    BearerAuth: []
-  }
-]
+  - { }
+  - BearerAuth: [ ]
 
 paths:
   '/v1/companycert/list':

--- a/pod/pod-api-public.yaml
+++ b/pod/pod-api-public.yaml
@@ -15,6 +15,21 @@ info:
     system even if ome subset of the request would have succeeded.
     - If this contract cannot be met for any reason then this is an error
     and the response code will be 50X.
+
+securityDefinitions:
+  BearerAuth:
+    type: apiKey
+    in: header
+    name: Authorization
+
+security: [
+  # empty to make it optional
+  {},
+  {
+    BearerAuth: []
+  }
+]
+
 paths:
   '/v1/companycert/list':
     get:


### PR DESCRIPTION
In order to start using the common jwt as authentication method for our public APIs we are going to add a security scheme to all of them to accept the Bearer token as header of the request. This scheme is optional in order to keep both auth method working (authorization and sessionToken) and also to avoid adding authentication for endpoints that do not actually need it (healtchecks for example)
