### PR TITLE
AGNT-9: Drop snapshot in Swagger spec version

### DIFF
--- a/agent/agent-api-public-deprecated.yaml
+++ b/agent/agent-api-public-deprecated.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: '22.5.1-SNAPSHOT'
+  version: '22.5.1'
   title: Agent API
   description: |
     This document refers to Symphony API calls to send and receive messages

--- a/agent/agent-api-public.yaml
+++ b/agent/agent-api-public.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: '22.5.1-SNAPSHOT'
+  version: '22.5.1'
   title: Agent API
   description: |
     This document refers to Symphony API calls to send and receive messages


### PR DESCRIPTION
As we are using master branch only, just drop it and use the next
version of the Agent instead. Once we start putting new features in the
spec we can increment this number manually too.

Upon a release when we synchronize the internal specs with those being
public we will put anyway the released version of the Agent or SBE.