### PR TITLE
AGNT-53: support Real-time Events in datahose

### DIFF
--- a/agent/agent-api-public-deprecated.yaml
+++ b/agent/agent-api-public-deprecated.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: '22.5.1'
+  version: '22.7.1'
   title: Agent API
   description: |
     This document refers to Symphony API calls to send and receive messages
@@ -6470,16 +6470,29 @@ definitions:
         minLength: 1
         maxLength: 80
         description: A unique identifier to ensure uniqueness of the datafeed.
-      filters:
+      eventTypes:
         type: array
         description: |
-          If type is set to be fanout, this should not be set.
-          At least one value is required if type datahose is specified. Values must be valid real event types, allowed values are:
-          * SOCIALMESSAGE
-          * CREATE_ROOM
-          * UPDATE_ROOM
+          At least one value is required if the type of feed is "datahose". Values must be a valid Real-Time Event type, i.e. one of:
+          * MESSAGESENT
+          * MESSAGESUPPRESSED
+          * SYMPHONYELEMENTSACTION
+          * SHAREDPOST
+          * INSTANTMESSAGECREATED
+          * ROOMCREATED
+          * ROOMUPDATED
+          * ROOMDEACTIVATED
+          * ROOMREACTIVATED
+          * USERREQUESTEDTOJOINROOM
+          * USERJOINEDROOM
+          * USERLEFTROOM
+          * ROOMMEMBERPROMOTEDTOOWNER
+          * ROOMMEMBERDEMOTEDFROMOWNER
+          * CONNECTIONREQUESTED
+          * CONNECTIONACCEPTED
         items:
           type: string
+        x-since: 22.7
       ackId:
         type: string
         description: should be empty for the first call, acknowledges that the current batch of messages have been successfully received by the client.

--- a/agent/agent-api-public.yaml
+++ b/agent/agent-api-public.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: '22.5.1'
+  version: '22.7.1'
   title: Agent API
   description: |
     This document refers to Symphony API calls to send and receive messages

--- a/agent/agent-api-public.yaml
+++ b/agent/agent-api-public.yaml
@@ -5239,16 +5239,29 @@ definitions:
         minLength: 1
         maxLength: 80
         description: A unique identifier to ensure uniqueness of the datafeed.
-      filters:
+      eventTypes:
         type: array
         description: |
-          If type is set to be fanout, this should not be set.
-          At least one value is required if type datahose is specified. Values must be valid real event types, allowed values are:
-          * SOCIALMESSAGE
-          * CREATE_ROOM
-          * UPDATE_ROOM
+          At least one value is required if the type of feed is "datahose". Values must be a valid Real-Time Event type, i.e. one of:
+          * MESSAGESENT
+          * MESSAGESUPPRESSED
+          * SYMPHONYELEMENTSACTION
+          * SHAREDPOST
+          * INSTANTMESSAGECREATED
+          * ROOMCREATED
+          * ROOMUPDATED
+          * ROOMDEACTIVATED
+          * ROOMREACTIVATED
+          * USERREQUESTEDTOJOINROOM
+          * USERJOINEDROOM
+          * USERLEFTROOM
+          * ROOMMEMBERPROMOTEDTOOWNER
+          * ROOMMEMBERDEMOTEDFROMOWNER
+          * CONNECTIONREQUESTED
+          * CONNECTIONACCEPTED
         items:
           type: string
+        x-since: 22.7
       ackId:
         type: string
         description: should be empty for the first call, acknowledges that the current batch of messages have been successfully received by the client.

--- a/postman/Symphony_REST_APIs.postman_collection.json
+++ b/postman/Symphony_REST_APIs.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "1e868f65-9dda-496a-acae-cccfe7720d08",
+		"_postman_id": "b0d4d0d6-5cf3-424b-8546-59fd8c8271b7",
 		"name": "Symphony REST APIs",
 		"description": "[Full documentation on the developer's website](https://developers.symphony.com/restapi/reference)",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -13844,6 +13844,63 @@
 									]
 								},
 								"description": "A datafeed provides the messages in all conversations that a user is in.\nThis also includes system messages like new users joining a chatroom.\n\nA datafeed will expire if it isn't read before its capacity is reached.\n"
+							},
+							"response": []
+						},
+						{
+							"name": "Read Events",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"var jsonData = JSON.parse(responseBody);",
+											"pm.collectionVariables.set(\"ackId\", jsonData.ackId);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+                                "header": [
+                                  {
+                                    "key": "sessionToken",
+                                    "value": "{{sessionToken}}",
+                                    "description": "Session authentication token."
+                                  },
+                                  {
+                                    "key": "keyManagerToken",
+                                    "value": "{{keyManToken}}",
+                                    "description": "Key Manager authentication token."
+                                  },
+                                  {
+                                    "key": "Accept",
+                                    "value": "application/json"
+                                  }
+                                ],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"type\": \"datahose\",\n    \"tag\": \"{{botName}}\",\n    \"eventTypes\": [\"MESSAGESENT\", \"ROOMUPDATED\"],\n    \"ackId\": \"{{ackId}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "https://{{agentUrl}}/agent/v5/events/read",
+									"protocol": "https",
+									"host": [
+										"{{agentUrl}}"
+									],
+									"path": [
+										"agent",
+										"v5",
+										"events",
+										"read"
+									]
+								}
 							},
 							"response": []
 						}


### PR DESCRIPTION
The `/v5/events/read` endpoint (used mostly for datahose feeds) is updated to support the Real-time events as filters (MESSAGE SENT, ROOMCREATED, ROOMUPDATED, etc.) as defined in https://docs.developers.symphony.com/building-bots-on-symphony/datafeed/real-time-events.
Added Postman example for this endpoint