### PR TITLE
PLAT-11717: Add suspension info to user status endpoint

### DIFF
--- a/pod/pod-api-public-deprecated.yaml
+++ b/pod/pod-api-public-deprecated.yaml
@@ -6582,6 +6582,13 @@ definitions:
         enum:
           - ENABLED
           - DISABLED
+      suspended:
+        type: boolean
+      suspendedUntil:
+        type: integer
+        format: int64
+      suspensionReason:
+        type: string
   UserFilter:
     type: object
     properties:
@@ -7093,6 +7100,13 @@ definitions:
         enum:
           - ENABLED
           - DISABLED
+      suspended:
+        type: boolean
+      suspendedUntil:
+        type: integer
+        format: int64
+      suspensionReason:
+        type: string
       createdDate:
         type: integer
         format: int64

--- a/pod/pod-api-public.yaml
+++ b/pod/pod-api-public.yaml
@@ -5428,6 +5428,13 @@ definitions:
         enum:
           - ENABLED
           - DISABLED
+      suspended:
+        type: boolean
+      suspendedUntil:
+        type: integer
+        format: int64
+      suspensionReason:
+        type: string
   UserFilter:
     type: object
     properties:
@@ -5939,6 +5946,13 @@ definitions:
         enum:
           - ENABLED
           - DISABLED
+      suspended:
+        type: boolean
+      suspendedUntil:
+        type: integer
+        format: int64
+      suspensionReason:
+        type: string
       createdDate:
         type: integer
         format: int64


### PR DESCRIPTION
This PR is related to [PLAT-11717](https://perzoinc.atlassian.net/browse/PLAT-11717)

In this commit, we updated pod-api-public to add suspension fields (suspended, suspensionUntil, suspensionReason) to UserSystemInfo and UserStatus objects that are used in user endpoints response/parameters.