### PR TITLE
AGNT-9: Use master branch only

### DIFF
--- a/agent/agent-api-public-deprecated.yaml
+++ b/agent/agent-api-public-deprecated.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: '20.15.0-SNAPSHOT'
+  version: '22.5.1-SNAPSHOT'
   title: Agent API
   description: |
     This document refers to Symphony API calls to send and receive messages
@@ -725,7 +725,8 @@ paths:
           type: string
           required: false
           description: |
-            Optional boolean field that will determine if the user/s should receive the message as read or not (true by default)
+            Optional boolean field that will determine if the user/s should receive the message as read or not (true by default). Since Agent 20.14.
+          x-since: 20.14
       tags:
         - Messages
       responses:
@@ -3150,7 +3151,7 @@ paths:
         - Datafeed
       summary: Read Real Time Events from an event stream (aka datafeed)
       description: |
-        _Available on Agent 20.15.0 and above._
+        _Available on Agent 22.5 and above._
 
         This endpoint provides messages and events from all conversations that the user
         is in or events from the whole pod depending on the "type" field value.
@@ -4898,15 +4899,17 @@ definitions:
       streamId:
         type: string
       attachments:
-        description: List of message attachments
+        description: List of message attachments. Since Agent 20.14.
         type: array
         items:
           $ref: '#/definitions/V4ImportedMessageAttachment'
+        x-since: 20.14
       previews:
-        description: List of attachments previews
+        description: List of attachments previews. Since Agent 20.14.
         type: array
         items:
           $ref: '#/definitions/V4ImportedMessageAttachment'
+        x-since: 20.14
     required:
     - message
     - intendedMessageTimestamp
@@ -5062,7 +5065,8 @@ definitions:
         description: Id the the initial message that has been updated (present only if set)
       silent:
         type: boolean
-        description: When false the user/s will receive the message update as unread (true by default).
+        description: When false the user/s will receive the message update as unread (true by default). Since Agent 20.14.
+        x-since: 20.14
   V4MessageBlastResponse:
     type: object
     description: Wrapper response for a single message sent to multiple streams

--- a/agent/agent-api-public.yaml
+++ b/agent/agent-api-public.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: '20.15.0-SNAPSHOT'
+  version: '22.5.1-SNAPSHOT'
   title: Agent API
   description: |
     This document refers to Symphony API calls to send and receive messages
@@ -725,7 +725,8 @@ paths:
           type: string
           required: false
           description: |
-            Optional boolean field that will determine if the user/s should receive the message as read or not (true by default)
+            Optional boolean field that will determine if the user/s should receive the message as read or not (true by default). Since Agent 20.14.
+          x-since: 20.14
       tags:
         - Messages
       responses:
@@ -3149,8 +3150,9 @@ paths:
       tags:
         - Datafeed
       summary: Read Real Time Events from an event stream (aka datafeed)
+      x-since: 22.5
       description: |
-        _Available on Agent 20.15.0 and above._
+        _Available on Agent 22.5 and above._
 
         This endpoint provides messages and events from all conversations that the user
         is in or events from the whole pod depending on the "type" field value.
@@ -3666,15 +3668,17 @@ definitions:
       streamId:
         type: string
       attachments:
-        description: List of message attachments
+        description: List of message attachments. Since Agent 20.14.
         type: array
         items:
           $ref: '#/definitions/V4ImportedMessageAttachment'
+        x-since: 20.14
       previews:
-        description: List of attachments previews
+        description: List of attachments previews. Since Agent 20.14.
         type: array
         items:
           $ref: '#/definitions/V4ImportedMessageAttachment'
+        x-since: 20.14
     required:
     - message
     - intendedMessageTimestamp
@@ -3830,7 +3834,8 @@ definitions:
         description: Id the the initial message that has been updated (present only if set)
       silent:
         type: boolean
-        description: When false the user/s will receive the message update as unread (true by default).
+        description: When false the user/s will receive the message update as unread (true by default). Since Agent 20.14.
+        x-since: 20.14
   V4MessageBlastResponse:
     type: object
     description: Wrapper response for a single message sent to multiple streams

--- a/login/login-api-public.yaml
+++ b/login/login-api-public.yaml
@@ -246,7 +246,8 @@ paths:
   '/idm/keys':
     get:
       summary: Returns the Common Access Token (JWT) public keys as a JWKS.
-      description: This is a public endpoint, no authentication is required. The JWKS can be used to verify JWT issued by the idm/tokens endpoint.
+      x-since: 20.14
+      description: This is a public endpoint, no authentication is required. The JWKS can be used to verify JWT issued by the idm/tokens endpoint. Since SBE 20.14.
       produces:
         - application/json
       tags:

--- a/pod/pod-api-public-deprecated.yaml
+++ b/pod/pod-api-public-deprecated.yaml
@@ -6600,14 +6600,17 @@ definitions:
           - DISABLED
       suspended:
         type: boolean
-        description: An optional attribute indicating whether the user is temporarily suspended or not
+        description: An optional attribute indicating whether the user is temporarily suspended or not. Since SBE 20.14.
+        x-since: 20.14
       suspendedUntil:
         type: integer
         format: int64
-        description: An optional unix timestamp until which the suspension is effective
+        description: An optional unix timestamp until which the suspension is effective. Since SBE 20.14.
+        x-since: 20.14
       suspensionReason:
         type: string
-        description: An optional description of the suspension reason
+        description: An optional description of the suspension reason. Since SBE 20.14.
+        x-since: 20.14
   UserFilter:
     type: object
     properties:
@@ -7123,14 +7126,17 @@ definitions:
           - DISABLED
       suspended:
         type: boolean
-        description: An optional attribute indicating whether the user is temporarily suspended or not
+        description: An optional attribute indicating whether the user is temporarily suspended or not. Since SBE 20.14.
+        x-since: 20.14
       suspendedUntil:
         type: integer
         format: int64
-        description: An optional unix timestamp until which the suspension is effective
+        description: An optional unix timestamp until which the suspension is effective. Since SBE 20.14.
+        x-since: 20.14
       suspensionReason:
         type: string
-        description: An optional description of the suspension reason
+        description: An optional description of the suspension reason. Since SBE 20.14.
+        x-since: 20.14
       createdDate:
         type: integer
         format: int64
@@ -7201,7 +7207,8 @@ definitions:
         type: integer
         format: int64
       addedThroughGroups:
-        description: When the user has been added to the stream through a group (aka SDL), this array contains the group ID which the user belongs to.
+        description: When the user has been added to the stream through a group (aka SDL), this array contains the group ID which the user belongs to. Since SBE 20.14.
+        x-since: 20.14
         type: array
         items:
           type: integer
@@ -7254,7 +7261,8 @@ definitions:
         type: integer
         format: int64
       addedThroughGroups:
-        description: When the user has been added to the stream through a group (aka SDL), this array contains the group ID which the user belongs to.
+        description: When the user has been added to the stream through a group (aka SDL), this array contains the group ID which the user belongs to. Since SBE 20.14.
+        x-since: 20.14
         type: array
         items:
           type: integer
@@ -7450,7 +7458,8 @@ definitions:
         type: string
         description: Room name.
       groups:
-        description: List of groups (aka SDLs) that were added to the room.
+        description: List of groups (aka SDLs) that were added to the room. Since SBE 20.14.
+        x-since: 20.14
         type: array
         items:
           $ref: '#/definitions/GroupItem'
@@ -7892,7 +7901,8 @@ definitions:
         description: "apiKey sent into every callback request, using the X-API-KEY header"
   AppProperties:
     type: array
-    description: Application configuration properties that are shared with the extension application, client side. Do not store sensitive information here.
+    description: Application configuration properties that are shared with the extension application, client side. Do not store sensitive information here. Since SBE 20.14.
+    x-since: 20.14
     items:
       $ref: '#/definitions/AppProperty'
   AppProperty:

--- a/pod/pod-api-public.yaml
+++ b/pod/pod-api-public.yaml
@@ -5446,14 +5446,17 @@ definitions:
           - DISABLED
       suspended:
         type: boolean
-        description: An optional attribute indicating whether the user is temporarily suspended or not
+        description: An optional attribute indicating whether the user is temporarily suspended or not. Since SBE 20.14.
+        x-since: 20.14
       suspendedUntil:
         type: integer
         format: int64
-        description: An optional unix timestamp until which the suspension is effective
+        description: An optional unix timestamp until which the suspension is effective. Since SBE 20.14.
+        x-since: 20.14
       suspensionReason:
         type: string
-        description: An optional description of the suspension reason
+        description: An optional description of the suspension reason. Since SBE 20.14.
+        x-since: 20.14
   UserFilter:
     type: object
     properties:
@@ -5969,14 +5972,17 @@ definitions:
           - DISABLED
       suspended:
         type: boolean
-        description: An optional attribute indicating whether the user is temporarily suspended or not
+        description: An optional attribute indicating whether the user is temporarily suspended or not. Since SBE 20.14.
+        x-since: 20.14
       suspendedUntil:
         type: integer
         format: int64
-        description: An optional unix timestamp until which the suspension is effective
+        description: An optional unix timestamp until which the suspension is effective. Since SBE 20.14.
+        x-since: 20.14
       suspensionReason:
         type: string
-        description: An optional description of the suspension reason
+        description: An optional description of the suspension reason. Since SBE 20.14.
+        x-since: 20.14
       createdDate:
         type: integer
         format: int64
@@ -6047,7 +6053,8 @@ definitions:
         type: integer
         format: int64
       addedThroughGroups:
-        description: When the user has been added to the stream through a group (aka SDL), this array contains the group ID which the user belongs to.
+        description: When the user has been added to the stream through a group (aka SDL), this array contains the group ID which the user belongs to. Since SBE 20.14.
+        x-since: 20.14
         type: array
         items:
           type: integer
@@ -6100,7 +6107,8 @@ definitions:
         type: integer
         format: int64
       addedThroughGroups:
-        description: When the user has been added to the stream through a group (aka SDL), this array contains the group ID which the user belongs to.
+        description: When the user has been added to the stream through a group (aka SDL), this array contains the group ID which the user belongs to. Since SBE 20.14.
+        x-since: 20.14
         type: array
         items:
           type: integer
@@ -6296,7 +6304,8 @@ definitions:
         type: string
         description: Room name.
       groups:
-        description: List of groups (aka SDLs) that were added to the room.
+        description: List of groups (aka SDLs) that were added to the room. Since SBE 20.14.
+        x-since: 20.14
         type: array
         items:
           $ref: '#/definitions/GroupItem'
@@ -6738,7 +6747,8 @@ definitions:
         description: "apiKey sent into every callback request, using the X-API-KEY header"
   AppProperties:
     type: array
-    description: Application configuration properties that are shared with the extension application, client side. Do not store sensitive information here.
+    description: Application configuration properties that are shared with the extension application, client side. Do not store sensitive information here. Since SBE 20.14.
+    x-since: 20.14
     items:
       $ref: '#/definitions/AppProperty'
   AppProperty:


### PR DESCRIPTION
To decouple SBE/Agent releases, start adding information specific
information in the specification.

x-since is not used by any tool but is here as a meta information that
could potentially be used in the future. Therefore we also set this as
part of the description.

Backport this approach to changes from 20.14 version.