### PR TITLE
Deprecate V4 Datafeed API

### DIFF
--- a/agent/agent-api-public-deprecated.yaml
+++ b/agent/agent-api-public-deprecated.yaml
@@ -3457,7 +3457,10 @@ paths:
     post:
       deprecated: true
       summary: |
-        (Deprecated - Datafeed v1 will be soon fully replaced by Datafeed v2. Use Datafeed v2 related API instead /agent/v5/datafeeds)
+        (Deprecated - Datafeed v1 will be fully replaced by the datafeed 2 service in the future.  
+        Please consider migrating over to datafeed 2 APIs /agent/v5/datafeeds. For more information on the 
+        timeline as well as on the benefits of datafeed 2, please reach out to your Technical Account Manager or to 
+        our developer documentation https://docs.developers.symphony.com/building-bots-on-symphony/datafeed)
         Create a new real time message event stream.
       description: |
         A datafeed provides the messages in all conversations that a user is in.
@@ -3534,7 +3537,10 @@ paths:
     get:
       deprecated: true
       summary: |
-        (Deprecated - Datafeed v1 will be soon fully replaced by Datafeed v2. Use Datafeed v2 related API instead /agent/v5/datafeeds/{id}/read)
+        (Deprecated - Datafeed v1 will be fully replaced by the datafeed 2 service in the future.  
+        Please consider migrating over to datafeed 2 APIs /agent/v5/datafeeds/{id}/read. For more information on the 
+        timeline as well as on the benefits of datafeed 2, please reach out to your Technical Account Manager or to 
+        our developer documentation https://docs.developers.symphony.com/building-bots-on-symphony/datafeed)
         Read a given datafeed.
       description: |
         Read messages from the given datafeed. If no more messages are available then this method will block.

--- a/agent/agent-api-public-deprecated.yaml
+++ b/agent/agent-api-public-deprecated.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: '20.14.0'
+  version: '20.15.0-SNAPSHOT'
   title: Agent API
   description: |
     This document refers to Symphony API calls to send and receive messages
@@ -10,6 +10,9 @@ info:
     - sessionToken and keyManagerToken can be obtained by calling the
     authenticationAPI on the symphony back end and the key manager
     respectively. Refer to the methods described in authenticatorAPI.yaml.
+    - A new authorizationToken has been introduced in the authenticationAPI
+    response payload. It can be used to replace the sessionToken in any of
+    the API calls and can be passed as "Authorization" header.
     - Actions are defined to be atomic, ie will succeed in their entirety
     or fail and have changed nothing.
     - If it returns a 40X status then it will have sent no message to any
@@ -27,118 +30,6 @@ info:
     all events were added in 1.46.
 
 paths:
-  '/v4/datafeed/create':
-    post:
-      summary: Create a new real time message event stream.
-      description: |
-          A datafeed provides the messages in all conversations that a user is in.
-          This also includes system messages like new users joining a chatroom.
-
-          A datafeed will expire if it isn't read before its capacity is reached.
-      parameters:
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      tags:
-        - Datafeed
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/Datafeed'
-        '400':
-          description: 'Client error.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '503':
-          description: 'Max number of data feeds reached.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v4/datafeed/{id}/read':
-    get:
-      summary: Read a given datafeed.
-      description: |
-          Read messages from the given datafeed. If no more messages are available then this method will block.
-          It is intended that the client should re-call this method as soon as it has processed the messages
-          received in the previous call. If the client is able to consume messages more quickly than they become
-          available then each call will initially block, there is no need to delay before re-calling this method.
-
-          A datafeed will expire if its unread capacity is reached.
-          A datafeed can only be consumed by one client thread at a time. E.g. polling the datafeed by two threads may lead to messages being delivered out of order.
-      parameters:
-      - name: id
-        description: |
-          Datafeed ID
-        in: path
-        required: true
-        type: string
-      - name: limit
-        description: |
-            Max No. of messages to return.
-        in: query
-        type: integer
-      - name: sessionToken
-        description: Session authentication token.
-        in: header
-        required: true
-        type: string
-      - name: keyManagerToken
-        description: Key Manager authentication token.
-        in: header
-        required: true
-        type: string
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      tags:
-        - Datafeed
-      responses:
-        '200':
-          description: List of messages that have occurred since last time this URL was polled. If the list is empty, it means the request has reached its timeout, and the client should poll again.
-          schema:
-            $ref: '#/definitions/V4EventList'
-        '204':
-          description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
   '/v3/health':
     get:
       summary: Checks health status
@@ -343,21 +234,21 @@ paths:
       produces:
         - application/json
       parameters:
-          - name: sessionToken
-            description: Session authentication token.
-            in: header
-            required: true
-            type: string
-          - name: keyManagerToken
-            description: Key Manager authentication token.
-            in: header
-            required: true
-            type: string
-          - name: id
-            description: Message ID as a URL-safe string
-            in: path
-            required: true
-            type: string
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: id
+          description: Message ID as a URL-safe string
+          in: path
+          required: true
+          type: string
       tags:
         - Messages
       responses:
@@ -387,13 +278,13 @@ paths:
     get:
       summary: Search messages
       description: |
-          Search messages according to the specified criteria. The "query" parameter takes a search query defined as
-          "field:value" pairs combined by the operator "AND" (e.g. "text:foo AND autor:bar"). Supported fields are
-           (case-insensitive): "text", "author", "hashtag", "cashtag", "mention", "signal", "fromDate", "toDate",
-           "streamId", "streamType".
-           "text" search requires a "streamId" to be specified.
-           "streamType" accepts one of the following values: "chat" (IMs and MIMs), "im", "mim", "chatroom", "post".
-           "signal" queries can only be combined with "fromDate", "toDate", "skip" and "limit" parameters.
+        Search messages according to the specified criteria. The "query" parameter takes a search query defined as
+        "field:value" pairs combined by the operator "AND" (e.g. "text:foo AND autor:bar"). Supported fields are
+         (case-insensitive): "text", "author", "hashtag", "cashtag", "mention", "signal", "fromDate", "toDate",
+         "streamId", "streamType".
+         "text" search requires a "streamId" to be specified.
+         "streamType" accepts one of the following values: "chat" (IMs and MIMs), "im", "mim", "chatroom", "post".
+         "signal" queries can only be combined with "fromDate", "toDate", "skip" and "limit" parameters.
       produces:
         - application/json
       parameters:
@@ -463,7 +354,7 @@ paths:
     post:
       summary: Search messages
       description: |
-          Search messages according to the specified criteria.
+        Search messages according to the specified criteria.
       consumes:
         - application/json
       produces:
@@ -596,17 +487,17 @@ paths:
     get:
       summary: Get messages from an existing stream.
       description: |
-          A caller can fetch all unseen messages by passing the timestamp of
-          the last message seen as the since parameter and the number of messages
-          with the same timestamp value already seen as the skip parameter. This
-          means that every message will be seen exactly once even in the case that
-          an additional message is processed with the same timestamp as the last
-          message returned by the previous call, and the case where there are
-          more than maxMessages with the same timestamp value.
-
-          This method is intended for historic queries and is generally reliable
-          but if guaranteed delivery of every message in real time is required
-          then the equivilent firehose method should be called.
+        A caller can fetch all unseen messages by passing the timestamp of
+        the last message seen as the since parameter and the number of messages
+        with the same timestamp value already seen as the skip parameter. This
+        means that every message will be seen exactly once even in the case that
+        an additional message is processed with the same timestamp as the last
+        message returned by the previous call, and the case where there are
+        more than maxMessages with the same timestamp value.
+        
+        This method is intended for historic queries and is generally reliable
+        but if guaranteed delivery of every message in real time is required
+        then the equivilent firehose method should be called.
       produces:
         - application/json
       parameters:
@@ -967,8 +858,8 @@ paths:
   '/v1/signals/list':
     get:
       summary: |
-          List signals for the requesting user. This includes signals that the user has created and public signals
-          to which they subscribed.
+        List signals for the requesting user. This includes signals that the user has created and public signals
+        to which they subscribed.
       consumes:
         - application/json
       produces:
@@ -3126,6 +3017,7 @@ paths:
                 createdAt: 1536346282592
               - id: '8e7c8672-221...'
                 createdAt: 1536346282500
+
         400:
           description: Bad request.
           schema:
@@ -3252,18 +3144,18 @@ paths:
           schema:
             $ref: '#/definitions/V2Error'
 
-#
-# Deprecated paths
-#
+  #
+  # Deprecated paths
+  #
   '/v1/datafeed/create':
     post:
       deprecated: true
       summary: Create a new real time message event stream.
       description: |
-          A datafeed provides the messages in all conversations that a user is in.
-          System messages like new users joining a chatroom are not part of the datafeed.
-
-          A datafeed will expire after if it isn't read before its capacity is reached.
+        A datafeed provides the messages in all conversations that a user is in.
+        System messages like new users joining a chatroom are not part of the datafeed.
+        
+        A datafeed will expire after if it isn't read before its capacity is reached.
       parameters:
         - name: sessionToken
           description: Session authentication token.
@@ -3315,35 +3207,35 @@ paths:
       deprecated: true
       summary: Read a given datafeed.
       description: |
-          Read messages from the given datafeed. If no more messages are available then this method will block.
-          It is intended that the client should re-call this method as soon as it has processed the messages
-          received in the previous call. If the client is able to consume messages more quickly than they become
-          available then each call will initially block, there is no need to delay before re-calling this method.
-
-          A datafeed will expire if its unread capacity is reached.
-          A datafeed can only be consumed by one client thread at a time. E.g. polling the datafeed by two threads may lead to messages being delivered out of order.
+        Read messages from the given datafeed. If no more messages are available then this method will block.
+        It is intended that the client should re-call this method as soon as it has processed the messages
+        received in the previous call. If the client is able to consume messages more quickly than they become
+        available then each call will initially block, there is no need to delay before re-calling this method.
+        
+        A datafeed will expire if its unread capacity is reached.
+        A datafeed can only be consumed by one client thread at a time. E.g. polling the datafeed by two threads may lead to messages being delivered out of order.
       parameters:
-      - name: id
-        description: |
-          Datafeed ID
-        in: path
-        required: true
-        type: string
-      - name: maxMessages
-        description: |
+        - name: id
+          description: |
+            Datafeed ID
+          in: path
+          required: true
+          type: string
+        - name: maxMessages
+          description: |
             Max No. of messages to return.
-        in: query
-        type: integer
-      - name: sessionToken
-        description: Session authentication token.
-        in: header
-        required: true
-        type: string
-      - name: keyManagerToken
-        description: Key Manager authentication token.
-        in: header
-        required: true
-        type: string
+          in: query
+          type: integer
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
       consumes:
         - application/json
       produces:
@@ -3382,9 +3274,9 @@ paths:
       deprecated: true
       summary: Checks the health of the Agent.
       description: |
-          Used to validate the configuration of the agent.
-          Makes a request to the HealthCheck on the Symphony cloud.
-          Makes a request to the HealthCheck on the Key Manager service.
+        Used to validate the configuration of the agent.
+        Makes a request to the HealthCheck on the Symphony cloud.
+        Makes a request to the HealthCheck on the Key Manager service.
       produces:
         - application/json
       tags:
@@ -3499,35 +3391,35 @@ paths:
       deprecated: true
       summary: Read a given datafeed.
       description: |
-          Read messages from the given datafeed. If no more messages are available then this method will block.
-          It is intended that the client should re-call this method as soon as it has processed the messages
-          received in the previous call. If the client is able to consume messages more quickly than they become
-          available then each call will initially block, there is no need to delay before re-calling this method.
-
-          A datafeed will expire if its unread capacity is reached.
-          A datafeed can only be consumed by one client thread at a time. E.g. polling the datafeed by two threads may lead to messages being delivered out of order.
+        Read messages from the given datafeed. If no more messages are available then this method will block.
+        It is intended that the client should re-call this method as soon as it has processed the messages
+        received in the previous call. If the client is able to consume messages more quickly than they become
+        available then each call will initially block, there is no need to delay before re-calling this method.
+        
+        A datafeed will expire if its unread capacity is reached.
+        A datafeed can only be consumed by one client thread at a time. E.g. polling the datafeed by two threads may lead to messages being delivered out of order.
       parameters:
-      - name: id
-        description: |
-          Datafeed ID
-        in: path
-        required: true
-        type: string
-      - name: maxMessages
-        description: |
+        - name: id
+          description: |
+            Datafeed ID
+          in: path
+          required: true
+          type: string
+        - name: maxMessages
+          description: |
             Max No. of messages to return.
-        in: query
-        type: integer
-      - name: sessionToken
-        description: Session authentication token.
-        in: header
-        required: true
-        type: string
-      - name: keyManagerToken
-        description: Key Manager authentication token.
-        in: header
-        required: true
-        type: string
+          in: query
+          type: integer
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
       consumes:
         - application/json
       produces:
@@ -3561,6 +3453,172 @@ paths:
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/Error'
+  '/v4/datafeed/create':
+    post:
+      deprecated: true
+      summary: |
+        (Deprecated - Datafeed v1 will be soon fully replaced by Datafeed v2. Use Datafeed v2 related API instead /agent/v5/datafeeds)
+        Create a new real time message event stream.
+      description: |
+        A datafeed provides the messages in all conversations that a user is in.
+        This also includes system messages like new users joining a chatroom.
+
+        A datafeed will expire if it isn't read before its capacity is reached.
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - Datafeed
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Datafeed'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '400':
+          description: 'Client error.'
+          schema:
+            $ref: '#/definitions/V2Error'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '503':
+          description: 'Max number of data feeds reached.'
+          schema:
+            $ref: '#/definitions/V2Error'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+  '/v4/datafeed/{id}/read':
+    get:
+      deprecated: true
+      summary: |
+        (Deprecated - Datafeed v1 will be soon fully replaced by Datafeed v2. Use Datafeed v2 related API instead /agent/v5/datafeeds/{id}/read)
+        Read a given datafeed.
+      description: |
+        Read messages from the given datafeed. If no more messages are available then this method will block.
+        It is intended that the client should re-call this method as soon as it has processed the messages
+        received in the previous call. If the client is able to consume messages more quickly than they become
+        available then each call will initially block, there is no need to delay before re-calling this method.
+
+        A datafeed will expire if its unread capacity is reached.
+        A datafeed can only be consumed by one client thread at a time. E.g. polling the datafeed by two threads may lead to messages being delivered out of order.
+      parameters:
+        - name: id
+          description: |
+            Datafeed ID
+          in: path
+          required: true
+          type: string
+        - name: limit
+          description: |
+            Max No. of messages to return.
+          in: query
+          type: integer
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - Datafeed
+      responses:
+        '200':
+          description: List of messages that have occurred since last time this URL was polled. If the list is empty, it means the request has reached its timeout, and the client should poll again.
+          schema:
+            $ref: '#/definitions/V4EventList'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '204':
+          description: No Messages.
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
   '/v1/message/import':
     post:
       deprecated: true
@@ -3815,17 +3873,17 @@ paths:
       deprecated: true
       summary: Get messages from an existing stream.
       description: |
-          A caller can fetch all unseen messages by passing the timestamp of
-          the last message seen as the since parameter and the number of messages
-          with the same timestamp value already seen as the skip parameter. This
-          means that every message will be seen exactly once even in the case that
-          an additional message is processed with the same timestamp as the last
-          message returned by the previous call, and the case where there are
-          more than maxMessages with the same timestamp value.
-
-          This method is intended for historic queries and is generally reliable
-          but if guaranteed delivery of every message in real time is required
-          then the equivilent firehose method should be called.
+        A caller can fetch all unseen messages by passing the timestamp of
+        the last message seen as the since parameter and the number of messages
+        with the same timestamp value already seen as the skip parameter. This
+        means that every message will be seen exactly once even in the case that
+        an additional message is processed with the same timestamp as the last
+        message returned by the previous call, and the case where there are
+        more than maxMessages with the same timestamp value.
+        
+        This method is intended for historic queries and is generally reliable
+        but if guaranteed delivery of every message in real time is required
+        then the equivilent firehose method should be called.
       produces:
         - application/json
       parameters:
@@ -3900,17 +3958,17 @@ paths:
       deprecated: true
       summary: Get messages from an existing stream.
       description: |
-          A caller can fetch all unseen messages by passing the timestamp of
-          the last message seen as the since parameter and the number of messages
-          with the same timestamp value already seen as the skip parameter. This
-          means that every message will be seen exactly once even in the case that
-          an additional message is processed with the same timestamp as the last
-          message returned by the previous call, and the case where there are
-          more than maxMessages with the same timestamp value.
-
-          This method is intended for historic queries and is generally reliable
-          but if guaranteed delivery of every message in real time is required
-          then the equivilent firehose method should be called.
+        A caller can fetch all unseen messages by passing the timestamp of
+        the last message seen as the since parameter and the number of messages
+        with the same timestamp value already seen as the skip parameter. This
+        means that every message will be seen exactly once even in the case that
+        an additional message is processed with the same timestamp as the last
+        message returned by the previous call, and the case where there are
+        more than maxMessages with the same timestamp value.
+        
+        This method is intended for historic queries and is generally reliable
+        but if guaranteed delivery of every message in real time is required
+        then the equivilent firehose method should be called.
       produces:
         - application/json
       parameters:
@@ -4333,8 +4391,8 @@ definitions:
       details:
         type: object
     required:
-    - code
-    - message
+      - code
+      - message
   SuccessResponse:
     type: object
     properties:
@@ -4359,187 +4417,187 @@ definitions:
       streamId:
         type: string
     required:
-    - v2messageType
-    - timestamp
-    - streamId
+      - v2messageType
+      - timestamp
+      - streamId
   V2Message:
     type: object
     description: A representation of a message sent by a user of Symphony.
     allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        message:
-          type: string
-          format: MessageML
-          description: Message text in MessageML
-        fromUserId:
-          type: integer
-          format: int64
-          description: the Symphony userId of the user who sent the message. This will be populated by the server (and actually ignored if included when sending a message).
-        attachments:
-          type: array
-          items:
-            $ref: '#/definitions/AttachmentInfo'
-      required:
-      - message
-      - fromUserId
+      - $ref: '#/definitions/V2BaseMessage'
+      - type: object
+        properties:
+          message:
+            type: string
+            format: MessageML
+            description: Message text in MessageML
+          fromUserId:
+            type: integer
+            format: int64
+            description: the Symphony userId of the user who sent the message. This will be populated by the server (and actually ignored if included when sending a message).
+          attachments:
+            type: array
+            items:
+              $ref: '#/definitions/AttachmentInfo'
+        required:
+          - message
+          - fromUserId
   RoomCreatedMessage:
     type: object
     description: Generated when a room is created.
     allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        creationDate:
-          type: integer
-          format: int64
-        name:
-          type: string
-        keywords:
-          type: array
-          items:
-            $ref: '#/definitions/RoomTag'
-        description:
-          type: string
-        createdByUserId:
-          type: integer
-          format: int64
-          description: The Symphony userId of the user who created the room.
-        readOnly:
-          type: boolean
-        discoverable:
-          type: boolean
-        public:
-          type: boolean
-        membersCanInvite:
-          type: boolean
-        copyProtected:
-          type: boolean
+      - $ref: '#/definitions/V2BaseMessage'
+      - type: object
+        properties:
+          creationDate:
+            type: integer
+            format: int64
+          name:
+            type: string
+          keywords:
+            type: array
+            items:
+              $ref: '#/definitions/RoomTag'
+          description:
+            type: string
+          createdByUserId:
+            type: integer
+            format: int64
+            description: The Symphony userId of the user who created the room.
+          readOnly:
+            type: boolean
+          discoverable:
+            type: boolean
+          public:
+            type: boolean
+          membersCanInvite:
+            type: boolean
+          copyProtected:
+            type: boolean
   RoomDeactivatedMessage:
     type: object
     description: Generated when a room is deactivated.
     allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        deactivatedByUserId:
-          type: integer
-          format: int64
+      - $ref: '#/definitions/V2BaseMessage'
+      - type: object
+        properties:
+          deactivatedByUserId:
+            type: integer
+            format: int64
   RoomReactivatedMessage:
     type: object
     description: Generated when a room is reactivated.
     allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        reactivatedByUserId:
-          type: integer
-          format: int64
+      - $ref: '#/definitions/V2BaseMessage'
+      - type: object
+        properties:
+          reactivatedByUserId:
+            type: integer
+            format: int64
   RoomUpdatedMessage:
     type: object
     description: Generated when a room is updated.
     allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        oldName:
-          type: string
-        newName:
-          type: string
-        keywords:
-          type: array
-          items:
-            $ref: '#/definitions/RoomTag'
-        oldDescription:
-          type: string
-        newDescription:
-          type: string
-        membersCanInvite:
-          type: boolean
-        discoverable:
-          type: boolean
-        readOnly:
-          type: boolean
-        copyProtected:
-          type: boolean
+      - $ref: '#/definitions/V2BaseMessage'
+      - type: object
+        properties:
+          oldName:
+            type: string
+          newName:
+            type: string
+          keywords:
+            type: array
+            items:
+              $ref: '#/definitions/RoomTag'
+          oldDescription:
+            type: string
+          newDescription:
+            type: string
+          membersCanInvite:
+            type: boolean
+          discoverable:
+            type: boolean
+          readOnly:
+            type: boolean
+          copyProtected:
+            type: boolean
   UserJoinedRoomMessage:
     type: object
     description: Generated when a user joins a room.
     allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        addedByUserId:
-          type: integer
-          format: int64
-        memberAddedUserId:
-          type: integer
-          format: int64
+      - $ref: '#/definitions/V2BaseMessage'
+      - type: object
+        properties:
+          addedByUserId:
+            type: integer
+            format: int64
+          memberAddedUserId:
+            type: integer
+            format: int64
   UserLeftRoomMessage:
     type: object
     description: Generated when a user leaves a room.
     allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        removedByUserId:
-          type: integer
-          format: int64
-        memberLeftUserId:
-          type: integer
-          format: int64
-        informationBarrierRemediation:
-          type: boolean
+      - $ref: '#/definitions/V2BaseMessage'
+      - type: object
+        properties:
+          removedByUserId:
+            type: integer
+            format: int64
+          memberLeftUserId:
+            type: integer
+            format: int64
+          informationBarrierRemediation:
+            type: boolean
   RoomMemberPromotedToOwnerMessage:
     type: object
     description: Generated when a room member is promoted to owner.
     allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        promotedByUserId:
-          type: integer
-          format: int64
-        promotedUserId:
-          type: integer
-          format: int64
+      - $ref: '#/definitions/V2BaseMessage'
+      - type: object
+        properties:
+          promotedByUserId:
+            type: integer
+            format: int64
+          promotedUserId:
+            type: integer
+            format: int64
   RoomMemberDemotedFromOwnerMessage:
     type: object
     description: Generated when a room member is promoted to owner.
     allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        demotedByUserId:
-          type: integer
-          format: int64
-        demotedUserId:
-          type: integer
-          format: int64
+      - $ref: '#/definitions/V2BaseMessage'
+      - type: object
+        properties:
+          demotedByUserId:
+            type: integer
+            format: int64
+          demotedUserId:
+            type: integer
+            format: int64
   ConnectionRequestMessage:
     type: object
     description: Generated when a connection request is sent.
     allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        requestingUserId:
-          type: integer
-          format: int64
-        targetUserId:
-          type: integer
-          format: int64
-        firstRequestedAt:
-          type: integer
-          format: int64
-        updatedAt:
-          type: integer
-          format: int64
-        requestCounter:
-          type: integer
-        status:
-          type: string
+      - $ref: '#/definitions/V2BaseMessage'
+      - type: object
+        properties:
+          requestingUserId:
+            type: integer
+            format: int64
+          targetUserId:
+            type: integer
+            format: int64
+          firstRequestedAt:
+            type: integer
+            format: int64
+          updatedAt:
+            type: integer
+            format: int64
+          requestCounter:
+            type: integer
+          status:
+            type: string
   AttachmentInfo:
     type: object
     properties:
@@ -4554,9 +4612,9 @@ definitions:
         format: int64
         description: Size in bytes.
     required:
-    - id
-    - name
-    - size
+      - id
+      - name
+      - size
   V2MessageList:
     type: array
     items:
@@ -4567,11 +4625,7 @@ definitions:
     properties:
       message:
         type: string
-  Datafeed:
-    type: object
-    properties:
-      id:
-        type: string
+
   RoomTag:
     description: Room Tag object. A key:value pair describing additional properties of the room.
     properties:
@@ -4582,8 +4636,8 @@ definitions:
         description: The value of this Tag's label.
         type: string
     required:
-    - key
-    - value
+      - key
+      - value
   ShareArticle:
     type: object
     properties:
@@ -4628,10 +4682,10 @@ definitions:
         type: string
         description: App icon url of the calling application
     required:
-    - title
-    - publisher
-    - author
-    - appId
+      - title
+      - publisher
+      - author
+      - appId
   ShareContent:
     type: object
     properties:
@@ -4641,50 +4695,50 @@ definitions:
       content:
         $ref: '#/definitions/ShareArticle'
   V2HealthCheckResponse:
-     type: object
-     properties:
-       podConnectivity:
-         type: boolean
-         description: Indicates whether the Agent server can connect to the Pod
-       podConnectivityError:
-         type: string
-         description: Error details in case of no Pod connectivity
-       keyManagerConnectivity:
-         type: boolean
-         description: Indicates whether the Agent server can connect to the Key Manager
-       keyManagerConnectivityError:
-         type: string
-         description: Error details in case of no Key Manager connectivity
-       firehoseConnectivity:
-         type: boolean
-         description: Indicates whether the Agent server can connect to Firehose Service
-       firehoseConnectivityError:
-         type: string
-         description: Error details in case of no Firehose connectivity
-       encryptDecryptSuccess:
-         type: boolean
-         description: Indicates whether the Agent can successfully decrypt and encrypt messages
-       encryptDecryptError:
-         type: string
-         description: Error details in case of the encryption or decryption of the message fails
-       podVersion:
-         type: string
-         description: The version number of the pod
-       agentVersion:
-         type: string
-         description: The version number of the Agent server
-       agentServiceUser:
-         type: boolean
-         description: Indicates whether agent service user is setup correctly.
-       agentServiceUserError:
-         type: string
-         description: Error details in case agent service user is setup incorrectly.
-       ceServiceUser:
-         type: boolean
-         description: Indicates whether CEService user is setup correctly.
-       ceServiceUserError:
-         type: string
-         description: Error details in case CEService user is setup incorrectly.
+    type: object
+    properties:
+      podConnectivity:
+        type: boolean
+        description: Indicates whether the Agent server can connect to the Pod
+      podConnectivityError:
+        type: string
+        description: Error details in case of no Pod connectivity
+      keyManagerConnectivity:
+        type: boolean
+        description: Indicates whether the Agent server can connect to the Key Manager
+      keyManagerConnectivityError:
+        type: string
+        description: Error details in case of no Key Manager connectivity
+      firehoseConnectivity:
+        type: boolean
+        description: Indicates whether the Agent server can connect to Firehose Service
+      firehoseConnectivityError:
+        type: string
+        description: Error details in case of no Firehose connectivity
+      encryptDecryptSuccess:
+        type: boolean
+        description: Indicates whether the Agent can successfully decrypt and encrypt messages
+      encryptDecryptError:
+        type: string
+        description: Error details in case of the encryption or decryption of the message fails
+      podVersion:
+        type: string
+        description: The version number of the pod
+      agentVersion:
+        type: string
+        description: The version number of the Agent server
+      agentServiceUser:
+        type: boolean
+        description: Indicates whether agent service user is setup correctly.
+      agentServiceUserError:
+        type: string
+        description: Error details in case agent service user is setup incorrectly.
+      ceServiceUser:
+        type: boolean
+        description: Indicates whether CEService user is setup correctly.
+      ceServiceUserError:
+        type: string
+        description: Error details in case CEService user is setup incorrectly.
   MessageSearchQuery:
     type: object
     properties:
@@ -4781,11 +4835,11 @@ definitions:
         items:
           $ref: '#/definitions/V4ImportedMessageAttachment'
     required:
-    - message
-    - intendedMessageTimestamp
-    - intendedMessageFromUserId
-    - originatingSystemId
-    - streamId
+      - message
+      - intendedMessageTimestamp
+      - intendedMessageFromUserId
+      - originatingSystemId
+      - streamId
   V4ImportedMessageAttachment:
     type: object
     properties:
@@ -4840,9 +4894,9 @@ definitions:
         items:
           $ref: '#/definitions/V4ThumbnailInfo'
     required:
-    - id
-    - name
-    - size
+      - id
+      - name
+      - size
   V4ThumbnailInfo:
     type: object
     properties:
@@ -5393,10 +5447,10 @@ definitions:
   V1DLPPolicy:
     type: object
     required:
-    - "contentTypes"
-    - "name"
-    - "scopes"
-    - "type"
+      - "contentTypes"
+      - "name"
+      - "scopes"
+      - "type"
     properties:
       active:
         type: boolean
@@ -5455,10 +5509,10 @@ definitions:
   V1DLPPolicyRequest:
     type: object
     required:
-    - "contentTypes"
-    - "name"
-    - "scopes"
-    - "type"
+      - "contentTypes"
+      - "name"
+      - "scopes"
+      - "type"
     properties:
       contentTypes:
         type: array
@@ -5495,7 +5549,7 @@ definitions:
   V1DLPDictionary:
     type: object
     required:
-    - dictionaryMetadata
+      - dictionaryMetadata
     properties:
       content:
         $ref: '#/definitions/V1DLPDictionaryContent'
@@ -5537,7 +5591,7 @@ definitions:
   V1DLPDictionaryMetadataResponse:
     type: object
     required:
-    - data
+      - data
     properties:
       data:
         $ref: '#/definitions/V1DLPDictionaryMetadata'
@@ -5545,8 +5599,8 @@ definitions:
   V1DLPDictionaryMetadataCreateRequest:
     type: object
     required:
-    - name
-    - type
+      - name
+      - type
     properties:
       name:
         type: string
@@ -5561,7 +5615,7 @@ definitions:
   V1DLPDictionaryMetadataUpdateRequest:
     type: object
     required:
-    - name
+      - name
     properties:
       name:
         type: string
@@ -5571,8 +5625,8 @@ definitions:
   V1DLPDictionaryMetadata:
     type: object
     required:
-    - dictRef
-    - type
+      - dictRef
+      - type
     properties:
       creationDate:
         type: integer
@@ -5596,7 +5650,7 @@ definitions:
   V1DLPDictionaryRef:
     type: object
     required:
-    - name
+      - name
     properties:
       dictId:
         type: string
@@ -5656,8 +5710,8 @@ definitions:
       diagnostic:
         type: string
         description: |
-            A diagnostic message containing an error message in the event there are parsing errors.
-            May also be present in the case of a successful call if there is useful narrative to return.
+          A diagnostic message containing an error message in the event there are parsing errors.
+          May also be present in the case of a successful call if there is useful narrative to return.
   V1DLPViolationStream:
     type: object
     properties:
@@ -5711,8 +5765,8 @@ definitions:
         type: string
         description: Version of application which processed the message and produced this violation.
       ignoreDLPwarning:
-          type: boolean
-          description: Did the user chose to ignore DLP warning that was presented?
+        type: boolean
+        description: Did the user chose to ignore DLP warning that was presented?
   V1DLPMatchedPolicyList:
     type: array
     items:
@@ -5740,9 +5794,9 @@ definitions:
       diagnostic:
         type: string
         description: |
-            A diagnostic message containing an error message in the event that the
-            decryption of terms failed. May also be present in the case of a successful
-            call if there is useful narrative to return.
+          A diagnostic message containing an error message in the event that the
+          decryption of terms failed. May also be present in the case of a successful
+          call if there is useful narrative to return.
   V1DLPOutcome:
     type: object
     description: A representation of outcome of DLP message/stream/signal sent by a user of Symphony
@@ -5761,93 +5815,93 @@ definitions:
     type: object
     description: Room details in the context of violation.
     properties:
-        name:
-          type: string
-          description:  Name of the Stream/Room.
-        creatorPrettyName:
-          type: string
-          description:  Name of the creator of the Room.
-        publicRoom:
-          type: boolean
-          description:  Is this a public room?
-        crossPod:
-          type: boolean
-          description:  Is this a cross pod scenario?
-        allowExternal:
-          type: boolean
-          description:  Is external messaging allowed
-        creatorId:
-          type: string
-          description:  Id of the creator of the Room.
-        roomDescription:
-          type: string
-          description:  Description of the Room.
-        streamId:
-          type: string
-          description:  ThreadId of the Room.
-        state:
-          type: string
-          description:  State of the Room (example CREATED etc)
-        type:
-          type: string
-          description:  Type of the Room (example ROOM (or IM or Wall))
-        lastDisabled:
-          type: integer
-          format: int64
-          description: Timestamp of last time the room is Disabled
-        memberAddUserEnabled:
-          type: boolean
-          description:  Is memberAddUserEnabled
-        active:
-          type: boolean
-          description:  Is Room Active
-        discoverable:
-          type: boolean
-          description:  Is Room discoverable
-        readOnly:
-          type: boolean
-          description:  Is Room read-only
-        copyDisabled:
-          type: boolean
-          description:  Is Room copyDisabled
-        externalOwned:
-          type: boolean
-          description:  Is Room externalOwned
-        sendMessageDisabled:
-          type: boolean
-          description:  Is sendMessage Disabled for this Room
-        moderated:
-          type: boolean
-          description:  Is room moderated
-        shareHistoryEnabled:
-          type: boolean
-          description:  Is room shareHistoryEnabled
-        diagnostic:
-          type: string
-          description: |
-              A diagnostic message containing an error message in the event that the
-              stream retrieval failed. May also be present in the case of a successful
-              call if there is useful narrative to return.
+      name:
+        type: string
+        description:  Name of the Stream/Room.
+      creatorPrettyName:
+        type: string
+        description:  Name of the creator of the Room.
+      publicRoom:
+        type: boolean
+        description:  Is this a public room?
+      crossPod:
+        type: boolean
+        description:  Is this a cross pod scenario?
+      allowExternal:
+        type: boolean
+        description:  Is external messaging allowed
+      creatorId:
+        type: string
+        description:  Id of the creator of the Room.
+      roomDescription:
+        type: string
+        description:  Description of the Room.
+      streamId:
+        type: string
+        description:  ThreadId of the Room.
+      state:
+        type: string
+        description:  State of the Room (example CREATED etc)
+      type:
+        type: string
+        description:  Type of the Room (example ROOM (or IM or Wall))
+      lastDisabled:
+        type: integer
+        format: int64
+        description: Timestamp of last time the room is Disabled
+      memberAddUserEnabled:
+        type: boolean
+        description:  Is memberAddUserEnabled
+      active:
+        type: boolean
+        description:  Is Room Active
+      discoverable:
+        type: boolean
+        description:  Is Room discoverable
+      readOnly:
+        type: boolean
+        description:  Is Room read-only
+      copyDisabled:
+        type: boolean
+        description:  Is Room copyDisabled
+      externalOwned:
+        type: boolean
+        description:  Is Room externalOwned
+      sendMessageDisabled:
+        type: boolean
+        description:  Is sendMessage Disabled for this Room
+      moderated:
+        type: boolean
+        description:  Is room moderated
+      shareHistoryEnabled:
+        type: boolean
+        description:  Is room shareHistoryEnabled
+      diagnostic:
+        type: string
+        description: |
+          A diagnostic message containing an error message in the event that the
+          stream retrieval failed. May also be present in the case of a successful
+          call if there is useful narrative to return.
   V1DLPSignal:
     type: object
     description: Signal details
     properties:
-        name:
-          type: string
-          description:  Name of the Signal
-        rules:
-          type: string
-          description:  Signal rules decrypted.
-        diagnostic:
-          type: string
-          description: |
-              A diagnostic message containing an error message in the event that the
-              signal decryption failed. May also be present in the case of a successful
-              call if there is useful narrative to return.
+      name:
+        type: string
+        description:  Name of the Signal
+      rules:
+        type: string
+        description:  Signal rules decrypted.
+      diagnostic:
+        type: string
+        description: |
+          A diagnostic message containing an error message in the event that the
+          signal decryption failed. May also be present in the case of a successful
+          call if there is useful narrative to return.
 
-#
-# V3 Policies definitions
-#
+  #
+  # V3 Policies definitions
+  #
   V3DLPPolicyRequest:
     type: object
     required:
@@ -5935,8 +5989,8 @@ definitions:
   V3DLPRule:
     type: object
     required:
-     - "type"
-     - "name"
+      - "type"
+      - "name"
     properties:
       id:
         type: string
@@ -5957,25 +6011,25 @@ definitions:
       fileClassifierConfig:
         $ref: '#/definitions/V3DLPFileClassifierConfig'
     description: |
-     A Rule defines the actual matching specification for policies. It holds a type and a configuration
-     for the rule, these properties should be used to build the corresponding matching implementation.
-     Only one of the configuration property should be set [textMatchConfig, fileSizeConfig, fileExtensionConfig, filePasswordConfig, fileClassifierConfig].
+      A Rule defines the actual matching specification for policies. It holds a type and a configuration
+      for the rule, these properties should be used to build the corresponding matching implementation.
+      Only one of the configuration property should be set [textMatchConfig, fileSizeConfig, fileExtensionConfig, filePasswordConfig, fileClassifierConfig].
   V3DLPFilePasswordConfig:
     type: object
     required:
       - "applicableFileTypes"
       - "matchCriteria"
     properties:
-        applicableFileTypes:
-          type: array
-          items:
-            type: string
-          description: File types that can be applied. Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
-        matchCriteria:
+      applicableFileTypes:
+        type: array
+        items:
           type: string
-          description: |
-           Based on the criteria, whether a file is password protected or not means a match.
-           Can be ["PASSWORD_PROTECTED", "NOT_PASSWORD_PROTECTED"]. The default is "NOT_PASSWORD_PROTECTED".
+        description: File types that can be applied. Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
+      matchCriteria:
+        type: string
+        description: |
+          Based on the criteria, whether a file is password protected or not means a match.
+          Can be ["PASSWORD_PROTECTED", "NOT_PASSWORD_PROTECTED"]. The default is "NOT_PASSWORD_PROTECTED".
     description: Password protected detection config for files that are password protected or not.
   V3DLPFileExtensionConfig:
     type: object
@@ -6006,14 +6060,14 @@ definitions:
       dictionaries:
         type: array
         items:
-         $ref: '#/definitions/V3DLPDictionaryMeta'
+          $ref: '#/definitions/V3DLPDictionaryMeta'
       countUniqueOccurrences:
         type: integer
         format: int32
       applicableFileTypes:
         type: array
         items:
-         type: string
+          type: string
         description: |
           File types must be applied only for rule type "FileContent", otherwise must be empty.
           Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
@@ -6044,16 +6098,16 @@ definitions:
       classifiers:
         type: object
         additionalProperties:
-         type: string
+          type: string
         description: |
-         Classifier is defined as a Key and its Value: e.g.: "classification": "Internal".
-         Name and value can contain UTF-8 characters. Neither the name nor value cannot be left empty.
-         Maximum 30 characters for the name and value, case insensitive.
-         If files contains k-v pairs in the classifers map, it means a match. Maximum 30 classifiers per policy.
+          Classifier is defined as a Key and its Value: e.g.: "classification": "Internal".
+          Name and value can contain UTF-8 characters. Neither the name nor value cannot be left empty.
+          Maximum 30 characters for the name and value, case insensitive.
+          If files contains k-v pairs in the classifers map, it means a match. Maximum 30 classifiers per policy.
       applicableFileTypes:
         type: array
         items:
-         type: string
+          type: string
         description: |
           File types that can be applied. Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
   V3DLPPolicyAppliesTo:
@@ -6147,8 +6201,8 @@ definitions:
         # Message details when DLP was enforced
         $ref: '#/definitions/V4Message'
       sharedMessage:
-              description: Shared message details if present in message.
-              $ref: '#/definitions/V4Message'
+        description: Shared message details if present in message.
+        $ref: '#/definitions/V4Message'
       diagnostic:
         type: string
         description: |
@@ -6209,8 +6263,8 @@ definitions:
         type: string
         description: Version of application which processed the message and produced this violation.
       ignoreDLPwarning:
-          type: boolean
-          description: Did the user chose to ignore DLP warning that was presented?
+        type: boolean
+        description: Did the user chose to ignore DLP warning that was presented?
   Pagination:
     type: object
     required:
@@ -6328,21 +6382,21 @@ definitions:
         type: string
         description: The ackId which acknowledges that the current batch of messages have been successfully received by the client
   V3Health:
-      properties:
-        services:
-          additionalProperties:
-            $ref: '#/definitions/V3HealthComponent'
-          type: object
-        status:
-          $ref: '#/definitions/V3HealthStatus'
-        users:
-          additionalProperties:
-            $ref: '#/definitions/V3HealthComponent'
-          type: object
-        version:
-          description: Required Agent verison
-          type: string
-      type: object
+    properties:
+      services:
+        additionalProperties:
+          $ref: '#/definitions/V3HealthComponent'
+        type: object
+      status:
+        $ref: '#/definitions/V3HealthStatus'
+      users:
+        additionalProperties:
+          $ref: '#/definitions/V3HealthComponent'
+        type: object
+      version:
+        description: Required Agent verison
+        type: string
+    type: object
   V3HealthAuthType:
     description: Type of authentication
     enum:
@@ -6369,9 +6423,9 @@ definitions:
       - DOWN
     type: string
 
-#
-# Deprecated definitions
-#
+  #
+  # Deprecated definitions
+  #
   MessageSubmission:
     type: object
     properties:
@@ -6440,18 +6494,18 @@ definitions:
       streamId:
         type: string
     required:
-    - message
-    - intendedMessageTimestamp
-    - intendedMessageFromUserId
-    - originatingSystemId
-    - streamId
+      - message
+      - intendedMessageTimestamp
+      - intendedMessageFromUserId
+      - originatingSystemId
+      - streamId
   V2MessageImportList:
-      description: |
-        An ordered list of historic messages to be imported.
-        A list of import responsees will be returned in the same order.
-      type: array
-      items:
-        $ref: '#/definitions/V2ImportedMessage'
+    description: |
+      An ordered list of historic messages to be imported.
+      A list of import responsees will be returned in the same order.
+    type: array
+    items:
+      $ref: '#/definitions/V2ImportedMessage'
   V2ImportedMessage:
     description: |
       A historic message to be imported into the system.
@@ -6493,11 +6547,11 @@ definitions:
       streamId:
         type: string
     required:
-    - message
-    - intendedMessageTimestamp
-    - intendedMessageFromUserId
-    - originatingSystemId
-    - streamId
+      - message
+      - intendedMessageTimestamp
+      - intendedMessageFromUserId
+      - originatingSystemId
+      - streamId
   ImportResponseList:
     type: array
     items:
@@ -6556,9 +6610,9 @@ definitions:
       streamId:
         type: string
     required:
-    - messageType
-    - timestamp
-    - streamId
+      - messageType
+      - timestamp
+      - streamId
   V1HealthCheckResponse:
     deprecated: true
     type: object
@@ -6582,22 +6636,27 @@ definitions:
     type: object
     description: A representation of a message sent by a user of Symphony.
     allOf:
-    - $ref: '#/definitions/BaseMessage'
-    - type: object
-      properties:
-        message:
-          type: string
-          format: MessageML
-          description: Message text in MessageML
-        fromUserId:
-          type: integer
-          format: int64
-          description: the Symphony userId of the user who sent the message. This will be populated by the server (and actually ignored if included when sending a message).
-      required:
-      - message
-      - fromUserId
+      - $ref: '#/definitions/BaseMessage'
+      - type: object
+        properties:
+          message:
+            type: string
+            format: MessageML
+            description: Message text in MessageML
+          fromUserId:
+            type: integer
+            format: int64
+            description: the Symphony userId of the user who sent the message. This will be populated by the server (and actually ignored if included when sending a message).
+        required:
+          - message
+          - fromUserId
   MessageList:
     type: array
     items:
       $ref: '#/definitions/Message'
+  Datafeed:
+    type: object
+    properties:
+      id:
+        type: string
 

--- a/agent/agent-api-public.yaml
+++ b/agent/agent-api-public.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: '20.14.0'
+  version: '20.15.0-SNAPSHOT'
   title: Agent API
   description: |
     This document refers to Symphony API calls to send and receive messages
@@ -10,6 +10,9 @@ info:
     - sessionToken and keyManagerToken can be obtained by calling the
     authenticationAPI on the symphony back end and the key manager
     respectively. Refer to the methods described in authenticatorAPI.yaml.
+    - A new authorizationToken has been introduced in the authenticationAPI
+    response payload. It can be used to replace the sessionToken in any of
+    the API calls and can be passed as "Authorization" header.
     - Actions are defined to be atomic, ie will succeed in their entirety
     or fail and have changed nothing.
     - If it returns a 40X status then it will have sent no message to any
@@ -27,118 +30,6 @@ info:
     all events were added in 1.46.
 
 paths:
-  '/v4/datafeed/create':
-    post:
-      summary: Create a new real time message event stream.
-      description: |
-          A datafeed provides the messages in all conversations that a user is in.
-          This also includes system messages like new users joining a chatroom.
-
-          A datafeed will expire if it isn't read before its capacity is reached.
-      parameters:
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      tags:
-        - Datafeed
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/Datafeed'
-        '400':
-          description: 'Client error.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '503':
-          description: 'Max number of data feeds reached.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v4/datafeed/{id}/read':
-    get:
-      summary: Read a given datafeed.
-      description: |
-          Read messages from the given datafeed. If no more messages are available then this method will block.
-          It is intended that the client should re-call this method as soon as it has processed the messages
-          received in the previous call. If the client is able to consume messages more quickly than they become
-          available then each call will initially block, there is no need to delay before re-calling this method.
-
-          A datafeed will expire if its unread capacity is reached.
-          A datafeed can only be consumed by one client thread at a time. E.g. polling the datafeed by two threads may lead to messages being delivered out of order.
-      parameters:
-      - name: id
-        description: |
-          Datafeed ID
-        in: path
-        required: true
-        type: string
-      - name: limit
-        description: |
-            Max No. of messages to return.
-        in: query
-        type: integer
-      - name: sessionToken
-        description: Session authentication token.
-        in: header
-        required: true
-        type: string
-      - name: keyManagerToken
-        description: Key Manager authentication token.
-        in: header
-        required: true
-        type: string
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      tags:
-        - Datafeed
-      responses:
-        '200':
-          description: List of messages that have occurred since last time this URL was polled. If the list is empty, it means the request has reached its timeout, and the client should poll again.
-          schema:
-            $ref: '#/definitions/V4EventList'
-        '204':
-          description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
   '/v3/health':
     get:
       summary: Checks health status
@@ -343,21 +234,21 @@ paths:
       produces:
         - application/json
       parameters:
-          - name: sessionToken
-            description: Session authentication token.
-            in: header
-            required: true
-            type: string
-          - name: keyManagerToken
-            description: Key Manager authentication token.
-            in: header
-            required: true
-            type: string
-          - name: id
-            description: Message ID as a URL-safe string
-            in: path
-            required: true
-            type: string
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: id
+          description: Message ID as a URL-safe string
+          in: path
+          required: true
+          type: string
       tags:
         - Messages
       responses:
@@ -387,13 +278,13 @@ paths:
     get:
       summary: Search messages
       description: |
-          Search messages according to the specified criteria. The "query" parameter takes a search query defined as
-          "field:value" pairs combined by the operator "AND" (e.g. "text:foo AND autor:bar"). Supported fields are
-           (case-insensitive): "text", "author", "hashtag", "cashtag", "mention", "signal", "fromDate", "toDate",
-           "streamId", "streamType".
-           "text" search requires a "streamId" to be specified.
-           "streamType" accepts one of the following values: "chat" (IMs and MIMs), "im", "mim", "chatroom", "post".
-           "signal" queries can only be combined with "fromDate", "toDate", "skip" and "limit" parameters.
+        Search messages according to the specified criteria. The "query" parameter takes a search query defined as
+        "field:value" pairs combined by the operator "AND" (e.g. "text:foo AND autor:bar"). Supported fields are
+         (case-insensitive): "text", "author", "hashtag", "cashtag", "mention", "signal", "fromDate", "toDate",
+         "streamId", "streamType".
+         "text" search requires a "streamId" to be specified.
+         "streamType" accepts one of the following values: "chat" (IMs and MIMs), "im", "mim", "chatroom", "post".
+         "signal" queries can only be combined with "fromDate", "toDate", "skip" and "limit" parameters.
       produces:
         - application/json
       parameters:
@@ -463,7 +354,7 @@ paths:
     post:
       summary: Search messages
       description: |
-          Search messages according to the specified criteria.
+        Search messages according to the specified criteria.
       consumes:
         - application/json
       produces:
@@ -596,17 +487,17 @@ paths:
     get:
       summary: Get messages from an existing stream.
       description: |
-          A caller can fetch all unseen messages by passing the timestamp of
-          the last message seen as the since parameter and the number of messages
-          with the same timestamp value already seen as the skip parameter. This
-          means that every message will be seen exactly once even in the case that
-          an additional message is processed with the same timestamp as the last
-          message returned by the previous call, and the case where there are
-          more than maxMessages with the same timestamp value.
-
-          This method is intended for historic queries and is generally reliable
-          but if guaranteed delivery of every message in real time is required
-          then the equivilent firehose method should be called.
+        A caller can fetch all unseen messages by passing the timestamp of
+        the last message seen as the since parameter and the number of messages
+        with the same timestamp value already seen as the skip parameter. This
+        means that every message will be seen exactly once even in the case that
+        an additional message is processed with the same timestamp as the last
+        message returned by the previous call, and the case where there are
+        more than maxMessages with the same timestamp value.
+        
+        This method is intended for historic queries and is generally reliable
+        but if guaranteed delivery of every message in real time is required
+        then the equivilent firehose method should be called.
       produces:
         - application/json
       parameters:
@@ -967,8 +858,8 @@ paths:
   '/v1/signals/list':
     get:
       summary: |
-          List signals for the requesting user. This includes signals that the user has created and public signals
-          to which they subscribed.
+        List signals for the requesting user. This includes signals that the user has created and public signals
+        to which they subscribed.
       consumes:
         - application/json
       produces:
@@ -3126,6 +3017,7 @@ paths:
                 createdAt: 1536346282592
               - id: '8e7c8672-221...'
                 createdAt: 1536346282500
+
         400:
           description: Bad request.
           schema:
@@ -3272,8 +3164,8 @@ definitions:
       details:
         type: object
     required:
-    - code
-    - message
+      - code
+      - message
   SuccessResponse:
     type: object
     properties:
@@ -3298,187 +3190,187 @@ definitions:
       streamId:
         type: string
     required:
-    - v2messageType
-    - timestamp
-    - streamId
+      - v2messageType
+      - timestamp
+      - streamId
   V2Message:
     type: object
     description: A representation of a message sent by a user of Symphony.
     allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        message:
-          type: string
-          format: MessageML
-          description: Message text in MessageML
-        fromUserId:
-          type: integer
-          format: int64
-          description: the Symphony userId of the user who sent the message. This will be populated by the server (and actually ignored if included when sending a message).
-        attachments:
-          type: array
-          items:
-            $ref: '#/definitions/AttachmentInfo'
-      required:
-      - message
-      - fromUserId
+      - $ref: '#/definitions/V2BaseMessage'
+      - type: object
+        properties:
+          message:
+            type: string
+            format: MessageML
+            description: Message text in MessageML
+          fromUserId:
+            type: integer
+            format: int64
+            description: the Symphony userId of the user who sent the message. This will be populated by the server (and actually ignored if included when sending a message).
+          attachments:
+            type: array
+            items:
+              $ref: '#/definitions/AttachmentInfo'
+        required:
+          - message
+          - fromUserId
   RoomCreatedMessage:
     type: object
     description: Generated when a room is created.
     allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        creationDate:
-          type: integer
-          format: int64
-        name:
-          type: string
-        keywords:
-          type: array
-          items:
-            $ref: '#/definitions/RoomTag'
-        description:
-          type: string
-        createdByUserId:
-          type: integer
-          format: int64
-          description: The Symphony userId of the user who created the room.
-        readOnly:
-          type: boolean
-        discoverable:
-          type: boolean
-        public:
-          type: boolean
-        membersCanInvite:
-          type: boolean
-        copyProtected:
-          type: boolean
+      - $ref: '#/definitions/V2BaseMessage'
+      - type: object
+        properties:
+          creationDate:
+            type: integer
+            format: int64
+          name:
+            type: string
+          keywords:
+            type: array
+            items:
+              $ref: '#/definitions/RoomTag'
+          description:
+            type: string
+          createdByUserId:
+            type: integer
+            format: int64
+            description: The Symphony userId of the user who created the room.
+          readOnly:
+            type: boolean
+          discoverable:
+            type: boolean
+          public:
+            type: boolean
+          membersCanInvite:
+            type: boolean
+          copyProtected:
+            type: boolean
   RoomDeactivatedMessage:
     type: object
     description: Generated when a room is deactivated.
     allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        deactivatedByUserId:
-          type: integer
-          format: int64
+      - $ref: '#/definitions/V2BaseMessage'
+      - type: object
+        properties:
+          deactivatedByUserId:
+            type: integer
+            format: int64
   RoomReactivatedMessage:
     type: object
     description: Generated when a room is reactivated.
     allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        reactivatedByUserId:
-          type: integer
-          format: int64
+      - $ref: '#/definitions/V2BaseMessage'
+      - type: object
+        properties:
+          reactivatedByUserId:
+            type: integer
+            format: int64
   RoomUpdatedMessage:
     type: object
     description: Generated when a room is updated.
     allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        oldName:
-          type: string
-        newName:
-          type: string
-        keywords:
-          type: array
-          items:
-            $ref: '#/definitions/RoomTag'
-        oldDescription:
-          type: string
-        newDescription:
-          type: string
-        membersCanInvite:
-          type: boolean
-        discoverable:
-          type: boolean
-        readOnly:
-          type: boolean
-        copyProtected:
-          type: boolean
+      - $ref: '#/definitions/V2BaseMessage'
+      - type: object
+        properties:
+          oldName:
+            type: string
+          newName:
+            type: string
+          keywords:
+            type: array
+            items:
+              $ref: '#/definitions/RoomTag'
+          oldDescription:
+            type: string
+          newDescription:
+            type: string
+          membersCanInvite:
+            type: boolean
+          discoverable:
+            type: boolean
+          readOnly:
+            type: boolean
+          copyProtected:
+            type: boolean
   UserJoinedRoomMessage:
     type: object
     description: Generated when a user joins a room.
     allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        addedByUserId:
-          type: integer
-          format: int64
-        memberAddedUserId:
-          type: integer
-          format: int64
+      - $ref: '#/definitions/V2BaseMessage'
+      - type: object
+        properties:
+          addedByUserId:
+            type: integer
+            format: int64
+          memberAddedUserId:
+            type: integer
+            format: int64
   UserLeftRoomMessage:
     type: object
     description: Generated when a user leaves a room.
     allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        removedByUserId:
-          type: integer
-          format: int64
-        memberLeftUserId:
-          type: integer
-          format: int64
-        informationBarrierRemediation:
-          type: boolean
+      - $ref: '#/definitions/V2BaseMessage'
+      - type: object
+        properties:
+          removedByUserId:
+            type: integer
+            format: int64
+          memberLeftUserId:
+            type: integer
+            format: int64
+          informationBarrierRemediation:
+            type: boolean
   RoomMemberPromotedToOwnerMessage:
     type: object
     description: Generated when a room member is promoted to owner.
     allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        promotedByUserId:
-          type: integer
-          format: int64
-        promotedUserId:
-          type: integer
-          format: int64
+      - $ref: '#/definitions/V2BaseMessage'
+      - type: object
+        properties:
+          promotedByUserId:
+            type: integer
+            format: int64
+          promotedUserId:
+            type: integer
+            format: int64
   RoomMemberDemotedFromOwnerMessage:
     type: object
     description: Generated when a room member is promoted to owner.
     allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        demotedByUserId:
-          type: integer
-          format: int64
-        demotedUserId:
-          type: integer
-          format: int64
+      - $ref: '#/definitions/V2BaseMessage'
+      - type: object
+        properties:
+          demotedByUserId:
+            type: integer
+            format: int64
+          demotedUserId:
+            type: integer
+            format: int64
   ConnectionRequestMessage:
     type: object
     description: Generated when a connection request is sent.
     allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        requestingUserId:
-          type: integer
-          format: int64
-        targetUserId:
-          type: integer
-          format: int64
-        firstRequestedAt:
-          type: integer
-          format: int64
-        updatedAt:
-          type: integer
-          format: int64
-        requestCounter:
-          type: integer
-        status:
-          type: string
+      - $ref: '#/definitions/V2BaseMessage'
+      - type: object
+        properties:
+          requestingUserId:
+            type: integer
+            format: int64
+          targetUserId:
+            type: integer
+            format: int64
+          firstRequestedAt:
+            type: integer
+            format: int64
+          updatedAt:
+            type: integer
+            format: int64
+          requestCounter:
+            type: integer
+          status:
+            type: string
   AttachmentInfo:
     type: object
     properties:
@@ -3493,9 +3385,9 @@ definitions:
         format: int64
         description: Size in bytes.
     required:
-    - id
-    - name
-    - size
+      - id
+      - name
+      - size
   V2MessageList:
     type: array
     items:
@@ -3506,11 +3398,7 @@ definitions:
     properties:
       message:
         type: string
-  Datafeed:
-    type: object
-    properties:
-      id:
-        type: string
+
   RoomTag:
     description: Room Tag object. A key:value pair describing additional properties of the room.
     properties:
@@ -3521,8 +3409,8 @@ definitions:
         description: The value of this Tag's label.
         type: string
     required:
-    - key
-    - value
+      - key
+      - value
   ShareArticle:
     type: object
     properties:
@@ -3567,10 +3455,10 @@ definitions:
         type: string
         description: App icon url of the calling application
     required:
-    - title
-    - publisher
-    - author
-    - appId
+      - title
+      - publisher
+      - author
+      - appId
   ShareContent:
     type: object
     properties:
@@ -3580,50 +3468,50 @@ definitions:
       content:
         $ref: '#/definitions/ShareArticle'
   V2HealthCheckResponse:
-     type: object
-     properties:
-       podConnectivity:
-         type: boolean
-         description: Indicates whether the Agent server can connect to the Pod
-       podConnectivityError:
-         type: string
-         description: Error details in case of no Pod connectivity
-       keyManagerConnectivity:
-         type: boolean
-         description: Indicates whether the Agent server can connect to the Key Manager
-       keyManagerConnectivityError:
-         type: string
-         description: Error details in case of no Key Manager connectivity
-       firehoseConnectivity:
-         type: boolean
-         description: Indicates whether the Agent server can connect to Firehose Service
-       firehoseConnectivityError:
-         type: string
-         description: Error details in case of no Firehose connectivity
-       encryptDecryptSuccess:
-         type: boolean
-         description: Indicates whether the Agent can successfully decrypt and encrypt messages
-       encryptDecryptError:
-         type: string
-         description: Error details in case of the encryption or decryption of the message fails
-       podVersion:
-         type: string
-         description: The version number of the pod
-       agentVersion:
-         type: string
-         description: The version number of the Agent server
-       agentServiceUser:
-         type: boolean
-         description: Indicates whether agent service user is setup correctly.
-       agentServiceUserError:
-         type: string
-         description: Error details in case agent service user is setup incorrectly.
-       ceServiceUser:
-         type: boolean
-         description: Indicates whether CEService user is setup correctly.
-       ceServiceUserError:
-         type: string
-         description: Error details in case CEService user is setup incorrectly.
+    type: object
+    properties:
+      podConnectivity:
+        type: boolean
+        description: Indicates whether the Agent server can connect to the Pod
+      podConnectivityError:
+        type: string
+        description: Error details in case of no Pod connectivity
+      keyManagerConnectivity:
+        type: boolean
+        description: Indicates whether the Agent server can connect to the Key Manager
+      keyManagerConnectivityError:
+        type: string
+        description: Error details in case of no Key Manager connectivity
+      firehoseConnectivity:
+        type: boolean
+        description: Indicates whether the Agent server can connect to Firehose Service
+      firehoseConnectivityError:
+        type: string
+        description: Error details in case of no Firehose connectivity
+      encryptDecryptSuccess:
+        type: boolean
+        description: Indicates whether the Agent can successfully decrypt and encrypt messages
+      encryptDecryptError:
+        type: string
+        description: Error details in case of the encryption or decryption of the message fails
+      podVersion:
+        type: string
+        description: The version number of the pod
+      agentVersion:
+        type: string
+        description: The version number of the Agent server
+      agentServiceUser:
+        type: boolean
+        description: Indicates whether agent service user is setup correctly.
+      agentServiceUserError:
+        type: string
+        description: Error details in case agent service user is setup incorrectly.
+      ceServiceUser:
+        type: boolean
+        description: Indicates whether CEService user is setup correctly.
+      ceServiceUserError:
+        type: string
+        description: Error details in case CEService user is setup incorrectly.
   MessageSearchQuery:
     type: object
     properties:
@@ -3720,11 +3608,11 @@ definitions:
         items:
           $ref: '#/definitions/V4ImportedMessageAttachment'
     required:
-    - message
-    - intendedMessageTimestamp
-    - intendedMessageFromUserId
-    - originatingSystemId
-    - streamId
+      - message
+      - intendedMessageTimestamp
+      - intendedMessageFromUserId
+      - originatingSystemId
+      - streamId
   V4ImportedMessageAttachment:
     type: object
     properties:
@@ -3779,9 +3667,9 @@ definitions:
         items:
           $ref: '#/definitions/V4ThumbnailInfo'
     required:
-    - id
-    - name
-    - size
+      - id
+      - name
+      - size
   V4ThumbnailInfo:
     type: object
     properties:
@@ -4332,10 +4220,10 @@ definitions:
   V1DLPPolicy:
     type: object
     required:
-    - "contentTypes"
-    - "name"
-    - "scopes"
-    - "type"
+      - "contentTypes"
+      - "name"
+      - "scopes"
+      - "type"
     properties:
       active:
         type: boolean
@@ -4394,10 +4282,10 @@ definitions:
   V1DLPPolicyRequest:
     type: object
     required:
-    - "contentTypes"
-    - "name"
-    - "scopes"
-    - "type"
+      - "contentTypes"
+      - "name"
+      - "scopes"
+      - "type"
     properties:
       contentTypes:
         type: array
@@ -4434,7 +4322,7 @@ definitions:
   V1DLPDictionary:
     type: object
     required:
-    - dictionaryMetadata
+      - dictionaryMetadata
     properties:
       content:
         $ref: '#/definitions/V1DLPDictionaryContent'
@@ -4476,7 +4364,7 @@ definitions:
   V1DLPDictionaryMetadataResponse:
     type: object
     required:
-    - data
+      - data
     properties:
       data:
         $ref: '#/definitions/V1DLPDictionaryMetadata'
@@ -4484,8 +4372,8 @@ definitions:
   V1DLPDictionaryMetadataCreateRequest:
     type: object
     required:
-    - name
-    - type
+      - name
+      - type
     properties:
       name:
         type: string
@@ -4500,7 +4388,7 @@ definitions:
   V1DLPDictionaryMetadataUpdateRequest:
     type: object
     required:
-    - name
+      - name
     properties:
       name:
         type: string
@@ -4510,8 +4398,8 @@ definitions:
   V1DLPDictionaryMetadata:
     type: object
     required:
-    - dictRef
-    - type
+      - dictRef
+      - type
     properties:
       creationDate:
         type: integer
@@ -4535,7 +4423,7 @@ definitions:
   V1DLPDictionaryRef:
     type: object
     required:
-    - name
+      - name
     properties:
       dictId:
         type: string
@@ -4595,8 +4483,8 @@ definitions:
       diagnostic:
         type: string
         description: |
-            A diagnostic message containing an error message in the event there are parsing errors.
-            May also be present in the case of a successful call if there is useful narrative to return.
+          A diagnostic message containing an error message in the event there are parsing errors.
+          May also be present in the case of a successful call if there is useful narrative to return.
   V1DLPViolationStream:
     type: object
     properties:
@@ -4650,8 +4538,8 @@ definitions:
         type: string
         description: Version of application which processed the message and produced this violation.
       ignoreDLPwarning:
-          type: boolean
-          description: Did the user chose to ignore DLP warning that was presented?
+        type: boolean
+        description: Did the user chose to ignore DLP warning that was presented?
   V1DLPMatchedPolicyList:
     type: array
     items:
@@ -4679,9 +4567,9 @@ definitions:
       diagnostic:
         type: string
         description: |
-            A diagnostic message containing an error message in the event that the
-            decryption of terms failed. May also be present in the case of a successful
-            call if there is useful narrative to return.
+          A diagnostic message containing an error message in the event that the
+          decryption of terms failed. May also be present in the case of a successful
+          call if there is useful narrative to return.
   V1DLPOutcome:
     type: object
     description: A representation of outcome of DLP message/stream/signal sent by a user of Symphony
@@ -4700,93 +4588,93 @@ definitions:
     type: object
     description: Room details in the context of violation.
     properties:
-        name:
-          type: string
-          description:  Name of the Stream/Room.
-        creatorPrettyName:
-          type: string
-          description:  Name of the creator of the Room.
-        publicRoom:
-          type: boolean
-          description:  Is this a public room?
-        crossPod:
-          type: boolean
-          description:  Is this a cross pod scenario?
-        allowExternal:
-          type: boolean
-          description:  Is external messaging allowed
-        creatorId:
-          type: string
-          description:  Id of the creator of the Room.
-        roomDescription:
-          type: string
-          description:  Description of the Room.
-        streamId:
-          type: string
-          description:  ThreadId of the Room.
-        state:
-          type: string
-          description:  State of the Room (example CREATED etc)
-        type:
-          type: string
-          description:  Type of the Room (example ROOM (or IM or Wall))
-        lastDisabled:
-          type: integer
-          format: int64
-          description: Timestamp of last time the room is Disabled
-        memberAddUserEnabled:
-          type: boolean
-          description:  Is memberAddUserEnabled
-        active:
-          type: boolean
-          description:  Is Room Active
-        discoverable:
-          type: boolean
-          description:  Is Room discoverable
-        readOnly:
-          type: boolean
-          description:  Is Room read-only
-        copyDisabled:
-          type: boolean
-          description:  Is Room copyDisabled
-        externalOwned:
-          type: boolean
-          description:  Is Room externalOwned
-        sendMessageDisabled:
-          type: boolean
-          description:  Is sendMessage Disabled for this Room
-        moderated:
-          type: boolean
-          description:  Is room moderated
-        shareHistoryEnabled:
-          type: boolean
-          description:  Is room shareHistoryEnabled
-        diagnostic:
-          type: string
-          description: |
-              A diagnostic message containing an error message in the event that the
-              stream retrieval failed. May also be present in the case of a successful
-              call if there is useful narrative to return.
+      name:
+        type: string
+        description:  Name of the Stream/Room.
+      creatorPrettyName:
+        type: string
+        description:  Name of the creator of the Room.
+      publicRoom:
+        type: boolean
+        description:  Is this a public room?
+      crossPod:
+        type: boolean
+        description:  Is this a cross pod scenario?
+      allowExternal:
+        type: boolean
+        description:  Is external messaging allowed
+      creatorId:
+        type: string
+        description:  Id of the creator of the Room.
+      roomDescription:
+        type: string
+        description:  Description of the Room.
+      streamId:
+        type: string
+        description:  ThreadId of the Room.
+      state:
+        type: string
+        description:  State of the Room (example CREATED etc)
+      type:
+        type: string
+        description:  Type of the Room (example ROOM (or IM or Wall))
+      lastDisabled:
+        type: integer
+        format: int64
+        description: Timestamp of last time the room is Disabled
+      memberAddUserEnabled:
+        type: boolean
+        description:  Is memberAddUserEnabled
+      active:
+        type: boolean
+        description:  Is Room Active
+      discoverable:
+        type: boolean
+        description:  Is Room discoverable
+      readOnly:
+        type: boolean
+        description:  Is Room read-only
+      copyDisabled:
+        type: boolean
+        description:  Is Room copyDisabled
+      externalOwned:
+        type: boolean
+        description:  Is Room externalOwned
+      sendMessageDisabled:
+        type: boolean
+        description:  Is sendMessage Disabled for this Room
+      moderated:
+        type: boolean
+        description:  Is room moderated
+      shareHistoryEnabled:
+        type: boolean
+        description:  Is room shareHistoryEnabled
+      diagnostic:
+        type: string
+        description: |
+          A diagnostic message containing an error message in the event that the
+          stream retrieval failed. May also be present in the case of a successful
+          call if there is useful narrative to return.
   V1DLPSignal:
     type: object
     description: Signal details
     properties:
-        name:
-          type: string
-          description:  Name of the Signal
-        rules:
-          type: string
-          description:  Signal rules decrypted.
-        diagnostic:
-          type: string
-          description: |
-              A diagnostic message containing an error message in the event that the
-              signal decryption failed. May also be present in the case of a successful
-              call if there is useful narrative to return.
+      name:
+        type: string
+        description:  Name of the Signal
+      rules:
+        type: string
+        description:  Signal rules decrypted.
+      diagnostic:
+        type: string
+        description: |
+          A diagnostic message containing an error message in the event that the
+          signal decryption failed. May also be present in the case of a successful
+          call if there is useful narrative to return.
 
-#
-# V3 Policies definitions
-#
+  #
+  # V3 Policies definitions
+  #
   V3DLPPolicyRequest:
     type: object
     required:
@@ -4874,8 +4762,8 @@ definitions:
   V3DLPRule:
     type: object
     required:
-     - "type"
-     - "name"
+      - "type"
+      - "name"
     properties:
       id:
         type: string
@@ -4896,25 +4784,25 @@ definitions:
       fileClassifierConfig:
         $ref: '#/definitions/V3DLPFileClassifierConfig'
     description: |
-     A Rule defines the actual matching specification for policies. It holds a type and a configuration
-     for the rule, these properties should be used to build the corresponding matching implementation.
-     Only one of the configuration property should be set [textMatchConfig, fileSizeConfig, fileExtensionConfig, filePasswordConfig, fileClassifierConfig].
+      A Rule defines the actual matching specification for policies. It holds a type and a configuration
+      for the rule, these properties should be used to build the corresponding matching implementation.
+      Only one of the configuration property should be set [textMatchConfig, fileSizeConfig, fileExtensionConfig, filePasswordConfig, fileClassifierConfig].
   V3DLPFilePasswordConfig:
     type: object
     required:
       - "applicableFileTypes"
       - "matchCriteria"
     properties:
-        applicableFileTypes:
-          type: array
-          items:
-            type: string
-          description: File types that can be applied. Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
-        matchCriteria:
+      applicableFileTypes:
+        type: array
+        items:
           type: string
-          description: |
-           Based on the criteria, whether a file is password protected or not means a match.
-           Can be ["PASSWORD_PROTECTED", "NOT_PASSWORD_PROTECTED"]. The default is "NOT_PASSWORD_PROTECTED".
+        description: File types that can be applied. Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
+      matchCriteria:
+        type: string
+        description: |
+          Based on the criteria, whether a file is password protected or not means a match.
+          Can be ["PASSWORD_PROTECTED", "NOT_PASSWORD_PROTECTED"]. The default is "NOT_PASSWORD_PROTECTED".
     description: Password protected detection config for files that are password protected or not.
   V3DLPFileExtensionConfig:
     type: object
@@ -4945,14 +4833,14 @@ definitions:
       dictionaries:
         type: array
         items:
-         $ref: '#/definitions/V3DLPDictionaryMeta'
+          $ref: '#/definitions/V3DLPDictionaryMeta'
       countUniqueOccurrences:
         type: integer
         format: int32
       applicableFileTypes:
         type: array
         items:
-         type: string
+          type: string
         description: |
           File types must be applied only for rule type "FileContent", otherwise must be empty.
           Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
@@ -4983,16 +4871,16 @@ definitions:
       classifiers:
         type: object
         additionalProperties:
-         type: string
+          type: string
         description: |
-         Classifier is defined as a Key and its Value: e.g.: "classification": "Internal".
-         Name and value can contain UTF-8 characters. Neither the name nor value cannot be left empty.
-         Maximum 30 characters for the name and value, case insensitive.
-         If files contains k-v pairs in the classifers map, it means a match. Maximum 30 classifiers per policy.
+          Classifier is defined as a Key and its Value: e.g.: "classification": "Internal".
+          Name and value can contain UTF-8 characters. Neither the name nor value cannot be left empty.
+          Maximum 30 characters for the name and value, case insensitive.
+          If files contains k-v pairs in the classifers map, it means a match. Maximum 30 classifiers per policy.
       applicableFileTypes:
         type: array
         items:
-         type: string
+          type: string
         description: |
           File types that can be applied. Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
   V3DLPPolicyAppliesTo:
@@ -5086,8 +4974,8 @@ definitions:
         # Message details when DLP was enforced
         $ref: '#/definitions/V4Message'
       sharedMessage:
-              description: Shared message details if present in message.
-              $ref: '#/definitions/V4Message'
+        description: Shared message details if present in message.
+        $ref: '#/definitions/V4Message'
       diagnostic:
         type: string
         description: |
@@ -5148,8 +5036,8 @@ definitions:
         type: string
         description: Version of application which processed the message and produced this violation.
       ignoreDLPwarning:
-          type: boolean
-          description: Did the user chose to ignore DLP warning that was presented?
+        type: boolean
+        description: Did the user chose to ignore DLP warning that was presented?
   Pagination:
     type: object
     required:
@@ -5267,21 +5155,21 @@ definitions:
         type: string
         description: The ackId which acknowledges that the current batch of messages have been successfully received by the client
   V3Health:
-      properties:
-        services:
-          additionalProperties:
-            $ref: '#/definitions/V3HealthComponent'
-          type: object
-        status:
-          $ref: '#/definitions/V3HealthStatus'
-        users:
-          additionalProperties:
-            $ref: '#/definitions/V3HealthComponent'
-          type: object
-        version:
-          description: Required Agent verison
-          type: string
-      type: object
+    properties:
+      services:
+        additionalProperties:
+          $ref: '#/definitions/V3HealthComponent'
+        type: object
+      status:
+        $ref: '#/definitions/V3HealthStatus'
+      users:
+        additionalProperties:
+          $ref: '#/definitions/V3HealthComponent'
+        type: object
+      version:
+        description: Required Agent verison
+        type: string
+    type: object
   V3HealthAuthType:
     description: Type of authentication
     enum:


### PR DESCRIPTION
Datafeed v1 will be soon fully replaced by Datafeed v2. 
V4Datafeed APIs (using DFv1) are being deprecated in this PR in favor of V5 API (using DFv2).
Two endpoint have been deprecated :
- POST `/agent/v4/datafeed/create`
- GET `/agent/v4/datafeed/{id}/read`