### PR TITLE
Remove unsupported Datahose events from documentation

### DIFF
--- a/agent/agent-api-public-deprecated.yaml
+++ b/agent/agent-api-public-deprecated.yaml
@@ -6473,13 +6473,11 @@ definitions:
       filters:
         type: array
         description: |
+          If type is set to be fanout, this should not be set.
           At least one value is required if type datahose is specified. Values must be valid real event types, allowed values are:
           * SOCIALMESSAGE
-          * CHANNEL_CREATE
-          * CHANNEL_UPDATE
           * CREATE_ROOM
           * UPDATE_ROOM
-          * UPDATE_STREAM
         items:
           type: string
       ackId:

--- a/agent/agent-api-public.yaml
+++ b/agent/agent-api-public.yaml
@@ -5242,13 +5242,11 @@ definitions:
       filters:
         type: array
         description: |
+          If type is set to be fanout, this should not be set.
           At least one value is required if type datahose is specified. Values must be valid real event types, allowed values are:
           * SOCIALMESSAGE
-          * CHANNEL_CREATE
-          * CHANNEL_UPDATE
           * CREATE_ROOM
           * UPDATE_ROOM
-          * UPDATE_STREAM
         items:
           type: string
       ackId:


### PR DESCRIPTION
Those events are not yet handled by the Agent so avoid mentionning them
in the OpenAPI specification.