### PR TITLE
Correct appId maxLength in pod api specs

### DIFF
--- a/pod/pod-api-public-deprecated.yaml
+++ b/pod/pod-api-public-deprecated.yaml
@@ -6676,6 +6676,8 @@ definitions:
       appId:
         type: string
         description: App ID for the Product
+        maxLength: 256
+        minLength: 1
       name:
         type: string
         minLength: 1
@@ -6737,7 +6739,7 @@ definitions:
       appId:
         type: string
         description: Unique ID for the Application
-        maxLength: 32
+        maxLength: 256
         minLength: 1
       appName:
         type: string
@@ -6765,7 +6767,7 @@ definitions:
       appId:
         type: string
         description: Unique ID for the Application
-        maxLength: 32
+        maxLength: 256
         minLength: 1
       appName:
         type: string
@@ -6847,7 +6849,7 @@ definitions:
       appId:
         type: string
         description: Unique ID for the Application
-        maxLength: 32
+        maxLength: 256
         minLength: 1
       listed:
         type: string
@@ -7566,6 +7568,8 @@ definitions:
       appId:
         description: An unique id for the application.
         type: string
+        maxLength: 256
+        minLength: 1
       name:
         description: User defined name for the application.
         type: string

--- a/pod/pod-api-public.yaml
+++ b/pod/pod-api-public.yaml
@@ -5522,6 +5522,8 @@ definitions:
       appId:
         type: string
         description: App ID for the Product
+        maxLength: 256
+        minLength: 1
       name:
         type: string
         minLength: 1
@@ -5583,7 +5585,7 @@ definitions:
       appId:
         type: string
         description: Unique ID for the Application
-        maxLength: 32
+        maxLength: 256
         minLength: 1
       appName:
         type: string
@@ -5611,7 +5613,7 @@ definitions:
       appId:
         type: string
         description: Unique ID for the Application
-        maxLength: 32
+        maxLength: 256
         minLength: 1
       appName:
         type: string
@@ -5693,7 +5695,7 @@ definitions:
       appId:
         type: string
         description: Unique ID for the Application
-        maxLength: 32
+        maxLength: 256
         minLength: 1
       listed:
         type: string
@@ -6412,6 +6414,8 @@ definitions:
       appId:
         description: An unique id for the application.
         type: string
+        maxLength: 256
+        minLength: 1
       name:
         description: User defined name for the application.
         type: string


### PR DESCRIPTION
Related to [PLAT-10763](https://perzoinc.atlassian.net/browse/PLAT-10763)
AppId maxLength is 256 in SBE while it is set to 32 in api specs. It is corrected here to be 256 character