### PR TITLE
Migrating agent APIs to OpenApi 3

### DIFF
--- a/agent/agent-api-public-deprecated.yaml
+++ b/agent/agent-api-public-deprecated.yaml
@@ -1,6 +1,5 @@
-swagger: '2.0'
+openapi: 3.0.1
 info:
-  version: '22.7.1'
   title: Agent API
   description: |
     This document refers to Symphony API calls to send and receive messages
@@ -10,9 +9,6 @@ info:
     - sessionToken and keyManagerToken can be obtained by calling the
     authenticationAPI on the symphony back end and the key manager
     respectively. Refer to the methods described in authenticatorAPI.yaml.
-    - A new authorizationToken has been introduced in the authenticationAPI
-    response payload. It can be used to replace the sessionToken in any of
-    the API calls and can be passed as "Authorization" header.
     - Actions are defined to be atomic, ie will succeed in their entirety
     or fail and have changed nothing.
     - If it returns a 40X status then it will have sent no message to any
@@ -28,29 +24,31 @@ info:
     To know more about the endpoints, refer to Create Messages/Events
     Stream and Read Messages/Events Stream. Unless otherwise specified,
     all events were added in 1.46.
-
+  version: '22.9.1'
+servers:
+  - url: /
 paths:
-  '/v3/health':
+  /v3/health:
     get:
+      tags:
+        - System
       summary: Checks health status
       description: |
         _Available on Agent 2.57.0 and above._
 
         Returns the connectivity status of your Agent server. If your Agent server is started and running, the status value will be `UP`
       operationId: v3Health
-      consumes:
-        - application/json
-      produces:
-        - application/json
+      responses:
+        200:
+          description: Agent application is alive.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3Health'
+  /v3/health/extended:
+    get:
       tags:
         - System
-      responses:
-        '200':
-          description: Agent application is alive.
-          schema:
-            $ref: '#/definitions/V3Health'
-  '/v3/health/extended':
-    get:
       summary: Checks health status of services and users
       description: |
         _Available on Agent 2.57.0 and above._
@@ -60,23 +58,23 @@ paths:
 
         The global status will be set to `DOWN` if at least one of the sub-status is also `DOWN`.
       operationId: v3ExtendedHealth
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      tags:
-        - System
       responses:
-        '200':
+        200:
           description: Agent is healthy, all components are `UP`.
-          schema:
-            $ref: '#/definitions/V3Health'
-        '503':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3Health'
+        503:
           description: Agent is unhealthy, some components are `DOWN`.
-          schema:
-            $ref: '#/definitions/V3Health'
-  '/v4/message/import':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3Health'
+  /v4/message/import:
     post:
+      tags:
+        - Messages
       summary: Import messages from other systems into Symphony.
       description: |
         Sends a message to be imported into the system.
@@ -85,51 +83,61 @@ paths:
         The user that the message is intended to have come from must also be present in the conversation.
         The intended message timestamp must be a valid time from the past. It cannot be a future timestamp.
         Optionally the original message ID can be specified to identify the imported message for the purpose of repeat imports.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: messageList
-          in: body
           required: true
           schema:
-            $ref: '#/definitions/V4MessageImportList'
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V4MessageImportList'
+        required: true
+      responses:
+        200:
+          description: Message sent.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V4ImportResponseList'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+      x-codegen-request-body-name: messageList
+  /v4/message/blast:
+    post:
       tags:
         - Messages
-      responses:
-        '200':
-          description: Message sent.
-          schema:
-            $ref: '#/definitions/V4ImportResponseList'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v4/message/blast':
-    post:
       summary: Post a message to multiple existing streams.
       description: |
         Post a new message to the given list of streams. The stream can be a chatroom,
@@ -153,422 +161,483 @@ paths:
 
         Regarding authentication, you must either use the sessionToken which was created for delegated app access
         or both the sessionToken and keyManagerToken together.
-      consumes:
-        - multipart/form-data
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Authorization token used to make delegated calls.
-          in: header
           required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          type: string
-          required: false
-        - name: sids
-          description: A comma-separated list of Stream IDs
-          in: formData
-          required: true
-          type: array
-          items:
+          schema:
             type: string
-        - name: message
-          description: The message payload in MessageML.
-          in: formData
-          type: string
-          required: false
-        - name: data
-          description: Optional message data in EntityJSON.
-          in: formData
-          type: string
-          required: false
-        - name: version
-          description: |
-            Optional message version in the format "major.minor". If empty, defaults to the latest supported version.
-          in: formData
-          type: string
-          required: false
-        - name: attachment
-          description: Optional file attachment.
-          in: formData
-          type: file
-          required: false
-        - name: preview
-          description: Optional attachment preview.
-          in: formData
-          type: file
-          required: false
-      tags:
-        - Messages
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          schema:
+            type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              required:
+                - sids
+              properties:
+                sids:
+                  type: array
+                  description: A comma-separated list of Stream IDs
+                  items:
+                    type: string
+                message:
+                  type: string
+                  description: The message payload in MessageML.
+                data:
+                  type: string
+                  description: Optional message data in EntityJSON.
+                version:
+                  type: string
+                  description: |
+                    Optional message version in the format "major.minor". If empty, defaults to the latest supported version.
+                attachment:
+                  type: string
+                  description: Optional file attachment.
+                  format: binary
+                preview:
+                  type: string
+                  description: Optional attachment preview.
+                  format: binary
       responses:
-        '200':
+        200:
           description: Blast message sent.
-          schema:
-            $ref: '#/definitions/V4MessageBlastResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V4MessageBlastResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '451':
-          description: 'Compliance Issues found in message or file'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/message/{id}':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        451:
+          description: Compliance Issues found in message or file
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+  /v1/message/{id}:
     get:
+      tags:
+        - Messages
       summary: Get a message by ID
-      produces:
-        - application/json
       parameters:
-          - name: sessionToken
-            description: Session authentication token.
-            in: header
-            required: true
-            type: string
-          - name: keyManagerToken
-            description: Key Manager authentication token.
-            in: header
-            required: true
-            type: string
-          - name: id
-            description: Message ID as a URL-safe string
-            in: path
-            required: true
-            type: string
-      tags:
-        - Messages
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/V4Message'
-        '204':
-          description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/message/search':
-    get:
-      summary: Search messages
-      description: |
-          Search messages according to the specified criteria. The "query" parameter takes a search query defined as
-          "field:value" pairs combined by the operator "AND" (e.g. "text:foo AND autor:bar"). Supported fields are
-           (case-insensitive): "text", "author", "hashtag", "cashtag", "mention", "signal", "fromDate", "toDate",
-           "streamId", "streamType".
-           "text" search requires a "streamId" to be specified.
-           "streamType" accepts one of the following values: "chat" (IMs and MIMs), "im", "mim", "chatroom", "post".
-           "signal" queries can only be combined with "fromDate", "toDate", "skip" and "limit" parameters.
-      produces:
-        - application/json
-      parameters:
-        - name: query
-          description: The search query. See above for the query syntax.
-          in: query
-          type: string
-          required: true
-        - name: skip
-          description: |
-            No. of results to skip.
-          in: query
-          type: integer
-        - name: limit
-          description: |
-            Max no. of results to return. If no value is provided, 50 is the default.
-          in: query
-          type: integer
-          required: false
-        - name: scope
-          description: |
-            Describes where content should be searched for that query.
-            It can exclusively apply to Symphony content or to one Connector.
-          in: query
-          type: string
-        - name: sortDir
-          description: |
-            Messages sort direction : ASC or DESC (default to DESC)
-          in: query
-          type: string
-          required: false
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
+          in: header
           description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-      tags:
-        - Messages
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/V4MessageList'
-        '204':
-          description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-    post:
-      summary: Search messages
-      description: |
-          Search messages according to the specified criteria.
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - name: query
-          description: The search query. See above for the query syntax.
-          in: body
           required: true
           schema:
-            $ref: '#/definitions/MessageSearchQuery'
-        - name: skip
-          description: |
-            No. of results to skip.
-          in: query
-          type: integer
-        - name: limit
-          description: |
-            Max no. of results to return. If no value is provided, 50 is the default.
-          in: query
-          type: integer
-          required: false
-        - name: scope
-          description: |
-            Describes where content should be searched for that query.
-            It can exclusively apply to Symphony content or to one Connector.
-          in: query
-          type: string
-        - name: sortDir
-          description: |
-            Messages sort direction : ASC or DESC (default to DESC)
-          in: query
-          type: string
-          required: false
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-      tags:
-        - Messages
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/V4MessageList'
-        '204':
-          description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/stream/{sid}/attachment':
-    get:
-      summary: Download an attachment.
-      description: |
-        Downloads the attachment body by the attachment ID, stream ID, and message ID.
-      consumes:
-        - application/json
-      produces:
-        - application/octet-stream
-      parameters:
-        - name: sid
-          description: Stream ID
+            type: string
+        - name: id
           in: path
+          description: Message ID as a URL-safe string
           required: true
-          type: string
-        - name: fileId
-          description: The attachment ID (Base64-encoded)
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V4Message'
+        204:
+          description: No Messages.
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+  /v1/message/search:
+    get:
+      tags:
+        - Messages
+      summary: Search messages
+      description: |
+        Search messages according to the specified criteria. The "query" parameter takes a search query defined as
+        "field:value" pairs combined by the operator "AND" (e.g. "text:foo AND autor:bar"). Supported fields are
+         (case-insensitive): "text", "author", "hashtag", "cashtag", "mention", "signal", "fromDate", "toDate",
+         "streamId", "streamType".
+         "text" search requires a "streamId" to be specified.
+         "streamType" accepts one of the following values: "chat" (IMs and MIMs), "im", "mim", "chatroom", "post".
+         "signal" queries can only be combined with "fromDate", "toDate", "skip" and "limit" parameters.
+      parameters:
+        - name: query
           in: query
+          description: The search query. See above for the query syntax.
           required: true
-          type: string
-        - name: messageId
-          description: The ID of the message containing the attachment
+          schema:
+            type: string
+        - name: skip
           in: query
-          required: true
-          type: string
+          description: No. of results to skip.
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: Max no. of results to return. If no value is provided, 50 is the default.
+          schema:
+            type: integer
+        - name: scope
+          in: query
+          description: |
+            Describes where content should be searched for that query.
+            It can exclusively apply to Symphony content or to one Connector.
+          schema:
+            type: string
+        - name: sortDir
+          in: query
+          description: |
+            Messages sort direction : ASC or DESC (default to DESC)
+          schema:
+            type: string
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V4MessageList'
+        204:
+          description: No Messages.
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+    post:
+      tags:
+        - Messages
+      summary: Search messages
+      description: Search messages according to the specified criteria.
+      parameters:
+        - name: skip
+          in: query
+          description: No. of results to skip.
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: Max no. of results to return. If no value is provided, 50 is the default.
+          schema:
+            type: integer
+        - name: scope
+          in: query
+          description: |
+            Describes where content should be searched for that query.
+            It can exclusively apply to Symphony content or to one Connector.
+          schema:
+            type: string
+        - name: sortDir
+          in: query
+          description: |
+            Messages sort direction : ASC or DESC (default to DESC)
+          schema:
+            type: string
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: The search query. See above for the query syntax.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MessageSearchQuery'
+        required: true
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V4MessageList'
+        204:
+          description: No Messages.
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+      x-codegen-request-body-name: query
+  /v1/stream/{sid}/attachment:
+    get:
       tags:
         - Attachments
-      responses:
-        '200':
-          description: 'Attachment body as Base64 encoded string.'
-          schema:
-            type: string
-            format: byte
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v4/stream/{sid}/message':
-    get:
-      summary: Get messages from an existing stream.
-      description: |
-          A caller can fetch all unseen messages by passing the timestamp of
-          the last message seen as the since parameter and the number of messages
-          with the same timestamp value already seen as the skip parameter. This
-          means that every message will be seen exactly once even in the case that
-          an additional message is processed with the same timestamp as the last
-          message returned by the previous call, and the case where there are
-          more than maxMessages with the same timestamp value.
-
-          This method is intended for historic queries and is generally reliable
-          but if guaranteed delivery of every message in real time is required
-          then the equivilent firehose method should be called.
-      produces:
-        - application/json
+      summary: Download an attachment.
+      description: Downloads the attachment body by the attachment ID, stream ID, and message ID.
       parameters:
         - name: sid
-          description: |
-            Stream ID
           in: path
+          description: Stream ID
           required: true
-          type: string
-        - name: since
-          description: |
-            Timestamp of first required message.
-
-            This is a long integer value representing milliseconds since
-            Jan 1 1970
+          schema:
+            type: string
+        - name: fileId
           in: query
+          description: The attachment ID (Base64-encoded)
           required: true
-          type: integer
-          format: int64
-        - name: skip
-          description: |
-            No. of messages to skip.
+          schema:
+            type: string
+        - name: messageId
           in: query
-          type: integer
-        - name: limit
-          description: |
-            Max No. of messages to return. If no value is provided, 50 is the default. The maximum supported value is 500.
-          in: query
-          type: integer
-          required: false
+          description: The ID of the message containing the attachment
+          required: true
+          schema:
+            type: string
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
+      responses:
+        200:
+          description: Attachment body as Base64 encoded string.
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: byte
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v4/stream/{sid}/message:
+    get:
       tags:
         - Messages
+      summary: Get messages from an existing stream.
+      description: |
+        A caller can fetch all unseen messages by passing the timestamp of
+        the last message seen as the since parameter and the number of messages
+        with the same timestamp value already seen as the skip parameter. This
+        means that every message will be seen exactly once even in the case that
+        an additional message is processed with the same timestamp as the last
+        message returned by the previous call, and the case where there are
+        more than maxMessages with the same timestamp value.
+
+        This method is intended for historic queries and is generally reliable
+        but if guaranteed delivery of every message in real time is required
+        then the equivilent firehose method should be called.
+      parameters:
+        - name: sid
+          in: path
+          description: Stream ID
+          required: true
+          schema:
+            type: string
+        - name: since
+          in: query
+          description: |
+            Timestamp of first required message.
+            
+            This is a long integer value representing milliseconds since
+            Jan 1 1970
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: skip
+          in: query
+          description: No. of messages to skip.
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: |
+            Max No. of messages to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          schema:
+            type: integer
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
       responses:
-        '200':
+        200:
           description: OK
-          schema:
-            $ref: '#/definitions/V4MessageList'
-        '204':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V4MessageList'
+        204:
           description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v4/stream/{sid}/message/create':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+  /v4/stream/{sid}/message/create:
     post:
+      tags:
+        - Messages
       summary: Post a message to one existing stream.
       description: |
-        Post a new message to the given stream. The stream can be a chatroom,
-        an IM or a multiparty IM.
+        Post a new message to the given stream. The stream can be a chatroom,,an IM or a multiparty IM.
 
         You may include an attachment on the message.
 
@@ -578,90 +647,94 @@ paths:
         If the message contains explicit references to entity data (in "data-entity-id" element attributes),
         this parameter is required.
 
-        If the message is in MessageML and fails schema validation
-        a client error results
+        If the message is in MessageML and fails schema validation a client error will be returned.
 
         If the message is sent then 200 is returned.
 
         Regarding authentication, you must either use the sessionToken which was created for delegated app access
         or both the sessionToken and keyManagerToken together.
-      consumes:
-        - multipart/form-data
-      produces:
-        - application/json
       parameters:
         - name: sid
-          description: Stream ID
           in: path
+          description: Stream ID
           required: true
-          type: string
+          schema:
+            type: string
         - name: sessionToken
+          in: header
           description: Authorization token used to make delegated calls.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
-          type: string
-          required: false
-        - name: message
-          description: The message payload in MessageML.
-          in: formData
-          type: string
-          required: false
-        - name: data
-          description: Optional message data in EntityJSON.
-          in: formData
-          type: string
-          required: false
-        - name: version
-          description: |
-            Optional message version in the format "major.minor". If empty, defaults to the latest supported version.
-          in: formData
-          type: string
-          required: false
-        - name: attachment
-          description: Optional file attachment.
-          in: formData
-          type: file
-          required: false
-        - name: preview
-          description: Optional attachment preview.
-          in: formData
-          type: file
-          required: false
-
+          description: Key Manager authentication token.
+          schema:
+            type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                message:
+                  type: string
+                  description: The message payload in MessageML.
+                data:
+                  type: string
+                  description: Optional message data in EntityJSON.
+                version:
+                  type: string
+                  description: |
+                    Optional message version in the format "major.minor". If empty, defaults to the latest supported version.
+                attachment:
+                  type: string
+                  description: Optional file attachment.
+                  format: binary
+                preview:
+                  type: string
+                  description: Optional attachment preview.
+                  format: binary
+      responses:
+        200:
+          description: Message sent.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V4Message'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        451:
+          description: Compliance Issues found in message or file
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+  /v4/stream/{sid}/message/{mid}/update:
+    post:
       tags:
         - Messages
-      responses:
-        '200':
-          description: Message sent.
-          schema:
-            $ref: '#/definitions/V4Message'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '451':
-          description: 'Compliance Issues found in message or file'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-
-  '/v4/stream/{sid}/message/{mid}/update':
-    post:
       summary: Update an existing message.
       description: |
         Update an existing message. The existing message must be a valid social message, that has not been deleted.
@@ -679,692 +752,810 @@ paths:
 
         Regarding authentication, you must either use the sessionToken which was created for delegated app access
         or both the sessionToken and keyManagerToken together.
-      consumes:
-        - multipart/form-data
-      produces:
-        - application/json
       parameters:
         - name: sid
+          in: path
           description: Stream ID
-          in: path
           required: true
-          type: string
+          schema:
+            type: string
         - name: mid
-          description: Parent message ID
           in: path
+          description: Parent message ID
           required: true
-          type: string
+          schema:
+            type: string
         - name: sessionToken
+          in: header
           description: Authorization token used to make delegated calls.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
-          type: string
-          required: false
-        - name: message
-          description: The message payload in MessageML.
-          in: formData
-          type: string
-          required: false
-        - name: data
-          description: Optional message data in EntityJSON.
-          in: formData
-          type: string
-          required: false
-        - name: version
-          description: |
-            Optional message version in the format "major.minor". If empty, defaults to the latest supported version.
-          in: formData
-          type: string
-          required: false
-        - name: silent
-          in: formData
-          type: string
-          required: false
-          description: |
-            Optional boolean field that will determine if the user/s should receive the message as read or not (true by default). Since Agent 20.14.
-          x-since: 20.14
-      tags:
-        - Messages
+          description: Key Manager authentication token.
+          schema:
+            type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                message:
+                  type: string
+                  description: The message payload in MessageML.
+                data:
+                  type: string
+                  description: Optional message data in EntityJSON.
+                version:
+                  type: string
+                  description: |
+                    Optional message version in the format "major.minor". If empty, defaults to the latest supported version.
+                silent:
+                  type: string
+                  description: |
+                    Optional boolean field that will determine if the user/s should receive the message as read or not (true by default)
       responses:
-        '200':
+        200:
           description: Message sent.
-          schema:
-            $ref: '#/definitions/V4Message'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V4Message'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '451':
-          description: 'Compliance Issues found in message or file'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-
-  '/v3/stream/{sid}/share':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        451:
+          description: Compliance Issues found in message or file
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+  /v3/stream/{sid}/share:
     post:
+      tags:
+        - Share
       summary: PROVISIONAL -  Share a piece of content into Symphony
       description: |
         Given a 3rd party content (eg. news article), it can share to the given stream.
         The stream can be a chatroom, an IM or a multiparty IM.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sid
-          description: Stream ID
           in: path
-          required: true
-          type: string
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: false
-          type: string
-        - name: shareContent
-          in: body
+          description: Stream ID
           required: true
           schema:
-            $ref: '#/definitions/ShareContent'
-      tags:
-        - Share
+            type: string
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ShareContent'
+        required: true
       responses:
-        '200':
+        200:
           description: Success
-          schema:
-            $ref: '#/definitions/V2Message'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Message'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/util/echo':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      x-codegen-request-body-name: shareContent
+  /v1/util/echo:
     post:
-      summary: Test endpoint, returns input.
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: echoInput
-          description: Message in plain text
-          in: body
-          required: true
-          schema:
-            $ref: '#/definitions/SimpleMessage'
       tags:
         - Util
-      responses:
-        '200':
-          description: Message sent.
-          schema:
-            $ref: '#/definitions/SimpleMessage'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/signals/list':
-    get:
-      summary: |
-          List signals for the requesting user. This includes signals that the user has created and public signals
-          to which they subscribed.
-      consumes:
-        - application/json
-      produces:
-        - application/json
+      summary: Test endpoint, returns input.
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
-          required: false
-          type: string
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Message in plain text
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SimpleMessage'
+        required: true
+      responses:
+        200:
+          description: Message sent.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleMessage'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      x-codegen-request-body-name: echoInput
+  /v1/signals/list:
+    get:
+      tags:
+        - Signals
+      summary: |
+        List signals for the requesting user. This includes signals that the user has created and public signals
+        to which they subscribed.
+      parameters:
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          schema:
+            type: string
         - name: skip
-          description: |
-            No. of signals to skip.
           in: query
-          type: integer
+          description: No. of signals to skip.
+          schema:
+            type: integer
         - name: limit
+          in: query
           description: |
             Max no. of signals to return. If no value is provided, 50 is the default. The maximum supported value is 500.
-          in: query
-          type: integer
-          required: false
+          schema:
+            type: integer
+      responses:
+        200:
+          description: List of signals for the requesting user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SignalList'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+  /v1/signals/{id}/get:
+    get:
       tags:
         - Signals
-      responses:
-        '200':
-          description: List of signals for the requesting user.
-          schema:
-            $ref: '#/definitions/SignalList'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/signals/{id}/get':
-    get:
       summary: Get details of the requested signal.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
-          required: false
-          type: string
+          description: Key Manager authentication token.
+          schema:
+            type: string
         - name: id
-          description: |
-            The ID of the signal to display.
           in: path
+          description: The ID of the signal to display.
           required: true
-          type: string
-      tags:
-        - Signals
+          schema:
+            type: string
       responses:
-        '200':
+        200:
           description: List of signals for the requesting user.
-          schema:
-            $ref: '#/definitions/Signal'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Signal'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/signals/create':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+  /v1/signals/create:
     post:
+      tags:
+        - Signals
       summary: Create a signal.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: false
-          type: string
-        - name: signal
-          description: Signal definition.
-          in: body
           required: true
           schema:
-            $ref: '#/definitions/BaseSignal'
-      tags:
-        - Signals
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          schema:
+            type: string
+      requestBody:
+        description: Signal definition.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BaseSignal'
+        required: true
       responses:
-        '200':
+        200:
           description: Signal created.
-          schema:
-            $ref: '#/definitions/Signal'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Signal'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '451':
-          description: 'Compliance Issues found in signal'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/signals/{id}/update':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        451:
+          description: Compliance Issues found in signal
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+      x-codegen-request-body-name: signal
+  /v1/signals/{id}/update:
     post:
+      tags:
+        - Signals
       summary: Update a signal.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: false
-          type: string
-        - name: id
-          description: The id of the signal.
-          in: path
-          required: true
-          type: string
-        - name: signal
-          description: Signal definition.
-          in: body
           required: true
           schema:
-            $ref: '#/definitions/BaseSignal'
-      tags:
-        - Signals
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          schema:
+            type: string
+        - name: id
+          in: path
+          description: The id of the signal.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Signal definition.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BaseSignal'
+        required: true
       responses:
-        '200':
+        200:
           description: Signal updated.
-          schema:
-            $ref: '#/definitions/Signal'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Signal'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '451':
-          description: 'Compliance Issues found in signal'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/signals/{id}/delete':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        451:
+          description: Compliance Issues found in signal
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+      x-codegen-request-body-name: signal
+  /v1/signals/{id}/delete:
     post:
+      tags:
+        - Signals
       summary: Delete a signal.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
-          required: false
-          type: string
+          description: Key Manager authentication token.
+          schema:
+            type: string
         - name: id
-          description: The id of the signal.
           in: path
+          description: The id of the signal.
           required: true
-          type: string
-      tags:
-        - Signals
+          schema:
+            type: string
       responses:
-        '200':
+        200:
           description: Signal deleted.
-          schema:
-            $ref: '#/definitions/SuccessResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/signals/{id}/subscribe':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+  /v1/signals/{id}/subscribe:
     post:
+      tags:
+        - Signals
       summary: Subscribe to a Signal.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
-          required: false
-          type: string
+          description: Key Manager authentication token.
+          schema:
+            type: string
         - name: id
-          description: The id of the signal.
           in: path
+          description: The id of the signal.
           required: true
-          type: string
+          schema:
+            type: string
         - name: pushed
+          in: query
           description: Prevent the user to unsubscribe (only for bulk subscription)
-          in: query
-          required: false
-          type: boolean
-        - name: users
-          description: UserIds to subscribe (only for bulk subscription)
-          in: body
-          required: false
           schema:
-            type: array
-            items:
-              type: integer
-              format: int64
-      tags:
-        - Signals
+            type: boolean
+      requestBody:
+        description: UserIds to subscribe (only for bulk subscription)
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: integer
+                format: int64
+        required: false
       responses:
-        '200':
+        200:
           description: Signal subscribed.
-          schema:
-            $ref: '#/definitions/ChannelSubscriptionResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChannelSubscriptionResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/signals/{id}/unsubscribe':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+      x-codegen-request-body-name: users
+  /v1/signals/{id}/unsubscribe:
     post:
+      tags:
+        - Signals
       summary: Unsubscribe to a Signal.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: false
-          type: string
-        - name: id
-          description: The id of the signal.
-          in: path
-          required: true
-          type: string
-        - name: users
-          description: UserIds to unsubscribe (only for bulk unsubscription)
-          in: body
-          required: false
           schema:
-            type: array
-            items:
-              type: integer
-              format: int64
-      tags:
-        - Signals
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          schema:
+            type: string
+        - name: id
+          in: path
+          description: The id of the signal.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: UserIds to unsubscribe (only for bulk unsubscription)
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: integer
+                format: int64
+        required: false
       responses:
-        '200':
+        200:
           description: Signal unsubscribed.
-          schema:
-            $ref: '#/definitions/ChannelSubscriptionResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChannelSubscriptionResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/signals/{id}/subscribers':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+      x-codegen-request-body-name: users
+  /v1/signals/{id}/subscribers:
     get:
+      tags:
+        - Signals
       summary: Get the subscribers of a signal
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
-          required: false
-          type: string
+          description: Key Manager authentication token.
+          schema:
+            type: string
         - name: id
-          description: The id of the signal.
           in: path
+          description: The id of the signal.
           required: true
-          type: string
+          schema:
+            type: string
         - name: skip
+          in: query
           description: No. of results to skip.
-          in: query
-          required: false
-          type: integer
-          default: 0
+          schema:
+            type: integer
+            default: 0
         - name: limit
-          description: Max No. of subscribers to return. If no value is provided, 100 is the default.
           in: query
-          required: false
-          type: integer
-          default: 100
-      tags:
-        - Signals
+          description: Max No. of subscribers to return. If no value is provided, 100
+            is the default.
+          schema:
+            type: integer
+            default: 100
       responses:
-        '200':
+        200:
           description: Signal Subscribers.
-          schema:
-            $ref: '#/definitions/ChannelSubscriberResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChannelSubscriberResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/info':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+  /v1/info:
     get:
-      summary: Get information about the Agent
-      consumes:
-        - application/json
-      produces:
-        - application/json
       tags:
         - Signals
+      summary: Get information about the Agent
       responses:
-        '200':
+        200:
           description: Agent info.
-          schema:
-            $ref: '#/definitions/AgentInfo'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentInfo'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/dlp/policies':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+  /v1/dlp/policies:
     get:
+      tags:
+        - DLP Policies and Dictionary Management
       summary: Get all policies
       description: Get all policies
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: page
           in: query
-          required: false
-          type: integer
-          format: int32
           description: Optional parameter to specify which page to return (default is 0)
+          schema:
+            type: integer
+            format: int32
         - name: limit
           in: query
-          required: false
-          type: integer
-          format: int32
           description: |
             Optional parameter to specify the number of result to return per page, default is 50. Maximum is 50.
+          schema:
+            type: integer
+            format: int32
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPPoliciesCollectionResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V1DLPPoliciesCollectionResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-    post:
       summary: Creates a policy
       description: |
         Creates a new policy with dictionary references.
@@ -1372,1513 +1563,1832 @@ paths:
         At the time of policy creation, the caller should only provide - contentTypes, name, scopes and type. The rest of the information is populated automatically.
 
         Note - You need to enable the policy after creation to start enforcing the policy.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: body
-          in: body
           required: true
           schema:
-            $ref: '#/definitions/V1DLPPolicyRequest'
-          description: Details about the policy that should be created.
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Details about the policy that should be created.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V1DLPPolicyRequest'
+        required: true
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      x-codegen-request-body-name: body
+  /v1/dlp/policies/{policyId}:
+    get:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V1DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/dlp/policies/{policyId}':
-    get:
       summary: Get a policy
       description: Get a policy
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: policyId
           in: path
-          required: true
-          type: string
           description: Unique dictionary identifier.
+          required: true
+          schema:
+            type: string
         - name: policyVersion
           in: query
-          required: false
-          type: string
           description: |
-            Optional parameter, if set to be valid policy version number,  will return policy with specified policyVersion. Otherwise, return the latest policy.
+            Optional parameter, if set to be valid policy version number,  will return policy with specified policyVersion. 
+            Otherwise, return the latest policy.
+          schema:
+            type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    put:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V1DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-    put:
       summary: Updates a policy. Cannot be used for creation.
       description: |
         Update the policy (name, type, contentTypes, scopes) and also the dictionaries for a policy.
         Warning: If you send empty list of dictionaries during the update operation, then all the
         dictionaries for this policy are deleted and policy is automatically disabled.
         Note: The policy should already exist.
-      consumes:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: policyId
           in: path
-          required: true
-          type: string
           description: Unique dictionary identifier.
-        - name: body
-          in: body
           required: true
           schema:
-            $ref: '#/definitions/V1DLPPolicyRequest'
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V1DLPPolicyRequest'
+        required: true
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      x-codegen-request-body-name: body
+    delete:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V1DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-    delete:
       summary: Delete a policy
       description: |
         Delete a policy.
         Note: Only disabled policy can be deleted
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: policyId
           in: path
-          required: true
-          type: string
           description: Unique dictionary identifier.
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/dlp/policies/{policyId}/enable:
+    post:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V1DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/dlp/policies/{policyId}/enable':
-    post:
       summary: Enables a policy.
       description: Enables a policy.
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: policyId
           in: path
           required: true
-          type: string
+          schema:
+            type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/dlp/policies/{policyId}/disable:
+    post:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V1DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/dlp/policies/{policyId}/disable':
-    post:
       summary: Disables a policy.
       description: Disables a policy.
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: policyId
           in: path
           required: true
-          type: string
+          schema:
+            type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/dlp/dictionaries:
+    get:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V1DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/dlp/dictionaries':
-    get:
       summary: Get all dictionary metadatas
       description: |
         Get all dictionary metadatas with the latest version. Each dictionary object will only contain meta data of the content.
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: page
           in: query
-          required: false
-          type: integer
-          format: int32
           description: Optional parameter to specify which page to return (default is 0)
+          schema:
+            type: integer
+            format: int32
         - name: limit
           in: query
-          required: false
-          type: integer
-          format: int32
           description: |
             Optional parameter to specify the number of result to return per page, default is 50. Maximum is 50.
+          schema:
+            type: integer
+            format: int32
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPDictionaryMetadataCollectionResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V1DLPDictionaryMetadataCollectionResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-    post:
       summary: Create a dictionary
       description: |
         Creates a dictionary with basic metadata and no content. Only "name" and "type" field is used to create a new dictionary entry.
-      consumes:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: body
-          in: body
           required: true
           schema:
-            $ref: '#/definitions/V1DLPDictionaryMetadataCreateRequest'
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V1DLPDictionaryMetadataCreateRequest'
+        required: true
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPDictionaryMetadataResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      x-codegen-request-body-name: body
+  /v1/dlp/dictionaries/{dictId}:
+    get:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V1DLPDictionaryMetadataResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/dlp/dictionaries/{dictId}':
-    get:
       summary: Get dictionary metadata
       description: Get basic information for a dictionary.
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: dictId
           in: path
-          required: true
-          type: string
           description: Unique dictionary identifier
+          required: true
+          schema:
+            type: string
         - name: dictVersion
           in: query
-          required: false
-          type: string
           description: |
-            If set to be valid dictionary version number, will return dictionary metadata with specified version. Otherwise, return the latest dictionary metadata.
+            If set to be valid dictionary version number, will return dictionary metadata with specified version. 
+            Otherwise, return the latest dictionary metadata.
+          schema:
+            type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPDictionaryMetadataResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    put:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V1DLPDictionaryMetadataResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-    put:
       summary: Updates a dictionary
       description: |
         Updates the dictionary's basic metadata without content.
         This API cannot be used for creating a new dictionary.
         In case of update only "name" can be changed.
         Note: All related policies will also have versions updated.
-      consumes:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: dictId
           in: path
-          required: true
-          type: string
           description: Unique dictionary identifier
-        - name: body
-          in: body
           required: true
           schema:
-            $ref: '#/definitions/V1DLPDictionaryMetadataUpdateRequest'
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V1DLPDictionaryMetadataUpdateRequest'
+        required: true
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPDictionaryMetadataResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      x-codegen-request-body-name: body
+    delete:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V1DLPDictionaryMetadataResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-    delete:
       summary: Delete a dictionary
       description: |
         Deletes a dictionary.
         Note: All related policies will be affected.
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: dictId
-          in: path
-          required: true
-          type: string
-          description: Unique dictionary identifier
-      tags:
-        - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            # Deleted dictionary's metadata.
-            $ref: '#/definitions/V1DLPDictionaryMetadataResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/dlp/dictionaries/{dictId}/data/download':
-    get:
-      summary: Downloads Base 64 encoded dictionary content.
-      description: Downloads Base 64 encoded dictionary content.
-      consumes:
-        - application/json
-      produces:
-        - application/octet-stream
-      parameters:
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: dictId
-          in: path
-          required: true
-          type: string
-          description: Unique dictionary identifier
-        - name: dictVersion
-          in: query
-          required: false
-          type: string
-          description: |
-            If set to be valid dictionary version number, will return dictionary with specified version. Otherwise, return the latest dictionary.
-      tags:
-        - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: 'Attachment body as Base64 encoded string.'
           schema:
             type: string
-            format: byte
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/dlp/dictionaries/{dictId}/data/upload':
-    post:
-      summary: Override dictionary content with provided content.
-      description: Override dictionary content with provided content.
-      consumes:
-        - multipart/form-data
-      parameters:
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: dictId
           in: path
-          required: true
-          type: string
           description: Unique dictionary identifier
-        - name: data
-          in: formData
           required: true
-          type: file
+          schema:
+            type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPDictionaryMetadataResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/dlp/dictionaries/{dictId}/data/download:
+    get:
       tags:
         - DLP Policies and Dictionary Management
+      summary: Downloads Base 64 encoded dictionary content.
+      description: Downloads Base 64 encoded dictionary content.
+      parameters:
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+        - name: dictId
+          in: path
+          description: Unique dictionary identifier
+          required: true
+          schema:
+            type: string
+        - name: dictVersion
+          in: query
+          description: |
+            If set to be valid dictionary version number, will return dictionary with specified version. 
+            Otherwise, return the latest dictionary.
+          schema:
+            type: string
       responses:
-        '200':
+        200:
+          description: Attachment body as Base64 encoded string.
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: byte
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/dlp/dictionaries/{dictId}/data/upload:
+    post:
+      tags:
+        - DLP Policies and Dictionary Management
+      summary: Override dictionary content with provided content.
+      description: Override dictionary content with provided content.
+      parameters:
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+        - name: dictId
+          in: path
+          description: Unique dictionary identifier
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              required:
+                - data
+              properties:
+                data:
+                  type: string
+                  format: binary
+        required: true
+      responses:
+        200:
           description: Success
-          schema:
-            $ref: '#/definitions/V1DLPDictionaryMetadataResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPDictionaryMetadataResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/dlp/violations/message':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/dlp/violations/message:
     get:
+      tags:
+        - Violations
       summary: Get violations as a result of policy enforcement on messages.
-      description: |
-        TBD
-      produces:
-        - application/json
       parameters:
         - name: startTime
+          in: query
           description: |
             Timestamp of the first required violation.
             This is a long integer value representing milliseconds since Jan 1 1970
-          in: query
           required: true
-          type: integer
-          format: int64
+          schema:
+            type: integer
+            format: int64
         - name: endTime
+          in: query
           description: |
             Timestamp of the last required violation.
             This is a long integer value representing milliseconds since Jan 1 1970
             If unspecified, it will default to current time of the request.
-          in: query
-          required: false
-          type: integer
-          format: int64
+          schema:
+            type: integer
+            format: int64
         - name: next
-          description: |
-            Offset of the next chunk of violations. Value is null for the first request.
           in: query
-          type: string
-          required: false
+          description: Offset of the next chunk of violations. Value is null for the first request.
+          schema:
+            type: string
         - name: limit
+          in: query
           description: |
             Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
-          in: query
-          type: integer
-          required: false
+          schema:
+            type: integer
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPViolationMessageResponse'
+        204:
+          description: No Messages.
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/dlp/violations/stream:
+    get:
       tags:
         - Violations
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/V1DLPViolationMessageResponse'
-        '204':
-          description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-
-  '/v1/dlp/violations/stream':
-    get:
       summary: Get violations as a result of policy enforcement on streams.
-      description: |
-        TBD
-      produces:
-        - application/json
       parameters:
         - name: startTime
+          in: query
           description: |
             Timestamp of the first required violation.
             This is a long integer value representing milliseconds since Jan 1 1970
-          in: query
           required: true
-          type: integer
-          format: int64
+          schema:
+            type: integer
+            format: int64
         - name: endTime
+          in: query
           description: |
             Timestamp of the last required violation.
             This is a long integer value representing milliseconds since Jan 1 1970
             If unspecified, it will default to current time of the request.
-          in: query
-          required: false
-          type: integer
-          format: int64
+          schema:
+            type: integer
+            format: int64
         - name: next
-          description: |
-            Offset of the next chunk of violations. Value is null for the first request.
           in: query
-          type: string
-          required: false
+          description: Offset of the next chunk of violations. Value is null for the first request.
+          schema:
+            type: string
         - name: limit
+          in: query
           description: |
             Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
-          in: query
-          type: integer
-          required: false
+          schema:
+            type: integer
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPViolationStreamResponse'
+        204:
+          description: No Messages.
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/dlp/violations/signal:
+    get:
       tags:
         - Violations
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/V1DLPViolationStreamResponse'
-        '204':
-          description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-
-  '/v1/dlp/violations/signal':
-    get:
       summary: Get violations as a result of policy enforcement on signals.
-      description: |
-        TBD
-      produces:
-        - application/json
       parameters:
         - name: startTime
+          in: query
           description: |
             Timestamp of the first required violation.
             This is a long integer value representing milliseconds since Jan 1 1970
-          in: query
           required: true
-          type: integer
-          format: int64
+          schema:
+            type: integer
+            format: int64
         - name: endTime
+          in: query
           description: |
             Timestamp of the last required violation.
             This is a long integer value representing milliseconds since Jan 1 1970
             If unspecified, it will default to current time of the request.
-          in: query
-          required: false
-          type: integer
-          format: int64
+          schema:
+            type: integer
+            format: int64
         - name: next
-          description: |
-            Offset of the next chunk of violations. Value is null for the first request.
           in: query
-          type: string
-          required: false
+          description: Offset of the next chunk of violations. Value is null for the first request.
+          schema:
+            type: string
         - name: limit
+          in: query
           description: |
             Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
-          in: query
-          type: integer
-          required: false
+          schema:
+            type: integer
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
-      tags:
-        - Violations
+          schema:
+            type: string
       responses:
-        '200':
+        200:
           description: OK
-          schema:
-            $ref: '#/definitions/V1DLPViolationSignalResponse'
-        '204':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPViolationSignalResponse'
+        204:
           description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-
-  '/v3/dlp/policies':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v3/dlp/policies:
     get:
+      tags:
+        - DLP Policies and Dictionary Management
       summary: Get all policies
       description: Get all policies
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: page
           in: query
-          required: false
-          type: integer
-          format: int32
           description: Optional parameter to specify which page to return (default is 0)
+          schema:
+            type: integer
+            format: int32
         - name: limit
           in: query
-          required: false
-          type: integer
-          format: int32
           description: |
             Optional parameter to specify the number of result to return per page, default is 50. Maximum is 50.
+          schema:
+            type: integer
+            format: int32
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3DLPPoliciesCollectionResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V3DLPPoliciesCollectionResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-    post:
       summary: Creates a policy
       description: |
         Creates a new policy with dictionary references.
         At the time of policy creation, the caller should only provide - contentTypes, name, scopes and type.
         The rest of the information is populated automatically.
         Note - You need to enable the policy after creation to start enforcing the policy.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: body
-          in: body
           required: true
           schema:
-            $ref: '#/definitions/V3DLPPolicyRequest'
-          description: Details about the policy that should be created.
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Details about the policy that should be created.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V3DLPPolicyRequest'
+        required: true
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      x-codegen-request-body-name: body
+  /v3/dlp/policies/{policyId}:
+    get:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V3DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v3/dlp/policies/{policyId}':
-    get:
       summary: Get a policy
       description: Get a policy
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: policyId
           in: path
-          required: true
-          type: string
           description: Unique dictionary identifier.
+          required: true
+          schema:
+            type: string
         - name: policyVersion
           in: query
-          required: false
-          type: string
           description: |
-            Optional parameter, if set to be valid policy version number,  will return policy with specified policyVersion. Otherwise, return the latest policy.
+            Optional parameter, if set to be valid policy version number,  will return policy with specified policyVersion. 
+            Otherwise, return the latest policy.
+          schema:
+            type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v3/dlp/policies/{policyId}/update:
+    post:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V3DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v3/dlp/policies/{policyId}/update':
-    post:
       summary: Updates a policy. Cannot be used for creation.
       description: |
         Update the policy (name, type, contentTypes, scopes) and also the dictionaries for a policy.
         Warning: If you send empty list of dictionaries during the update operation, then all the
         dictionaries for this policy are deleted and policy is automatically disabled.
         Note: The policy should already exist.
-      consumes:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: policyId
           in: path
-          required: true
-          type: string
           description: Unique dictionary identifier.
-        - name: body
-          in: body
           required: true
           schema:
-            $ref: '#/definitions/V3DLPPolicyRequest'
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V3DLPPolicyRequest'
+        required: true
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      x-codegen-request-body-name: body
+  /v3/dlp/policies/{policyId}/delete:
+    post:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V3DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v3/dlp/policies/{policyId}/delete':
-    post:
       summary: Delete a policy
       description: |
         Delete a policy.
         Note: Only disabled policy can be deleted
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: policyId
           in: path
-          required: true
-          type: string
           description: Unique dictionary identifier.
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v3/dlp/policies/{policyId}/enable:
+    post:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V3DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v3/dlp/policies/{policyId}/enable':
-    post:
       summary: Enables a policy.
       description: Enables a policy.
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: policyId
           in: path
           required: true
-          type: string
+          schema:
+            type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v3/dlp/policies/{policyId}/disable:
+    post:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V3DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v3/dlp/policies/{policyId}/disable':
-    post:
       summary: Disables a policy.
       description: Disables a policy.
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: policyId
           in: path
           required: true
-          type: string
-      tags:
-        - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V3DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v3/dlp/violations/message':
-    get:
-      summary: Get violations as a result of policy enforcement on messages.
-      description: Retrieves DLP v3 message related violations for a given time range
-      produces:
-        - application/json
-      parameters:
-        - name: startTime
-          description: |
-            Timestamp of the first required violation.
-            This is a long integer value representing milliseconds since Jan 1 1970
-          in: query
-          required: true
-          type: integer
-          format: int64
-        - name: endTime
-          description: |
-            Timestamp of the last required violation.
-            This is a long integer value representing milliseconds since Jan 1 1970
-            If unspecified, it will default to current time of the request.
-          in: query
-          required: false
-          type: integer
-          format: int64
-        - name: next
-          description: |
-            Offset of the next chunk of violations. Value is null for the first request.
-          in: query
-          type: string
-          required: false
-        - name: limit
-          description: |
-            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
-          in: query
-          type: integer
-          required: false
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-      tags:
-        - Violations
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/V3DLPViolationMessageResponse'
-        '204':
-          description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-
-  '/v3/dlp/violations/stream':
-    get:
-      summary: Get violations as a result of policy enforcement on streams.
-      description: Retrieves DLP v3 signal related violations for a given time range
-      produces:
-        - application/json
-      parameters:
-        - name: startTime
-          description: |
-            Timestamp of the first required violation.
-            This is a long integer value representing milliseconds since Jan 1 1970
-          in: query
-          required: true
-          type: integer
-          format: int64
-        - name: endTime
-          description: |
-            Timestamp of the last required violation.
-            This is a long integer value representing milliseconds since Jan 1 1970
-            If unspecified, it will default to current time of the request.
-          in: query
-          required: false
-          type: integer
-          format: int64
-        - name: next
-          description: |
-            Offset of the next chunk of violations. Value is null for the first request.
-          in: query
-          type: string
-          required: false
-        - name: limit
-          description: |
-            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
-          in: query
-          type: integer
-          required: false
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-      tags:
-        - Violations
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/V3DLPViolationStreamResponse'
-        '204':
-          description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-
-  '/v3/dlp/violations/signal':
-    get:
-      summary: Get violations as a result of policy enforcement on signals.
-      description: Retrieves DLP v3 signal related violations for a given time range
-      produces:
-        - application/json
-      parameters:
-        - name: startTime
-          description: |
-            Timestamp of the first required violation.
-            This is a long integer value representing milliseconds since Jan 1 1970
-          in: query
-          required: true
-          type: integer
-          format: int64
-        - name: endTime
-          description: |
-            Timestamp of the last required violation.
-            This is a long integer value representing milliseconds since Jan 1 1970
-            If unspecified, it will default to current time of the request.
-          in: query
-          required: false
-          type: integer
-          format: int64
-        - name: next
-          description: |
-            Offset of the next chunk of violations. Value is null for the first request.
-          in: query
-          type: string
-          required: false
-        - name: limit
-          description: |
-            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
-          in: query
-          type: integer
-          required: false
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-      tags:
-        - Violations
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/V3DLPViolationSignalResponse'
-        '204':
-          description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-
-  '/v3/dlp/violation/attachment':
-    get:
-      summary: Get attachments that were sent as part of messages that were flagged by the DLP System.
-      description: Retrieves attachments from related message violations as a base64 encoded String.
-      produces:
-        - application/octet-stream
-      parameters:
-        - name: fileId
-          description: |
-            ID of attachment that will be downloaded.
-          in: query
-          required: true
-          type: string
-        - name: violationId
-          description: |
-            ID of violation that corresponds to the flagged message that contains the attachment
-          in: query
-          required: true
-          type: string
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-      tags:
-        - Violations
-      responses:
-        '200':
-          description: Attachment body as Base64 encoded string.
           schema:
             type: string
-            format: byte
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '404':
-          description: 'Resource not found.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-
-  '/v1/audittrail/privilegeduser':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v3/dlp/violations/message:
     get:
-      summary: Get a list of  actions performed by a privileged account acting as privileged user given a period of time.
-      description: Get a list of actions performed by a privileged account acting as privileged user given a period of time.
-      produces:
-        - application/json
+      tags:
+        - Violations
+      summary: Get violations as a result of policy enforcement on messages.
+      description: Retrieves DLP v3 message related violations for a given time range
+      parameters:
+        - name: startTime
+          in: query
+          description: |
+            Timestamp of the first required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: endTime
+          in: query
+          description: |
+            Timestamp of the last required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+            If unspecified, it will default to current time of the request.
+          schema:
+            type: integer
+            format: int64
+        - name: next
+          in: query
+          description: Offset of the next chunk of violations. Value is null for the first request.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: |
+            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          schema:
+            type: integer
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3DLPViolationMessageResponse'
+        204:
+          description: No Messages.
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v3/dlp/violations/stream:
+    get:
+      tags:
+        - Violations
+      summary: Get violations as a result of policy enforcement on streams.
+      description: Retrieves DLP v3 signal related violations for a given time range
+      parameters:
+        - name: startTime
+          in: query
+          description: |
+            Timestamp of the first required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: endTime
+          in: query
+          description: |
+            Timestamp of the last required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+            If unspecified, it will default to current time of the request.
+          schema:
+            type: integer
+            format: int64
+        - name: next
+          in: query
+          description: Offset of the next chunk of violations. Value is null for the first request.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: |
+            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          schema:
+            type: integer
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3DLPViolationStreamResponse'
+        204:
+          description: No Messages.
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v3/dlp/violations/signal:
+    get:
+      tags:
+        - Violations
+      summary: Get violations as a result of policy enforcement on signals.
+      description: Retrieves DLP v3 signal related violations for a given time range
+      parameters:
+        - name: startTime
+          in: query
+          description: |
+            Timestamp of the first required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: endTime
+          in: query
+          description: |
+            Timestamp of the last required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+            If unspecified, it will default to current time of the request.
+          schema:
+            type: integer
+            format: int64
+        - name: next
+          in: query
+          description: Offset of the next chunk of violations. Value is null for the first request.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: |
+            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          schema:
+            type: integer
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3DLPViolationSignalResponse'
+        204:
+          description: No Messages.
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v3/dlp/violation/attachment:
+    get:
+      tags:
+        - Violations
+      summary: Get attachments that were sent as part of messages that were flagged by the DLP System.
+      description: Retrieves attachments from related message violations as a base64 encoded String.
+      parameters:
+        - name: fileId
+          in: query
+          description: ID of attachment that will be downloaded.
+          required: true
+          schema:
+            type: string
+        - name: violationId
+          in: query
+          description: ID of violation that corresponds to the flagged message that contains the attachment
+          required: true
+          schema:
+            type: string
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Attachment body as Base64 encoded string.
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: byte
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+        404:
+          description: Resource not found.
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/audittrail/privilegeduser:
+    get:
+      tags:
+        - AuditTrail
+      summary: Get a list of  actions performed by a privileged account acting as
+        privileged user given a period of time.
+      description: Get a list of actions performed by a privileged account acting
+        as privileged user given a period of time.
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: startTimestamp
-          description: |
-            Start timestamp in unix timestamp in millseconds.
           in: query
+          description: Start timestamp in unix timestamp in millseconds.
           required: true
-          type: integer
-          format: int64
+          schema:
+            type: integer
+            format: int64
         - name: endTimestamp
-          description: |
-            End timestamp in unix timestamp in millseconds.
-            If not specified, it assumes to be current time.
           in: query
-          required: false
-          type: integer
-          format: int64
+          description: End timestamp in unix timestamp in millseconds. If not specified, it assumes to be current time.
+          schema:
+            type: integer
+            format: int64
         - name: before
-          description: |
-            Return results from an opaque “before” cursor value as presented via a response cursor.
           in: query
-          type: string
-          required: false
+          description: Return results from an opaque “before” cursor value as presented via a response cursor.
+          schema:
+            type: string
         - name: after
-          description: |
-            Return results from an opaque “after” cursor value as presented via a response cursor.
           in: query
-          type: string
-          required: false
+          description: Return results from an opaque “after” cursor value as presented via a response cursor.
+          schema:
+            type: string
         - name: limit
+          in: query
           description: |
             Max No. of violations to return. If no value is provided, 50 is the default.
             Some maximums for limit may be enforced for performance reasons.
             The maximum supported value is 500.
-          in: query
-          type: integer
-          required: false
+          schema:
+            type: integer
         - name: initiatorId
-          description: |
-            If present, only the initiator with this initiator <user id> will be returned.
           in: query
-          type: integer
-          format: int64
+          description: If present, only the initiator with this initiator <user id> will be returned.
+          schema:
+            type: integer
+            format: int64
         - name: role
+          in: query
           description: |
             If present, only the audit trail initiated by s user with privileged role acting as
             privileged user will be returned.
@@ -2893,36 +3403,108 @@ paths:
             L1 (L1_SUPPORT),
             L2 (L2_SUPPORT),
             Scope Manager (SCOPE_MANAGEMENT)
-          in: query
-          type: string
-          required: false
-      tags:
-        - AuditTrail
+          schema:
+            type: string
       responses:
-        '200':
+        200:
           description: OK
-          schema:
-            $ref: '#/definitions/V1AuditTrailInitiatorList'
-        '204':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1AuditTrailInitiatorList'
+        204:
           description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v5/datafeeds:
+    get:
+      tags:
+        - Datafeed
+      summary: Read list of real time messages / events stream ("datafeed").
+      description: |
+        _Available on Agent 2.57.0 and above._
 
-  '/v5/datafeeds':
+        The datafeed provides messages and events from all conversations that the user
+        is in. The types of events surfaced in the datafeed can be found in the [Real Time Events](./docs/real-time-events.md) list.
+
+        Returns the list of the datafeeds for the user.
+        Any datafeed ID of the list can then be used as input to the Read Messages/Events Stream v4 endpoint.
+      operationId: listDatafeed
+      parameters:
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+        - name: tag
+          in: query
+          description: A unique identifier to ensure uniqueness of the datafeed. Used
+            to restrict search.
+          schema:
+            maxLength: 100
+            type: string
+      responses:
+        200:
+          description: Datafeed sucessfully created.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/V5Datafeed'
+              example:
+                - id: 8e7c8672-220...
+                  createdAt: 1536346282592
+                - id: 8e7c8672-221...
+                  createdAt: 1536346282500
+        400:
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
     post:
       tags:
         - Datafeed
@@ -2939,99 +3521,50 @@ paths:
       operationId: createDatafeed
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: body
-          in: body
-          required: false
           schema:
-            $ref: '#/definitions/V5DatafeedCreateBody'
-      produces:
-        - application/json
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V5DatafeedCreateBody'
+        required: false
       responses:
         201:
           description: Datafeed sucessfully created.
-          schema:
-            $ref: '#/definitions/V5Datafeed'
-        400:
-          description: Bad request.
-          schema:
-            $ref: '#/definitions/V2Error'
-        401:
-          description: Unauthorized.
-          schema:
-            $ref: '#/definitions/V2Error'
-        500:
-          description: Internal server error.
-          schema:
-            $ref: '#/definitions/V2Error'
-
-    get:
-      tags:
-        - Datafeed
-      summary: Read list of real time messages / events stream ("datafeed").
-      description: |
-        _Available on Agent 2.57.0 and above._
-
-        The datafeed provides messages and events from all conversations that the user
-        is in. The types of events surfaced in the datafeed can be found in the [Real Time Events](./docs/real-time-events.md) list.
-
-        Returns the list of the datafeeds for the user.
-        Any datafeed ID of the list can then be used as input to the Read Messages/Events Stream v4 endpoint.
-      operationId: listDatafeed
-      produces:
-        - application/json
-      parameters:
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: tag
-          maxLength: 100
-          required: false
-          description: A unique identifier to ensure uniqueness of the datafeed. Used to restrict search.
-          in: query
-          type: string
-      responses:
-        200:
-          description: Datafeed sucessfully created.
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/V5Datafeed'
-          examples:
+          content:
             application/json:
-              - id: '8e7c8672-220...'
-                createdAt: 1536346282592
-              - id: '8e7c8672-221...'
-                createdAt: 1536346282500
-
+              schema:
+                $ref: '#/components/schemas/V5Datafeed'
         400:
           description: Bad request.
-          schema:
-            $ref: '#/definitions/V2Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
         401:
           description: Unauthorized.
-          schema:
-            $ref: '#/definitions/V2Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
         500:
           description: Internal server error.
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v5/datafeeds/{datafeedId}':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+      x-codegen-request-body-name: body
+  /v5/datafeeds/{datafeedId}:
     delete:
       tags:
         - Datafeed
@@ -3046,40 +3579,50 @@ paths:
         Delete the specified datafeed.
       operationId: deleteDatafeed
       parameters:
-        - in: path
-          name: datafeedId
-          required: true
-          type: string
+        - name: datafeedId
+          in: path
           description: ID of the datafeed
+          required: true
+          schema:
+            type: string
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
       responses:
         204:
           description: Datafeed successfully deleted.
-          schema:
-            $ref: '#/definitions/V2Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
         400:
           description: Bad request.
-          schema:
-            $ref: '#/definitions/V2Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
         401:
           description: Unauthorized.
-          schema:
-            $ref: '#/definitions/V2Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
         500:
           description: Internal server error.
-          schema:
-            $ref: '#/definitions/V2Error'
-
-  '/v5/datafeeds/{datafeedId}/read':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+  /v5/datafeeds/{datafeedId}/read:
     post:
       tags:
         - Datafeed
@@ -3096,272 +3639,315 @@ paths:
         The ackId sent as parameter can be empty for the first call. In the response an ackId will be sent back and it can be used for
         the next call: in this way you acknowledge that you have received the events that came with that ackId; datafeed will remove the events
         associated with that ackId from your queue
-      consumes:
-        - application/json
-      produces:
-        - application/json
       operationId: readDatafeed
       parameters:
-        - in: path
-          name: datafeedId
-          required: true
-          type: string
+        - name: datafeedId
+          in: path
           description: ID of the datafeed
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
           required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: ackId
-          description: ackId received from last POST Base64 encoded.
-          in: body
-          required: false
           schema:
-            $ref: '#/definitions/AckId'
+            type: string
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: ackId received from last POST Base64 encoded.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AckId'
+        required: false
       responses:
         200:
           description: Datafeed successfully read.
-          schema:
-            $ref: '#/definitions/V5EventList'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V5EventList'
         400:
           description: Bad request.
-          schema:
-            $ref: '#/definitions/V2Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
         401:
           description: Unauthorized.
-          schema:
-            $ref: '#/definitions/V2Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
         403:
           description: Forbidden.
-          schema:
-            $ref: '#/definitions/V2Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
         500:
           description: Internal server error.
-          schema:
-            $ref: '#/definitions/V2Error'
-
-  '/v5/events/read':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+      x-codegen-request-body-name: ackId
+  /v5/events/read:
     post:
       tags:
         - Datafeed
       summary: Read Real Time Events from an event stream (aka datafeed)
       description: |
-        _Available on Agent 22.5 and above._
-
-        This endpoint provides messages and events from all conversations that the user
-        is in or events from the whole pod depending on the "type" field value.
-        When "type": "fanout" is provided in the body, then only events from streams the account belongs to are returned.
-        Otherwise, if "type": "datahose" is provided in the body, then events returned are not limited to the streams user
-        belongs to. In this case, at least one event type must be provided in the "filters" field. 
-        In case you are using a datahose feed and retrieving SOCIALMESSAGE events, ceservice account must be properly
-        configured in the Agent.
-
-        The types of events returned can be found in the Real Time Events list (see definition on top of the file).
-
-        The ackId sent as parameter can be empty for the first call. In the response an ackId will be sent back and it can be used for
-        the next call: in this way you acknowledge that you have received the events that came with that ackId.
-
-        If you have several instances of the same bot, they must share the same feed so that events are spread across
-        all bot instances. To do so, you must:
-        * share the same service account
-        * provide the same "tag" and same "filters" values
-      consumes:
-        - application/json
-      produces:
-        - application/json
+        _Available on Agent 22.5.1 and above.This endpoint provides
+        messages and events from all conversations that the user is in or events
+        from the whole pod depending on the "type" field value.
+        When "type":"fanout" is provided in the body, then only events from streams 
+        the accountbelongs to are returned. Otherwise, if "type": "datahose" is provided
+        in the body, then events returned are not limited to the streams user
+        belongs to. In this case, at least one event type must be provided in the
+        "filters" field. In case you are using a datahose feed and retrieving
+        SOCIALMESSAGE events, ceservice account must be properly configured in
+        the Agent.The types of events returned can be found in the Real Time
+        Events list (see definition on top of the file). The ackId sent as parameter
+        can be empty for the first call. In the response an ackId will be sent back
+        and it can be used for the next call: in this way you acknowledge that
+        you have received the events that came with that ackId.
+        If you have several instances of the same bot, they must share the same feed so 
+        that events are spread across all bot instances. To do so, you must: share the same 
+        service account provide the same "tag" and same "filters" values
       operationId: readEvents
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: body
-          description: body containing all information of events to be fetched
-          in: body
           required: true
           schema:
-            $ref: '#/definitions/V5EventsReadBody'
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: body containing all information of events to be fetched
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V5EventsReadBody'
+        required: true
       responses:
         200:
           description: Datafeed successfully read.
-          schema:
-            $ref: '#/definitions/V5EventList'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V5EventList'
         400:
           description: Bad request.
-          schema:
-            $ref: '#/definitions/V2Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
         401:
           description: Unauthorized.
-          schema:
-            $ref: '#/definitions/V2Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
         403:
           description: Forbidden.
-          schema:
-            $ref: '#/definitions/V2Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
         500:
           description: Internal server error.
-          schema:
-            $ref: '#/definitions/V2Error'
-#
-# Deprecated paths
-#
-  '/v1/datafeed/create':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+      x-codegen-request-body-name: body
+  #
+  # Deprecated paths
+  #
+  /v1/datafeed/create:
     post:
-      deprecated: true
+      tags:
+        - Datafeed
       summary: Create a new real time message event stream.
       description: |
-          A datafeed provides the messages in all conversations that a user is in.
-          System messages like new users joining a chatroom are not part of the datafeed.
-
-          A datafeed will expire after if it isn't read before its capacity is reached.
+        A datafeed provides the messages in all conversations that a user is in.
+        System messages like new users joining a chatroom are not part of the datafeed.
+        
+        A datafeed will expire after if it isn't read before its capacity is reached.
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      tags:
-        - Datafeed
-      responses:
-        '200':
-          description: OK
           schema:
-            $ref: '#/definitions/Datafeed'
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
           headers:
             X-Warning:
               description: This method is deprecated
-              type: string
-        '400':
-          description: 'Client error.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Datafeed'
+        400:
+          description: Client error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '503':
-          description: 'Max number of data feeds reached.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/datafeed/{id}/read':
-    get:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        503:
+          description: Max number of data feeds reached.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
       deprecated: true
+  /v1/datafeed/{id}/read:
+    get:
+      tags:
+        - Datafeed
       summary: Read a given datafeed.
       description: |
-          Read messages from the given datafeed. If no more messages are available then this method will block.
-          It is intended that the client should re-call this method as soon as it has processed the messages
-          received in the previous call. If the client is able to consume messages more quickly than they become
-          available then each call will initially block, there is no need to delay before re-calling this method.
+        Read messages from the given datafeed. If no more messages are available then this method will block.
+        It is intended that the client should re-call this method as soon as it has processed the messages
+        received in the previous call. If the client is able to consume messages more quickly than they become
+        available then each call will initially block, there is no need to delay before re-calling this method.
 
-          A datafeed will expire if its unread capacity is reached.
-          A datafeed can only be consumed by one client thread at a time. E.g. polling the datafeed by two threads may lead to messages being delivered out of order.
+        A datafeed will expire if its unread capacity is reached.
+        A datafeed can only be consumed by one client thread at a time. E.g. polling the datafeed by two threads may lead to messages being delivered out of order.
       parameters:
-      - name: id
-        description: |
-          Datafeed ID
-        in: path
-        required: true
-        type: string
-      - name: maxMessages
-        description: |
-            Max No. of messages to return.
-        in: query
-        type: integer
-      - name: sessionToken
-        description: Session authentication token.
-        in: header
-        required: true
-        type: string
-      - name: keyManagerToken
-        description: Key Manager authentication token.
-        in: header
-        required: true
-        type: string
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      tags:
-        - Datafeed
-      responses:
-        '200':
-          description: List of messages that have occurred since last time this URL was polled. If the list is empty, it means the request has reached its timeout, and the client should poll again.
+        - name: id
+          in: path
+          description: Datafeed ID
+          required: true
           schema:
-            $ref: '#/definitions/MessageList'
+            type: string
+        - name: maxMessages
+          in: query
+          description: Max No. of messages to return.
+          schema:
+            type: integer
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: List of messages that have occurred since last time this URL
+            was polled. If the list is empty, it means the request has reached its
+            timeout, and the client should poll again.
           headers:
             X-Warning:
               description: This method is deprecated
-              type: string
-        '204':
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageList'
+        204:
           description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/HealthCheck':
-    get:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
       deprecated: true
-      summary: Checks the health of the Agent.
-      description: |
-          Used to validate the configuration of the agent.
-          Makes a request to the HealthCheck on the Symphony cloud.
-          Makes a request to the HealthCheck on the Key Manager service.
-      produces:
-        - application/json
+  /v1/HealthCheck:
+    get:
       tags:
         - System
+      summary: Checks the health of the Agent.
+      description: |
+        Used to validate the configuration of the agent.
+        Makes a request to the HealthCheck on the Symphony cloud.
+        Makes a request to the HealthCheck on the Key Manager service.
       responses:
-        '200':
+        200:
           description: The Agent is functioning properly.
-          schema:
-            $ref: '#/definitions/V1HealthCheckResponse'
           headers:
             X-Warning:
               description: This method is deprecated
-              type: string
-  '/v2/HealthCheck':
-    get:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1HealthCheckResponse'
       deprecated: true
+  /v2/HealthCheck:
+    get:
+      tags:
+        - System
       summary: Checks the health of the Agent.
       description: |
         [deprecated] : This endpoint is deprecated.
@@ -3369,167 +3955,179 @@ paths:
         Unlike this deprecated endpoint, the extended health check endpoint provides status on external component such as pod, key manager, ceservice, agentservice...
       parameters:
         - name: showFirehoseErrors
+          in: query
           description: |
             [deprecated] Firehose Service has never been deployed. However, this request parameter has been kept here
             for specs backward compatibility.
-          in: query
-          required: false
-          type: boolean
+          schema:
+            type: boolean
         - name: failOnPodConnectivity
+          in: query
           description: |
             Defines the HealthCheck status code response whenever the Pod connectivity fails. When set to "true",
             in case of Pod connectivity failure, the response status code will be 503; otherwise, it will be 200.
             Default value is "false".
-          in: query
-          required: false
-          type: boolean
+          schema:
+            type: boolean
         - name: failOnKeyManagerConnectivity
+          in: query
           description: |
             Defines the HealthCheck status code response whenever the Key Manager connectivity fails. When set to "true",
             in case of Key Manager connectivity failure, the response status code will be 503; otherwise, it will be 200.
             Default value is "false".
-          in: query
-          required: false
-          type: boolean
+          schema:
+            type: boolean
         - name: failOnAgentServiceUser
+          in: query
           description: |
             Defines the HealthCheck status code response whenever the Agent Service User connectivity fails. When set to "true",
             in case of Agent Service connectivity failure, the response status code will be 503; otherwise, it will be 200.
             Default value is "false".
-          in: query
-          required: false
-          type: boolean
+          schema:
+            type: boolean
         - name: failOnCeServiceUser
+          in: query
           description: |
             This query parameter is not used as the ceservice is deprecated and it is kept for backward compatibility.
             Default value is "false" but it will not change the response status code if set to true.
-          in: query
-          required: false
-          type: boolean
+          schema:
+            type: boolean
         - name: failOnEncryptDecryptSuccess
+          in: query
           description: |
             Defines the status code response whenever the Encrypt/Decrypt message check fails. When set to "true",
             in case of Encrypt or Decrypt failure, the response status code will be 503; otherwise, it will be 200.
             Default value is "false".
-          in: query
-          required: false
-          type: boolean
+          schema:
+            type: boolean
         - name: failOnAny
+          in: query
           description: |
             Defines the status code response whenever at least one of the checks fails. When set to "true",
             in case of any failure, the response status code will be 503; otherwise, it will be 200.
             Default value is "false".
-          in: query
-          required: false
-          type: boolean
+          schema:
+            type: boolean
         - name: failOnDatafeedConnectivity
+          in: query
           description: |
             Defines the HealthCheck status code response whenever the Datafeed2 connectivity fails. When set to "true",
             in case of Datafeed connectivity failure, the response status code will be 503; otherwise, it will be 200.
             Default value is "false".
-          in: query
-          required: false
-          type: boolean
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: false
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: false
-          type: string
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      tags:
-        - System
-      responses:
-        '200':
-          description: The Agent is functioning properly.
           schema:
-            $ref: '#/definitions/V2HealthCheckResponse'
+            type: boolean
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          schema:
+            type: string
+      responses:
+        200:
+          description: The Agent is functioning properly.
           headers:
             X-Warning:
               description: This method is deprecated
-              type: string
-  '/v2/datafeed/{id}/read':
-    get:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2HealthCheckResponse'
       deprecated: true
-      summary: Read a given datafeed.
-      description: |
-          Read messages from the given datafeed. If no more messages are available then this method will block.
-          It is intended that the client should re-call this method as soon as it has processed the messages
-          received in the previous call. If the client is able to consume messages more quickly than they become
-          available then each call will initially block, there is no need to delay before re-calling this method.
-
-          A datafeed will expire if its unread capacity is reached.
-          A datafeed can only be consumed by one client thread at a time. E.g. polling the datafeed by two threads may lead to messages being delivered out of order.
-      parameters:
-      - name: id
-        description: |
-          Datafeed ID
-        in: path
-        required: true
-        type: string
-      - name: maxMessages
-        description: |
-            Max No. of messages to return.
-        in: query
-        type: integer
-      - name: sessionToken
-        description: Session authentication token.
-        in: header
-        required: true
-        type: string
-      - name: keyManagerToken
-        description: Key Manager authentication token.
-        in: header
-        required: true
-        type: string
-      consumes:
-        - application/json
-      produces:
-        - application/json
+  /v2/datafeed/{id}/read:
+    get:
       tags:
         - Datafeed
-      responses:
-        '200':
-          description: List of messages that have occurred since last time this URL was polled. If the list is empty, it means the request has reached its timeout, and the client should poll again.
+      summary: Read a given datafeed.
+      description: |
+        Read messages from the given datafeed. If no more messages are available then this method will block.
+        It is intended that the client should re-call this method as soon as it has processed the messages
+        received in the previous call. If the client is able to consume messages more quickly than they become
+        available then each call will initially block, there is no need to delay before re-calling this method.
+
+        A datafeed will expire if its unread capacity is reached.
+        A datafeed can only be consumed by one client thread at a time. E.g. polling the datafeed by two threads may lead to messages being delivered out of order.
+      parameters:
+        - name: id
+          in: path
+          description: Datafeed ID
+          required: true
           schema:
-            $ref: '#/definitions/V2MessageList'
+            type: string
+        - name: maxMessages
+          in: query
+          description: Max No. of messages to return.
+          schema:
+            type: integer
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: List of messages that have occurred since last time this URL
+            was polled. If the list is empty, it means the request has reached its
+            timeout, and the client should poll again.
           headers:
             X-Warning:
               description: This method is deprecated
-              type: string
-        '204':
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2MessageList'
+        204:
           description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v4/datafeed/create':
-    post:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
       deprecated: true
+  /v4/datafeed/create:
+    post:
+      tags:
+        - Datafeed
       summary: |
-        (Deprecated - Datafeed v1 will be fully replaced by the datafeed 2 service in the future.  
-        Please consider migrating over to datafeed 2 APIs /agent/v5/datafeeds. For more information on the 
-        timeline as well as on the benefits of datafeed 2, please reach out to your Technical Account Manager or to 
-        our developer documentation https://docs.developers.symphony.com/building-bots-on-symphony/datafeed)
+        (Deprecated - Datafeed v1 will be fully replaced by the datafeed 2
+        service in the future. Please consider migrating over to datafeed 2 APIs
+        /agent/v5/datafeeds. For more information on the timeline as well as on
+        the benefits of datafeed 2, please reach out to your Technical Account Manager
+        or to our developer documentation https://docs.developers.symphony.com/building-bots-on-symphony/datafeed)
         Create a new real time message event stream.
       description: |
         A datafeed provides the messages in all conversations that a user is in.
@@ -3538,78 +4136,95 @@ paths:
         A datafeed will expire if it isn't read before its capacity is reached.
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
-      consumes:
-        - application/json
-      produces:
-        - application/json
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Datafeed'
+        400:
+          description: Client error.
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        503:
+          description: Max number of data feeds reached.
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+      deprecated: true
+  /v4/datafeed/{id}/read:
+    get:
       tags:
         - Datafeed
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/Datafeed'
-          headers:
-            X-Warning:
-              description: This method is deprecated
-              type: string
-        '400':
-          description: 'Client error.'
-          schema:
-            $ref: '#/definitions/V2Error'
-          headers:
-            X-Warning:
-              description: This method is deprecated
-              type: string
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-          headers:
-            X-Warning:
-              description: This method is deprecated
-              type: string
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-          headers:
-            X-Warning:
-              description: This method is deprecated
-              type: string
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-          headers:
-            X-Warning:
-              description: This method is deprecated
-              type: string
-        '503':
-          description: 'Max number of data feeds reached.'
-          schema:
-            $ref: '#/definitions/V2Error'
-          headers:
-            X-Warning:
-              description: This method is deprecated
-              type: string
-  '/v4/datafeed/{id}/read':
-    get:
-      deprecated: true
       summary: |
-        (Deprecated - Datafeed v1 will be fully replaced by the datafeed 2 service in the future.  
-        Please consider migrating over to datafeed 2 APIs /agent/v5/datafeeds/{id}/read. For more information on the 
-        timeline as well as on the benefits of datafeed 2, please reach out to your Technical Account Manager or to 
-        our developer documentation https://docs.developers.symphony.com/building-bots-on-symphony/datafeed)
+        (Deprecated - Datafeed v1 will be fully replaced by the datafeed 2
+        service in the future.  Please consider migrating over to datafeed 2 APIs
+        /agent/v5/datafeeds/{id}/read. For more information on the timeline as
+        well as on the benefits of datafeed 2, please reach out to your Technical
+        Account Manager or to our developer documentation https://docs.developers.symphony.com/building-bots-on-symphony/datafeed)
         Read a given datafeed.
       description: |
         Read messages from the given datafeed. If no more messages are available then this method will block.
@@ -3621,82 +4236,99 @@ paths:
         A datafeed can only be consumed by one client thread at a time. E.g. polling the datafeed by two threads may lead to messages being delivered out of order.
       parameters:
         - name: id
-          description: |
-            Datafeed ID
           in: path
+          description: Datafeed ID
           required: true
-          type: string
-        - name: limit
-          description: |
-            Max No. of messages to return.
-          in: query
-          type: integer
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      tags:
-        - Datafeed
-      responses:
-        '200':
-          description: List of messages that have occurred since last time this URL was polled. If the list is empty, it means the request has reached its timeout, and the client should poll again.
           schema:
-            $ref: '#/definitions/V4EventList'
+            type: string
+        - name: limit
+          in: query
+          description: Max No. of messages to return.
+          schema:
+            type: integer
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: List of messages that have occurred since last time this URL
+            was polled. If the list is empty, it means the request has reached its
+            timeout, and the client should poll again.
           headers:
             X-Warning:
               description: This method is deprecated
-              type: string
-        '204':
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V4EventList'
+        204:
           description: No Messages.
           headers:
             X-Warning:
               description: This method is deprecated
-              type: string
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
+              schema:
+                type: string
+          content: {}
+        400:
+          description: Client error, see response body for further details.
           headers:
             X-Warning:
               description: This method is deprecated
-              type: string
-        '401':
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
           headers:
             X-Warning:
               description: This method is deprecated
-              type: string
-        '403':
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
           headers:
             X-Warning:
               description: This method is deprecated
-              type: string
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
           headers:
             X-Warning:
               description: This method is deprecated
-              type: string
-  '/v1/message/import':
-    post:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
       deprecated: true
+  /v1/message/import:
+    post:
+      tags:
+        - Messages
       summary: Import messages from other systems into Symphony.
       description: |
         Sends a message to be imported into the system.
@@ -3704,56 +4336,67 @@ paths:
         The requesting user must have the Content Management role.
         The user that the message is intended to have come from must also be present in the conversation.
         The intended message timestamp must be a valid time from the past. It cannot be a future timestamp.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
-          required: true
-          type: string
-        - name: messageList
-          in: body
+          description: Key Manager authentication token.
           required: true
           schema:
-            $ref: '#/definitions/MessageImportList'
-      tags:
-        - Messages
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MessageImportList'
+        required: true
       responses:
-        '200':
+        200:
           description: Message sent.
-          schema:
-            $ref: '#/definitions/ImportResponseList'
           headers:
             X-Warning:
               description: This method is deprecated
-              type: string
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImportResponseList'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v2/message/import':
-    post:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
       deprecated: true
+      x-codegen-request-body-name: messageList
+  /v2/message/import:
+    post:
+      tags:
+        - Messages
       summary: Import messages from other systems into Symphony.
       description: |
         Sends a message to be imported into the system.
@@ -3762,56 +4405,67 @@ paths:
         The user that the message is intended to have come from must also be present in the conversation.
         The intended message timestamp must be a valid time from the past. It cannot be a future timestamp.
         Optionally the original message ID can be specified to identify the imported message for the purpose of repeat imports.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
-          required: true
-          type: string
-        - name: messageList
-          in: body
+          description: Key Manager authentication token.
           required: true
           schema:
-            $ref: '#/definitions/V2MessageImportList'
-      tags:
-        - Messages
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V2MessageImportList'
+        required: true
       responses:
-        '200':
+        200:
           description: Message sent.
-          schema:
-            $ref: '#/definitions/V2ImportResponseList'
           headers:
             X-Warning:
               description: This method is deprecated
-              type: string
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2ImportResponseList'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/stream/{sid}/attachment/create':
-    post:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
       deprecated: true
+      x-codegen-request-body-name: messageList
+  /v1/stream/{sid}/attachment/create:
+    post:
+      tags:
+        - Attachments
       summary: Upload an attachment.
       description: |
         Upload an attachment to the given stream. The stream can be a chatroom,
@@ -3820,65 +4474,84 @@ paths:
         Once uploaded, you can use this attachment on a message you send in that stream.
 
         If the attachment is uploaded then 200 is returned.
-      consumes:
-        - multipart/form-data
-      produces:
-        - application/json
       parameters:
         - name: sid
-          description: Stream ID
           in: path
+          description: Stream ID
           required: true
-          type: string
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: file
-          description: The attachment body.
-          in: formData
-          required: true
-          type: file
-      tags:
-        - Attachments
-      responses:
-        '200':
-          description: 'Upload successful, return the attachment ID.'
           schema:
-            $ref: '#/definitions/AttachmentInfo'
+            type: string
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              required:
+                - file
+              properties:
+                file:
+                  type: string
+                  description: The attachment body.
+                  format: binary
+        required: true
+      responses:
+        200:
+          description: Upload successful, return the attachment ID.
           headers:
             X-Warning:
               description: This method is deprecated
-              type: string
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttachmentInfo'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        422:
           description: 'Unprocessable entity: The submitted data could not be processed.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v3/stream/{sid}/attachment/create':
-    post:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
       deprecated: true
+  /v3/stream/{sid}/attachment/create:
+    post:
+      tags:
+        - Attachments
       summary: PROVISIONAL - Upload an attachment.
       description: |
         Upload an attachment to the given stream. The stream can be a chatroom,
@@ -3887,235 +4560,277 @@ paths:
         Once uploaded, you can use this attachment on a message you send in that stream.
 
         If the attachment is uploaded then 200 is returned.
-      consumes:
-        - multipart/form-data
-      produces:
-        - application/json
       parameters:
         - name: sid
+          in: path
           description: Stream ID
-          in: path
           required: true
-          type: string
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: false
-          type: string
-        - name: file
-          description: The attachment body.
-          in: formData
-          required: true
-          type: file
-      tags:
-        - Attachments
-      responses:
-        '200':
-          description: 'Upload successful, return the attachment ID.'
           schema:
-            $ref: '#/definitions/AttachmentInfo'
+            type: string
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          schema:
+            type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              required:
+                - file
+              properties:
+                file:
+                  type: string
+                  description: The attachment body.
+                  format: binary
+        required: true
+      responses:
+        200:
+          description: Upload successful, return the attachment ID.
           headers:
             X-Warning:
               description: This method is deprecated
-              type: string
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttachmentInfo'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        422:
           description: 'Unprocessable entity: The submitted data could not be processed.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/stream/{sid}/message':
-    get:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
       deprecated: true
+  /v1/stream/{sid}/message:
+    get:
+      tags:
+        - Messages
       summary: Get messages from an existing stream.
       description: |
-          A caller can fetch all unseen messages by passing the timestamp of
-          the last message seen as the since parameter and the number of messages
-          with the same timestamp value already seen as the skip parameter. This
-          means that every message will be seen exactly once even in the case that
-          an additional message is processed with the same timestamp as the last
-          message returned by the previous call, and the case where there are
-          more than maxMessages with the same timestamp value.
+        A caller can fetch all unseen messages by passing the timestamp of
+        the last message seen as the since parameter and the number of messages
+        with the same timestamp value already seen as the skip parameter. This
+        means that every message will be seen exactly once even in the case that
+        an additional message is processed with the same timestamp as the last
+        message returned by the previous call, and the case where there are
+        more than maxMessages with the same timestamp value.
 
-          This method is intended for historic queries and is generally reliable
-          but if guaranteed delivery of every message in real time is required
-          then the equivilent firehose method should be called.
-      produces:
-        - application/json
+        This method is intended for historic queries and is generally reliable
+        but if guaranteed delivery of every message in real time is required
+        then the equivilent firehose method should be called.
       parameters:
         - name: sid
-          description: |
-            Stream ID
           in: path
+          description: Stream ID
           required: true
-          type: string
+          schema:
+            type: string
         - name: since
+          in: query
           description: |
             Timestamp of first required message.
-
+            
             This is a long integer value representing milliseconds since
             Jan 1 1970
-          in: query
           required: true
-          type: integer
-          format: int64
+          schema:
+            type: integer
+            format: int64
         - name: offset
-          description: |
-            No. of messages to skip.
           in: query
-          type: integer
+          description: No. of messages to skip.
+          schema:
+            type: integer
         - name: maxMessages
-          description: |
-            Max No. of messages to return. If no value is provided, 50 is the default.
           in: query
-          type: integer
-          required: false
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-      tags:
-        - Messages
-      responses:
-        '200':
-          description: OK
+          description: Max No. of messages to return. If no value is provided, 50 is the default.
           schema:
-            $ref: '#/definitions/MessageList'
+            type: integer
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
           headers:
             X-Warning:
               description: This method is deprecated
-              type: string
-        '204':
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageList'
+        204:
           description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v2/stream/{sid}/message':
-    get:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
       deprecated: true
+  /v2/stream/{sid}/message:
+    get:
+      tags:
+        - Messages
       summary: Get messages from an existing stream.
       description: |
-          A caller can fetch all unseen messages by passing the timestamp of
-          the last message seen as the since parameter and the number of messages
-          with the same timestamp value already seen as the skip parameter. This
-          means that every message will be seen exactly once even in the case that
-          an additional message is processed with the same timestamp as the last
-          message returned by the previous call, and the case where there are
-          more than maxMessages with the same timestamp value.
+        A caller can fetch all unseen messages by passing the timestamp of
+        the last message seen as the since parameter and the number of messages
+        with the same timestamp value already seen as the skip parameter. This
+        means that every message will be seen exactly once even in the case that
+        an additional message is processed with the same timestamp as the last
+        message returned by the previous call, and the case where there are
+        more than maxMessages with the same timestamp value.
 
-          This method is intended for historic queries and is generally reliable
-          but if guaranteed delivery of every message in real time is required
-          then the equivilent firehose method should be called.
-      produces:
-        - application/json
+        This method is intended for historic queries and is generally reliable
+        but if guaranteed delivery of every message in real time is required
+        then the equivilent firehose method should be called.
       parameters:
         - name: sid
-          description: |
-            Stream ID
           in: path
+          description: Stream ID
           required: true
-          type: string
+          schema:
+            type: string
         - name: since
+          in: query
           description: |
             Timestamp of first required message.
-
+            
             This is a long integer value representing milliseconds since
             Jan 1 1970
-          in: query
           required: true
-          type: integer
-          format: int64
-        - name: offset
-          description: |
-            No. of messages to skip.
-          in: query
-          type: integer
-        - name: limit
-          description: |
-            Max No. of messages to return. If no value is provided, 50 is the default.
-          in: query
-          type: integer
-          required: false
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-      tags:
-        - Messages
-      responses:
-        '200':
-          description: OK
           schema:
-            $ref: '#/definitions/V2MessageList'
+            type: integer
+            format: int64
+        - name: offset
+          in: query
+          description: No. of messages to skip.
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: Max No. of messages to return. If no value is provided, 50 is the default.
+          schema:
+            type: integer
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
           headers:
             X-Warning:
               description: This method is deprecated
-              type: string
-        '204':
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2MessageList'
+        204:
           description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/stream/{sid}/message/create':
-    post:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
       deprecated: true
+  /v1/stream/{sid}/message/create:
+    post:
+      tags:
+        - Messages
       summary: Post a message to one existing stream.
       description: |
         Post a new message to the given stream. The stream can be a chatroom,
@@ -4131,61 +4846,73 @@ paths:
         a client error results
 
         If the message is sent then 200 is returned.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sid
-          description: Stream ID
           in: path
+          description: Stream ID
           required: true
-          type: string
+          schema:
+            type: string
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
-          required: true
-          type: string
-        - name: message
-          in: body
+          description: Key Manager authentication token.
           required: true
           schema:
-            $ref: '#/definitions/MessageSubmission'
-      tags:
-        - Messages
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MessageSubmission'
+        required: true
       responses:
-        '200':
+        200:
           description: Message sent.
-          schema:
-            $ref: '#/definitions/Message'
           headers:
             X-Warning:
               description: This method is deprecated
-              type: string
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Message'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v2/stream/{sid}/message/create':
-    post:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
       deprecated: true
+      x-codegen-request-body-name: message
+  /v2/stream/{sid}/message/create:
+    post:
+      tags:
+        - Messages
       summary: Post a message to one existing stream.
       description: |
         Post a new message to the given stream. The stream can be a chatroom,
@@ -4203,61 +4930,73 @@ paths:
         a client error results
 
         If the message is sent then 200 is returned.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sid
-          description: Stream ID
           in: path
+          description: Stream ID
           required: true
-          type: string
+          schema:
+            type: string
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
-          required: true
-          type: string
-        - name: message
-          in: body
+          description: Key Manager authentication token.
           required: true
           schema:
-            $ref: '#/definitions/V2MessageSubmission'
-      tags:
-        - Messages
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V2MessageSubmission'
+        required: true
       responses:
-        '200':
+        200:
           description: Message sent.
-          schema:
-            $ref: '#/definitions/V2Message'
           headers:
             X-Warning:
               description: This method is deprecated
-              type: string
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Message'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v3/stream/{sid}/message/create':
-    post:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
       deprecated: true
+      x-codegen-request-body-name: message
+  /v3/stream/{sid}/message/create:
+    post:
+      tags:
+        - Messages
       summary: PROVISIONAL - Post a message to one existing stream.
       description: |
         Post a new message to the given stream. The stream can be a chatroom,
@@ -4278,2503 +5017,2591 @@ paths:
 
         Regarding authentication, you must either use the sessionToken which was created for delegated app access
         or both the sessionToken and keyManagerToken together.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sid
-          description: Stream ID
           in: path
+          description: Stream ID
           required: true
-          type: string
+          schema:
+            type: string
         - name: sessionToken
+          in: header
           description: Authorization token used to make delegated calls.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
-          required: false
-          type: string
-        - name: message
-          in: body
-          required: true
+          description: Key Manager authentication token.
           schema:
-            $ref: '#/definitions/V2MessageSubmission'
-      tags:
-        - Messages
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V2MessageSubmission'
+        required: true
       responses:
-        '200':
+        200:
           description: Message sent.
-          schema:
-            $ref: '#/definitions/V2Message'
           headers:
             X-Warning:
               description: This method is deprecated
-              type: string
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Message'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/stream/{sid}/share':
-    post:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
       deprecated: true
+      x-codegen-request-body-name: message
+  /v1/stream/{sid}/share:
+    post:
+      tags:
+        - Share
       summary: Share a piece of content into Symphony
       description: |
         Given a 3rd party content (eg. news article), it can share to the given stream.
         The stream can be a chatroom, an IM or a multiparty IM.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sid
-          description: Stream ID
           in: path
+          description: Stream ID
           required: true
-          type: string
+          schema:
+            type: string
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
-          required: true
-          type: string
-        - name: shareContent
-          in: body
+          description: Key Manager authentication token.
           required: true
           schema:
-            $ref: '#/definitions/ShareContent'
-      tags:
-        - Share
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ShareContent'
+        required: true
       responses:
-        '200':
+        200:
           description: Success
-          schema:
-            $ref: '#/definitions/V2Message'
           headers:
             X-Warning:
               description: This method is deprecated
-              type: string
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Message'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/util/obsolete':
-    post:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
       deprecated: true
-      summary: Example of a deprecated endpoint, returns input.
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: echoInput
-          description: Message in plain text
-          in: body
-          required: true
-          schema:
-            $ref: '#/definitions/SimpleMessage'
+      x-codegen-request-body-name: shareContent
+  /v1/util/obsolete:
+    post:
       tags:
         - Util
-      responses:
-        '200':
-          description: Message sent.
+      summary: Example of a deprecated endpoint, returns input.
+      parameters:
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
           schema:
-            $ref: '#/definitions/SimpleMessage'
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Message in plain text
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SimpleMessage'
+        required: true
+      responses:
+        200:
+          description: Message sent.
           headers:
             X-Warning:
               description: This method is deprecated
-              type: string
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleMessage'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '420':
-          description: 'Gone. Returned when the option to hard fail deprecated methods is enabled'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-definitions:
-  Error:
-    type: object
-    properties:
-      code:
-        type: integer
-        format: int32
-      message:
-        type: string
-  V2Error:
-    type: object
-    properties:
-      code:
-        type: integer
-        format: int32
-      message:
-        type: string
-      details:
-        type: object
-    required:
-    - code
-    - message
-  SuccessResponse:
-    type: object
-    properties:
-      format:
-        type: string
-        enum:
-          - TEXT
-          - XML
-      message:
-        type: string
-  V2BaseMessage:
-    type: object
-    discriminator: v2messageType
-    properties:
-      id:
-        type: string
-        description: The messageId is assigned by the ingestor service when a message is sent.
-      timestamp:
-        type: string
-      v2messageType:
-        type: string
-      streamId:
-        type: string
-    required:
-    - v2messageType
-    - timestamp
-    - streamId
-  V2Message:
-    type: object
-    description: A representation of a message sent by a user of Symphony.
-    allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        420:
+          description: Gone. Returned when the option to hard fail deprecated methods
+            is enabled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      deprecated: true
+      x-codegen-request-body-name: echoInput
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+    V2Error:
+      required:
+        - code
+        - message
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+        details:
+          type: object
+    SuccessResponse:
+      type: object
+      properties:
+        format:
+          type: string
+          enum:
+            - TEXT
+            - XML
+        message:
+          type: string
+    V2BaseMessage:
+      required:
+        - streamId
+        - timestamp
+        - v2messageType
+      type: object
+      properties:
+        id:
+          type: string
+          description: The messageId is assigned by the ingestor service when a message is sent.
+        timestamp:
+          type: string
+        v2messageType:
+          type: string
+        streamId:
+          type: string
+      discriminator:
+        propertyName: v2messageType
+    V2Message:
+      description: A representation of a message sent by a user of Symphony.
+      allOf:
+        - $ref: '#/components/schemas/V2BaseMessage'
+        - required:
+            - fromUserId
+            - message
+            - attachments
+          type: object
+          properties:
+            message:
+              type: string
+              description: Message text in MessageML
+              format: MessageML
+            fromUserId:
+              type: integer
+              description: the Symphony userId of the user who sent the message. This
+                will be populated by the server (and actually ignored if included when
+                sending a message).
+              format: int64
+            attachments:
+              type: array
+              items:
+                $ref: '#/components/schemas/AttachmentInfo'
+    RoomCreatedMessage:
+      description: Generated when a room is created.
+      allOf:
+        - $ref: '#/components/schemas/V2BaseMessage'
+        - type: object
+          required:
+            - keywords
+          properties:
+            creationDate:
+              type: integer
+              format: int64
+            name:
+              type: string
+            keywords:
+              type: array
+              items:
+                $ref: '#/components/schemas/RoomTag'
+            description:
+              type: string
+            createdByUserId:
+              type: integer
+              description: The Symphony userId of the user who created the room.
+              format: int64
+            readOnly:
+              type: boolean
+            discoverable:
+              type: boolean
+            public:
+              type: boolean
+            membersCanInvite:
+              type: boolean
+            copyProtected:
+              type: boolean
+    RoomDeactivatedMessage:
+      description: Generated when a room is deactivated.
+      allOf:
+        - $ref: '#/components/schemas/V2BaseMessage'
+        - type: object
+          properties:
+            deactivatedByUserId:
+              type: integer
+              format: int64
+    RoomReactivatedMessage:
+      description: Generated when a room is reactivated.
+      allOf:
+        - $ref: '#/components/schemas/V2BaseMessage'
+        - type: object
+          properties:
+            reactivatedByUserId:
+              type: integer
+              format: int64
+    RoomUpdatedMessage:
+      description: Generated when a room is updated.
+      allOf:
+        - $ref: '#/components/schemas/V2BaseMessage'
+        - type: object
+          required:
+            - keywords
+          properties:
+            oldName:
+              type: string
+            newName:
+              type: string
+            keywords:
+              type: array
+              items:
+                $ref: '#/components/schemas/RoomTag'
+            oldDescription:
+              type: string
+            newDescription:
+              type: string
+            membersCanInvite:
+              type: boolean
+            discoverable:
+              type: boolean
+            readOnly:
+              type: boolean
+            copyProtected:
+              type: boolean
+    UserJoinedRoomMessage:
+      description: Generated when a user joins a room.
+      allOf:
+        - $ref: '#/components/schemas/V2BaseMessage'
+        - type: object
+          properties:
+            addedByUserId:
+              type: integer
+              format: int64
+            memberAddedUserId:
+              type: integer
+              format: int64
+    UserLeftRoomMessage:
+      description: Generated when a user leaves a room.
+      allOf:
+        - $ref: '#/components/schemas/V2BaseMessage'
+        - type: object
+          properties:
+            removedByUserId:
+              type: integer
+              format: int64
+            memberLeftUserId:
+              type: integer
+              format: int64
+            informationBarrierRemediation:
+              type: boolean
+    RoomMemberPromotedToOwnerMessage:
+      description: Generated when a room member is promoted to owner.
+      allOf:
+        - $ref: '#/components/schemas/V2BaseMessage'
+        - type: object
+          properties:
+            promotedByUserId:
+              type: integer
+              format: int64
+            promotedUserId:
+              type: integer
+              format: int64
+    RoomMemberDemotedFromOwnerMessage:
+      description: Generated when a room member is promoted to owner.
+      allOf:
+        - $ref: '#/components/schemas/V2BaseMessage'
+        - type: object
+          properties:
+            demotedByUserId:
+              type: integer
+              format: int64
+            demotedUserId:
+              type: integer
+              format: int64
+    ConnectionRequestMessage:
+      description: Generated when a connection request is sent.
+      allOf:
+        - $ref: '#/components/schemas/V2BaseMessage'
+        - type: object
+          properties:
+            requestingUserId:
+              type: integer
+              format: int64
+            targetUserId:
+              type: integer
+              format: int64
+            firstRequestedAt:
+              type: integer
+              format: int64
+            updatedAt:
+              type: integer
+              format: int64
+            requestCounter:
+              type: integer
+            status:
+              type: string
+    AttachmentInfo:
+      required:
+        - id
+        - name
+        - size
+      type: object
+      properties:
+        id:
+          type: string
+          description: The attachment ID.
+        name:
+          type: string
+          description: The file name.
+        size:
+          type: integer
+          description: Size in bytes.
+          format: int64
+    V2MessageList:
+      type: array
+      items:
+        $ref: '#/components/schemas/V2BaseMessage'
+    SimpleMessage:
+      type: object
       properties:
         message:
           type: string
-          format: MessageML
-          description: Message text in MessageML
-        fromUserId:
+      description: A string wrapped in a JSON object.
+    RoomTag:
+      required:
+        - key
+        - value
+      type: object
+      properties:
+        key:
+          type: string
+          description: A unique label of the Tag.
+        value:
+          type: string
+          description: The value of this Tag's label.
+      description: Room Tag object. A key:value pair describing additional properties
+        of the room.
+    ShareArticle:
+      required:
+        - appId
+        - author
+        - publisher
+        - title
+      type: object
+      properties:
+        articleId:
+          type: string
+          description: |
+            An ID for this article that should be unique to the calling application. 
+            Either an articleId or an articleUrl is required.
+        title:
+          type: string
+          description: The title of the article
+        subTitle:
+          type: string
+          description: The subtitle of the article
+        message:
+          type: string
+          description: The message text that can be send along with the shared article
+        publisher:
+          type: string
+          description: Publisher of the article
+        publishDate:
           type: integer
+          description: Article publish date in unix timestamp
           format: int64
-          description: the Symphony userId of the user who sent the message. This will be populated by the server (and actually ignored if included when sending a message).
+        thumbnailUrl:
+          type: string
+          description: Url to the thumbnail image
+        author:
+          type: string
+          description: Author of the article
+        articleUrl:
+          type: string
+          description: Url to the article
+        summary:
+          type: string
+          description: Preview summary of the article
+        appId:
+          type: string
+          description: App ID of the calling application
+        appName:
+          type: string
+          description: App name of the calling application
+        appIconUrl:
+          type: string
+          description: App icon url of the calling application
+    ShareContent:
+      type: object
+      properties:
+        type:
+          type: string
+          description: Type of content to be shared.  Currently only support "com.symphony.sharing.article"
+        content:
+          $ref: '#/components/schemas/ShareArticle'
+    V2HealthCheckResponse:
+      type: object
+      properties:
+        podConnectivity:
+          type: boolean
+          description: Indicates whether the Agent server can connect to the Pod
+        podConnectivityError:
+          type: string
+          description: Error details in case of no Pod connectivity
+        keyManagerConnectivity:
+          type: boolean
+          description: Indicates whether the Agent server can connect to the Key Manager
+        keyManagerConnectivityError:
+          type: string
+          description: Error details in case of no Key Manager connectivity
+        firehoseConnectivity:
+          type: boolean
+          description: Indicates whether the Agent server can connect to Firehose Service
+        firehoseConnectivityError:
+          type: string
+          description: Error details in case of no Firehose connectivity
+        datafeedConnectivity:
+          type: boolean
+          description: Indicates whether the Agent server can connect to Datafeed V2 Service
+        datafeedConnectivityError:
+          type: string
+          description: Error details in case of no Datafeed V2 connectivity
+        datafeedVersion:
+          type: string
+          description: Indicates the Datafeed V2 version
+        encryptDecryptSuccess:
+          type: boolean
+          description: Indicates whether the Agent can successfully decrypt and encrypt messages
+        encryptDecryptError:
+          type: string
+          description: Error details in case of the encryption or decryption of the message fails
+        podVersion:
+          type: string
+          description: The version number of the pod
+        agentVersion:
+          type: string
+          description: The version number of the Agent server
+        agentServiceUser:
+          type: boolean
+          description: Indicates whether agent service user is setup correctly.
+        agentServiceUserError:
+          type: string
+          description: Error details in case agent service user is setup incorrectly.
+        ceServiceUser:
+          type: boolean
+          description: Indicates whether CEService user is setup correctly.
+        ceServiceUserError:
+          type: string
+          description: Error details in case CEService user is setup incorrectly.
+    MessageSearchQuery:
+      type: object
+      properties:
+        text:
+          type: string
+          description: Search for messages containing this text. Requires streamId
+            to be specified.
+        streamId:
+          type: string
+          description: Search for messages sent to this stream
+        streamType:
+          type: string
+          description: |
+            Search for messages sent to this type of streams. Accepted values are CHAT, IM, MIM, ROOM, POST.
+        author:
+          type: integer
+          description: Search for messages sent by this user ID
+          format: int64
+        hashtag:
+          type: string
+          description: Search for messages containing this hashtag
+        cashtag:
+          type: string
+          description: Search for messages containing this cashtag
+        mention:
+          type: integer
+          description: Search for messages mentioning this user ID
+          format: int64
+        signal:
+          type: string
+          description: |
+            Search for messages matching this signal. Can only be combined with date filtering and paging parameters.
+        fromDate:
+          type: integer
+          description: Search for messages sent on or after this timestamp
+          format: int64
+        toDate:
+          type: integer
+          description: Search for messages sent before this timestamp
+          format: int64
+    V4MessageImportList:
+      type: array
+      description: |
+        An ordered list of historic messages to be imported.
+        A list of import responses will be returned in the same order.
+      items:
+        $ref: '#/components/schemas/V4ImportedMessage'
+    V4ImportedMessage:
+      required:
+        - intendedMessageFromUserId
+        - intendedMessageTimestamp
+        - message
+        - originatingSystemId
+        - streamId
+      type: object
+      properties:
+        message:
+          type: string
+          description: Message text in MessageMLV2
+          format: MessageML
+        data:
+          type: string
+          description: Entity data in EntityJSON
+          format: JSON
+        intendedMessageTimestamp:
+          type: integer
+          description: |
+            The timestamp representing the time when the message was sent in the original system
+            in milliseconds since Jan 1st 1970.
+          format: int64
+        intendedMessageFromUserId:
+          type: integer
+          description: The long integer userid of the Symphony user who you intend to show sent the message.
+          format: int64
+        originatingSystemId:
+          type: string
+          description: The ID of the system through which the message was originally sent.
+        originalMessageId:
+          type: string
+          description: The ID of the message in the original system.
+        streamId:
+          type: string
         attachments:
           type: array
+          description: List of message attachments. Since Agent 20.14.
           items:
-            $ref: '#/definitions/AttachmentInfo'
-      required:
-      - message
-      - fromUserId
-  RoomCreatedMessage:
-    type: object
-    description: Generated when a room is created.
-    allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
+            $ref: '#/components/schemas/V4ImportedMessageAttachment'
+          x-since: 20.14
+        previews:
+          type: array
+          description: List of attachments previews. Since Agent 20.14.
+          items:
+            $ref: '#/components/schemas/V4ImportedMessageAttachment'
+          x-since: 20.14
+      description: |
+        A historic message to be imported into the system.
+        The importing user must have the Content Management role.
+        Also, the importing user must be a member of the conversation it is importing into.
+        The user that the message is intended to have come from must also be present in the conversation.
+        The intended message timestamp must be a valid time from the past. It cannot be a future timestamp.
+        By design, imported messages do not stream to datafeed or firehose endpoints.
+    V4ImportedMessageAttachment:
+      type: object
       properties:
-        creationDate:
-          type: integer
-          format: int64
+        filename:
+          type: string
+          description: Attachment filename
+          example: car.png
+        content:
+          type: string
+          description: Attachment content as Base64 encoded string
+    V4ImportResponseList:
+      type: array
+      items:
+        $ref: '#/components/schemas/V4ImportResponse'
+    V4ImportResponse:
+      type: object
+      properties:
+        messageId:
+          type: string
+          description: |
+            If the message was successfully imported then the message ID in the system
+            of the newly created message.
+        originatingSystemId:
+          type: string
+          description: The ID of the system through which the message was originally sent.
+        originalMessageId:
+          type: string
+          description: The ID of the message in the original system.
+        diagnostic:
+          type: string
+          description: |
+            A diagnostic message containing an error message in the event that the
+            message import failed. May also be present in the case of a successful
+            call if there is useful narrative to return.
+    V4AttachmentInfo:
+      required:
+        - id
+        - name
+        - size
+        - images
+      type: object
+      properties:
+        id:
+          type: string
+          description: The attachment ID.
         name:
           type: string
-        keywords:
+          description: The file name.
+        size:
+          type: integer
+          description: Size in bytes.
+          format: int64
+        images:
           type: array
           items:
-            $ref: '#/definitions/RoomTag'
+            $ref: '#/components/schemas/V4ThumbnailInfo'
+    V4ThumbnailInfo:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The thumbnail ID.
+        dimension:
+          type: string
+          description: The thumbnail pixel size.
+    V4MessageList:
+      type: array
+      items:
+        $ref: '#/components/schemas/V4Message'
+    V4Message:
+      type: object
+      required:
+        - attachments
+      properties:
+        messageId:
+          type: string
+          description: Id of the message
+        parentMessageId:
+          type: string
+          description: Id of the parent message, set when the message is a reply to
+            another message or a forwarded message. Since Agent 20.14.
+          x-since: 20.14
+        timestamp:
+          type: integer
+          description: Timestamp of the message in milliseconds since Jan 1 1970
+          format: int64
+        message:
+          type: string
+          description: Message content in MessageMLV2
+          format: MessageMLV2
+        sharedMessage:
+          $ref: '#/components/schemas/V4Message'
+        data:
+          type: string
+          description: Message data in EntityJSON
+          format: JSON
+        attachments:
+          type: array
+          description: Message attachments
+          items:
+            $ref: '#/components/schemas/V4AttachmentInfo'
+        user:
+          $ref: '#/components/schemas/V4User'
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+        externalRecipients:
+          type: boolean
+          description: Indicates if the message have external recipients. Only present
+            on real time messaging.
+        diagnostic:
+          type: string
+          description: |
+            Details if event failed to parse for any reason.  The contents of this field may not be useful,
+            depending on the nature of the error. Only present when error occurs.
+        userAgent:
+          type: string
+          description: |
+            User agent string for client that sent the message.  Allows callers to identify which client sent the
+            origin message (e.g. API Agent, SFE Client, mobile, etc)
+        originalFormat:
+          type: string
+          description: |
+            Indicates the format in which the message was originally sent.  This could have been either:
+            - com.symphony.markdown - Markdown OR Message ML V1
+            - com.symphony.messageml.v2 - Message ML V2
+        disclaimer:
+          type: string
+          description: |
+            Message that may be sent along with a regular message if configured for the POD,
+            usually the first message sent in a room that day.
+        sid:
+          type: string
+          description: |
+            Unique session identifier from where the message was created.
+          example: fa691cd3-484a-4109-aeb2-57c05b78c95b
+        replacing:
+          type: string
+          description: Id of the message that the current message is replacing (present only if set)
+        replacedBy:
+          type: string
+          description: Id of the message that the current message is being replaced with (present only if set)
+        initialTimestamp:
+          type: integer
+          description: |
+            Timestamp of when the initial message has been created in milliseconds since 
+            Jan 1 1970 (present only if set)
+          format: int64
+        initialMessageId:
+          type: string
+          description: Id the the initial message that has been updated (present only if set)
+        silent:
+          type: boolean
+          description: When false the user/s will receive the message update as unread (true by default)
+          x-since: 20.14
+      description: A representation of a message sent by a user of Symphony
+    V4MessageBlastResponse:
+      type: object
+      required:
+        - messages
+        - errors
+      properties:
+        messages:
+          type: array
+          description: List of messages successfully sent
+          items:
+            $ref: '#/components/schemas/V4Message'
+        errors:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/Error'
+          description: List of streams where the messages ingestion has failed
+      description: Wrapper response for a single message sent to multiple streams
+    V4User:
+      type: object
+      properties:
+        userId:
+          type: integer
+          description: Id of user
+          format: int64
+        firstName:
+          type: string
+          description: First name of user
+        lastName:
+          type: string
+          description: Last name of user
+        displayName:
+          type: string
+          description: User display name
+        email:
+          type: string
+          description: Email of user
+        username:
+          type: string
+          description: Applicable only to internal users
+    V4Stream:
+      type: object
+      properties:
+        streamId:
+          type: string
+          description: Id of stream
+        streamType:
+          type: string
+          description: |
+            Stream type, possible values are:
+              - IM
+              - MIM
+              - ROOM
+              - POST
+        roomName:
+          type: string
+          description: Applicable only to rooms
+        members:
+          type: array
+          description: Applicable only to IM Created
+          items:
+            $ref: '#/components/schemas/V4User'
+        external:
+          type: boolean
+        crossPod:
+          type: boolean
+    V4RoomProperties:
+      type: object
+      required:
+        - keywords
+      properties:
+        name:
+          type: string
         description:
           type: string
-        createdByUserId:
+        creatorUser:
+          $ref: '#/components/schemas/V4User'
+        createdDate:
           type: integer
+          description: Timestamp
           format: int64
-          description: The Symphony userId of the user who created the room.
-        readOnly:
+        external:
           type: boolean
-        discoverable:
+        crossPod:
           type: boolean
         public:
           type: boolean
-        membersCanInvite:
-          type: boolean
         copyProtected:
           type: boolean
-  RoomDeactivatedMessage:
-    type: object
-    description: Generated when a room is deactivated.
-    allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        deactivatedByUserId:
-          type: integer
-          format: int64
-  RoomReactivatedMessage:
-    type: object
-    description: Generated when a room is reactivated.
-    allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        reactivatedByUserId:
-          type: integer
-          format: int64
-  RoomUpdatedMessage:
-    type: object
-    description: Generated when a room is updated.
-    allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        oldName:
-          type: string
-        newName:
-          type: string
+        readOnly:
+          type: boolean
+        discoverable:
+          type: boolean
+        membersCanInvite:
+          type: boolean
         keywords:
           type: array
           items:
-            $ref: '#/definitions/RoomTag'
-        oldDescription:
-          type: string
-        newDescription:
-          type: string
-        membersCanInvite:
+            $ref: '#/components/schemas/V4KeyValuePair'
+        canViewHistory:
           type: boolean
-        discoverable:
-          type: boolean
-        readOnly:
-          type: boolean
-        copyProtected:
-          type: boolean
-  UserJoinedRoomMessage:
-    type: object
-    description: Generated when a user joins a room.
-    allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
+    V4KeyValuePair:
+      type: object
       properties:
-        addedByUserId:
-          type: integer
-          format: int64
-        memberAddedUserId:
-          type: integer
-          format: int64
-  UserLeftRoomMessage:
-    type: object
-    description: Generated when a user leaves a room.
-    allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
+        key:
+          type: string
+        value:
+          type: string
+    V4MessageSent:
+      type: object
       properties:
-        removedByUserId:
-          type: integer
-          format: int64
-        memberLeftUserId:
-          type: integer
-          format: int64
-        informationBarrierRemediation:
-          type: boolean
-  RoomMemberPromotedToOwnerMessage:
-    type: object
-    description: Generated when a room member is promoted to owner.
-    allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
+        message:
+          $ref: '#/components/schemas/V4Message'
+    V4Initiator:
+      type: object
       properties:
-        promotedByUserId:
-          type: integer
-          format: int64
-        promotedUserId:
-          type: integer
-          format: int64
-  RoomMemberDemotedFromOwnerMessage:
-    type: object
-    description: Generated when a room member is promoted to owner.
-    allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
+        user:
+          $ref: '#/components/schemas/V4User'
+    V4SharedPost:
+      type: object
       properties:
-        demotedByUserId:
-          type: integer
-          format: int64
-        demotedUserId:
-          type: integer
-          format: int64
-  ConnectionRequestMessage:
-    type: object
-    description: Generated when a connection request is sent.
-    allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
+        message:
+          $ref: '#/components/schemas/V4Message'
+        sharedMessage:
+          $ref: '#/components/schemas/V4Message'
+    V4InstantMessageCreated:
+      type: object
       properties:
-        requestingUserId:
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+    V4RoomCreated:
+      type: object
+      properties:
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+        roomProperties:
+          $ref: '#/components/schemas/V4RoomProperties'
+    V4RoomUpdated:
+      type: object
+      properties:
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+        newRoomProperties:
+          $ref: '#/components/schemas/V4RoomProperties'
+    V4RoomDeactivated:
+      type: object
+      properties:
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+    V4RoomReactivated:
+      type: object
+      properties:
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+    V4UserJoinedRoom:
+      type: object
+      properties:
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+        affectedUser:
+          $ref: '#/components/schemas/V4User'
+    V4UserLeftRoom:
+      type: object
+      properties:
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+        affectedUser:
+          $ref: '#/components/schemas/V4User'
+    V4RoomMemberPromotedToOwner:
+      type: object
+      properties:
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+        affectedUser:
+          $ref: '#/components/schemas/V4User'
+    V4RoomMemberDemotedFromOwner:
+      type: object
+      properties:
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+        affectedUser:
+          $ref: '#/components/schemas/V4User'
+    V4ConnectionRequested:
+      type: object
+      properties:
+        toUser:
+          $ref: '#/components/schemas/V4User'
+    V4ConnectionAccepted:
+      type: object
+      properties:
+        fromUser:
+          $ref: '#/components/schemas/V4User'
+    V4MessageSuppressed:
+      type: object
+      properties:
+        messageId:
+          type: string
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+    V4SymphonyElementsAction:
+      type: object
+      properties:
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+        formMessageId:
+          type: string
+          description: The id of the message that contains the Form
+        formId:
+          type: string
+          description: The id of the Form element
+        formValues:
+          type: object
+          description: The values (in JSON format) answered on the Form
+    V4UserRequestedToJoinRoom:
+      type: object
+      properties:
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+        affectedUsers:
+          type: array
+          description: List of affected users by the action (i.e. owners of the room)
+          items:
+            $ref: '#/components/schemas/V4User'
+    V4Payload:
+      type: object
+      properties:
+        messageSent:
+          $ref: '#/components/schemas/V4MessageSent'
+        sharedPost:
+          $ref: '#/components/schemas/V4SharedPost'
+        instantMessageCreated:
+          $ref: '#/components/schemas/V4InstantMessageCreated'
+        roomCreated:
+          $ref: '#/components/schemas/V4RoomCreated'
+        roomUpdated:
+          $ref: '#/components/schemas/V4RoomUpdated'
+        roomDeactivated:
+          $ref: '#/components/schemas/V4RoomDeactivated'
+        roomReactivated:
+          $ref: '#/components/schemas/V4RoomReactivated'
+        userJoinedRoom:
+          $ref: '#/components/schemas/V4UserJoinedRoom'
+        userLeftRoom:
+          $ref: '#/components/schemas/V4UserLeftRoom'
+        roomMemberPromotedToOwner:
+          $ref: '#/components/schemas/V4RoomMemberPromotedToOwner'
+        roomMemberDemotedFromOwner:
+          $ref: '#/components/schemas/V4RoomMemberDemotedFromOwner'
+        connectionRequested:
+          $ref: '#/components/schemas/V4ConnectionRequested'
+        connectionAccepted:
+          $ref: '#/components/schemas/V4ConnectionAccepted'
+        messageSuppressed:
+          $ref: '#/components/schemas/V4MessageSuppressed'
+        symphonyElementsAction:
+          $ref: '#/components/schemas/V4SymphonyElementsAction'
+        userRequestedToJoinRoom:
+          $ref: '#/components/schemas/V4UserRequestedToJoinRoom'
+    V4Event:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Event ID
+        messageId:
+          type: string
+          description: Message ID
+        timestamp:
           type: integer
+          description: Timestamp of event
           format: int64
-        targetUserId:
-          type: integer
-          format: int64
-        firstRequestedAt:
-          type: integer
-          format: int64
-        updatedAt:
-          type: integer
-          format: int64
-        requestCounter:
-          type: integer
-        status:
+        type:
           type: string
-  AttachmentInfo:
-    type: object
-    properties:
-      id:
-        type: string
-        description: The attachment ID.
-      name:
-        type: string
-        description: The file name.
-      size:
-        type: integer
-        format: int64
-        description: Size in bytes.
-    required:
-    - id
-    - name
-    - size
-  V2MessageList:
-    type: array
-    items:
-      $ref: '#/definitions/V2BaseMessage'
-  SimpleMessage:
-    description: A string wrapped in a JSON object.
-    type: object
-    properties:
-      message:
-        type: string
-
-  RoomTag:
-    description: Room Tag object. A key:value pair describing additional properties of the room.
-    properties:
-      key:
-        description: A unique label of the Tag.
-        type: string
-      value:
-        description: The value of this Tag's label.
-        type: string
-    required:
-    - key
-    - value
-  ShareArticle:
-    type: object
-    properties:
-      articleId:
-        type: string
-        description: An ID for this article that should be unique to the calling application. Either an articleId or an articleUrl is required.
-      title:
-        type: string
-        description: The title of the article
-      subTitle:
-        type: string
-        description: The subtitle of the article
-      message:
-        type: string
-        description: The message text that can be send along with the shared article
-      publisher:
-        type: string
-        description: Publisher of the article
-      publishDate:
-        type: integer
-        format: int64
-        description: Article publish date in unix timestamp
-      thumbnailUrl:
-        type: string
-        description: Url to the thumbnail image
-      author:
-        type: string
-        description: Author of the article
-      articleUrl:
-        type: string
-        description: Url to the article
-      summary:
-        type: string
-        description: Preview summary of the article
-      appId:
-        type: string
-        description: App ID of the calling application
-      appName:
-        type: string
-        description: App name of the calling application
-      appIconUrl:
-        type: string
-        description: App icon url of the calling application
-    required:
-    - title
-    - publisher
-    - author
-    - appId
-  ShareContent:
-    type: object
-    properties:
-      type:
-        type: string
-        description: Type of content to be shared.  Currently only support "com.symphony.sharing.article"
-      content:
-        $ref: '#/definitions/ShareArticle'
-  V2HealthCheckResponse:
-     type: object
-     properties:
-       podConnectivity:
-         type: boolean
-         description: Indicates whether the Agent server can connect to the Pod
-       podConnectivityError:
-         type: string
-         description: Error details in case of no Pod connectivity
-       keyManagerConnectivity:
-         type: boolean
-         description: Indicates whether the Agent server can connect to the Key Manager
-       keyManagerConnectivityError:
-         type: string
-         description: Error details in case of no Key Manager connectivity
-       firehoseConnectivity:
-         type: boolean
-         description: Indicates whether the Agent server can connect to Firehose Service
-       firehoseConnectivityError:
-         type: string
-         description: Error details in case of no Firehose connectivity
-       encryptDecryptSuccess:
-         type: boolean
-         description: Indicates whether the Agent can successfully decrypt and encrypt messages
-       encryptDecryptError:
-         type: string
-         description: Error details in case of the encryption or decryption of the message fails
-       podVersion:
-         type: string
-         description: The version number of the pod
-       agentVersion:
-         type: string
-         description: The version number of the Agent server
-       agentServiceUser:
-         type: boolean
-         description: Indicates whether agent service user is setup correctly.
-       agentServiceUserError:
-         type: string
-         description: Error details in case agent service user is setup incorrectly.
-       ceServiceUser:
-         type: boolean
-         description: Indicates whether CEService user is setup correctly.
-       ceServiceUserError:
-         type: string
-         description: Error details in case CEService user is setup incorrectly.
-  MessageSearchQuery:
-    type: object
-    properties:
-      text:
-        type: string
-        description: Search for messages containing this text. Requires streamId to be specified.
-      streamId:
-        type: string
-        description: Search for messages sent to this stream
-      streamType:
-        type: string
-        description: |
-          Search for messages sent to this type of streams. Accepted values are CHAT, IM, MIM, ROOM, POST.
-      author:
-        type: integer
-        format: int64
-        description: Search for messages sent by this user ID
-      hashtag:
-        type: string
-        description: Search for messages containing this hashtag
-      cashtag:
-        type: string
-        description: Search for messages containing this cashtag
-      mention:
-        type: integer
-        format: int64
-        description: Search for messages mentioning this user ID
-      signal:
-        type: string
-        description: |
-          Search for messages matching this signal. Can only be combined with date filtering and paging parameters.
-      fromDate:
-        type: integer
-        format: int64
-        description: Search for messages sent on or after this timestamp
-      toDate:
-        type: integer
-        format: int64
-        description: Search for messages sent before this timestamp
-  V4MessageImportList:
-    description: |
-      An ordered list of historic messages to be imported.
-      A list of import responsees will be returned in the same order.
-    type: array
-    items:
-      $ref: '#/definitions/V4ImportedMessage'
-  V4ImportedMessage:
-    description: |
-      A historic message to be imported into the system.
-      The importing user must have the Content Management role.
-      Also, the importing user must be a member of the conversation it is importing into.
-      The user that the message is intended to have come from must also be present in the conversation.
-      The intended message timestamp must be a valid time from the past. It cannot be a future timestamp.
-      By design, imported messages do not stream to datafeed or firehose endpoints.
-    type: object
-    properties:
-      message:
-        type: string
-        format: MessageML
-        description: Message text in MessageMLV2
-      data:
-        type: string
-        format: JSON
-        description: Entity data in EntityJSON
-      intendedMessageTimestamp:
-        description: |
-          The timestamp representing the time when the message was sent in the original system
-          in milliseconds since Jan 1st 1970.
-        type: integer
-        format: int64
-      intendedMessageFromUserId:
-        description: |
-          The long integer userid of the Symphony user who you intend to show sent the message.
-        type: integer
-        format: int64
-      originatingSystemId:
-        description: |
-          The ID of the system through which the message was originally sent.
-        type: string
-      originalMessageId:
-        description: |
-          The ID of the message in the original system.
-        type: string
-      streamId:
-        type: string
-      attachments:
-        description: List of message attachments. Since Agent 20.14.
-        type: array
-        items:
-          $ref: '#/definitions/V4ImportedMessageAttachment'
-        x-since: 20.14
-      previews:
-        description: List of attachments previews. Since Agent 20.14.
-        type: array
-        items:
-          $ref: '#/definitions/V4ImportedMessageAttachment'
-        x-since: 20.14
-    required:
-    - message
-    - intendedMessageTimestamp
-    - intendedMessageFromUserId
-    - originatingSystemId
-    - streamId
-  V4ImportedMessageAttachment:
-    type: object
-    properties:
-      filename:
-        description: Attachment filename
-        type: string
-        example: 'car.png'
-      content:
-        description: Attachment content as Base64 encoded string
-        type: string
-  V4ImportResponseList:
-    type: array
-    items:
-      $ref: '#/definitions/V4ImportResponse'
-  V4ImportResponse:
-    type: object
-    properties:
-      messageId:
-        description: |
-          If the message was successfully imported then the message ID in the system
-          of the newly created message.
-        type: string
-      originatingSystemId:
-        description: |
-          The ID of the system through which the message was originally sent.
-        type: string
-      originalMessageId:
-        description: |
-          The ID of the message in the original system.
-        type: string
-      diagnostic:
-        description: |
-          A diagnostic message containing an error message in the event that the
-          message import failed. May also be present in the case of a successful
-          call if there is useful narrative to return.
-        type: string
-  V4AttachmentInfo:
-    type: object
-    properties:
-      id:
-        type: string
-        description: The attachment ID.
-      name:
-        type: string
-        description: The file name.
-      size:
-        type: integer
-        format: int64
-        description: Size in bytes.
-      images:
-        type: array
-        items:
-          $ref: '#/definitions/V4ThumbnailInfo'
-    required:
-    - id
-    - name
-    - size
-  V4ThumbnailInfo:
-    type: object
-    properties:
-      id:
-        type: string
-        description: The thumbnail ID.
-      dimension:
-        type: string
-        description: The thumbnail pixel size.
-  V4MessageList:
-    type: array
-    items:
-      $ref: '#/definitions/V4Message'
-  V4Message:
-    type: object
-    description: A representation of a message sent by a user of Symphony
-    properties:
-      messageId:
-        type: string
-        description: Id of the message
-      parentMessageId:
-        type: string
-        description: Id of the parent message, set when the message is a reply to another message or a forwarded message. Since Agent 20.14.
-        x-since: 20.14
-      timestamp:
-        type: integer
-        format: int64
-        description: Timestamp of the message in milliseconds since Jan 1 1970
-      message:
-        type: string
-        format: MessageMLV2
-        description: Message content in MessageMLV2
-      sharedMessage:
-        description: Only present when the message represented by this class is a wall post sharing another message.
-        $ref: '#/definitions/V4Message'
-      data:
-        type: string
-        format: JSON
-        description: Message data in EntityJSON
-      attachments:
-        description: Message attachments
-        type: array
-        items:
-          $ref: '#/definitions/V4AttachmentInfo'
-      user:
-        $ref: '#/definitions/V4User'
-      stream:
-        $ref: '#/definitions/V4Stream'
-      externalRecipients:
-        description: Indicates if the message have external recipients. Only present on real time messaging.
-        type: boolean
-      diagnostic:
-        type: string
-        description: |
-          Details if event failed to parse for any reason.  The contents of this field may not be useful,
-          depending on the nature of the error. Only present when error occurs.
-      userAgent:
-        type: string
-        description: |
-          User agent string for client that sent the message.  Allows callers to identify which client sent the
-          origin message (e.g. API Agent, SFE Client, mobile, etc)
-      originalFormat:
-        type: string
-        description: |
-          Indicates the format in which the message was originally sent.  This could have been either:
-          - com.symphony.markdown - Markdown OR Message ML V1
-          - com.symphony.messageml.v2 - Message ML V2
-      disclaimer:
-        type: string
-        description: |
-          Message that may be sent along with a regular message if configured for the POD,
-          usually the first message sent in a room that day.
-      sid:
-        type: string
-        description: |
-          Unique session identifier from where the message was created.
-        example: 'fa691cd3-484a-4109-aeb2-57c05b78c95b'
-      replacing:
-        type: string
-        description: Id of the message that the current message is replacing (present only if set)
-      replacedBy:
-        type: string
-        description: Id of the message that the current message is being replaced with (present only if set)
-      initialTimestamp:
-        type: integer
-        format: int64
-        description: Timestamp of when the initial message has been created in milliseconds since Jan 1 1970 (present only if set)
-      initialMessageId:
-        type: string
-        description: Id the the initial message that has been updated (present only if set)
-      silent:
-        type: boolean
-        description: When false the user/s will receive the message update as unread (true by default). Since Agent 20.14.
-        x-since: 20.14
-  V4MessageBlastResponse:
-    type: object
-    description: Wrapper response for a single message sent to multiple streams
-    properties:
-      messages:
-        type: array
-        description: List of messages successfully sent
-        items:
-          $ref: '#/definitions/V4Message'
-      errors:
-        type: object
-        description: List of streams where the messages ingestion has failed
-        additionalProperties:
-          $ref: '#/definitions/Error'
-  V4User:
-    type: object
-    properties:
-      userId:
-        type: integer
-        format: int64
-        description: Id of user
-      firstName:
-        type: string
-        description: First name of user
-      lastName:
-        type: string
-        description: Last name of user
-      displayName:
-        type: string
-        description: User display name
-      email:
-        type: string
-        description: Email of user
-      username:
-        type: string
-        description: Applicable only to internal users
-  V4Stream:
-    type: object
-    properties:
-      streamId:
-        type: string
-        description: Id of stream
-      streamType:
-        type: string
-        description: |
-          Stream type, possible values are:
-            - IM
-            - MIM
-            - ROOM
-            - POST
-      roomName:
-        type: string
-        description: Applicable only to rooms
-      members:
-        description: Applicable only to IM Created
-        type: array
-        items:
-          $ref: '#/definitions/V4User'
-      external:
-        type: boolean
-      crossPod:
-        type: boolean
-  V4RoomProperties:
-    type: object
-    properties:
-      name:
-        type: string
-      description:
-        type: string
-      creatorUser:
-        $ref: '#/definitions/V4User'
-      createdDate:
-        type: integer
-        format: int64
-        description: Timestamp
-      external:
-        type: boolean
-      crossPod:
-        type: boolean
-      public:
-        type: boolean
-      copyProtected:
-        type: boolean
-      readOnly:
-        type: boolean
-      discoverable:
-        type: boolean
-      membersCanInvite:
-        type: boolean
-      keywords:
-        type: array
-        items:
-          $ref: '#/definitions/V4KeyValuePair'
-      canViewHistory:
-        type: boolean
-  V4KeyValuePair:
-    type: object
-    properties:
-      key:
-        type: string
-      value:
-        type: string
-  V4MessageSent:
-    type: object
-    properties:
-      message:
-        $ref: '#/definitions/V4Message'
-  V4Initiator:
-    type: object
-    properties:
-      user:
-        $ref: '#/definitions/V4User'
-  V4SharedPost:
-    type: object
-    properties:
-      message:
-        $ref: '#/definitions/V4Message'
-      sharedMessage:
-        $ref: '#/definitions/V4Message'
-  V4InstantMessageCreated:
-    type: object
-    properties:
-      stream:
-        $ref: '#/definitions/V4Stream'
-  V4RoomCreated:
-    type: object
-    properties:
-      stream:
-        $ref: '#/definitions/V4Stream'
-      roomProperties:
-        $ref: '#/definitions/V4RoomProperties'
-  V4RoomUpdated:
-    type: object
-    properties:
-      stream:
-        $ref: '#/definitions/V4Stream'
-      newRoomProperties:
-        $ref: '#/definitions/V4RoomProperties'
-  V4RoomDeactivated:
-    type: object
-    properties:
-      stream:
-        $ref: '#/definitions/V4Stream'
-  V4RoomReactivated:
-    type: object
-    properties:
-      stream:
-        $ref: '#/definitions/V4Stream'
-  V4UserJoinedRoom:
-    type: object
-    properties:
-      stream:
-        $ref: '#/definitions/V4Stream'
-      affectedUser:
-        # User who was affected by the action (i.e. added to the room)
-        $ref: '#/definitions/V4User'
-  V4UserLeftRoom:
-    type: object
-    properties:
-      stream:
-        $ref: '#/definitions/V4Stream'
-      affectedUser:
-        # User who was affected by the action (i.e. left the room)
-        $ref: '#/definitions/V4User'
-  V4RoomMemberPromotedToOwner:
-    type: object
-    properties:
-      stream:
-        $ref: '#/definitions/V4Stream'
-      affectedUser:
-        # User who was affected by the action (i.e. promoted to owner)
-        $ref: '#/definitions/V4User'
-  V4RoomMemberDemotedFromOwner:
-    type: object
-    properties:
-      stream:
-        $ref: '#/definitions/V4Stream'
-      affectedUser:
-        # User who was affected by the action (i.e. demoted from owner)
-        $ref: '#/definitions/V4User'
-  V4ConnectionRequested:
-    type: object
-    properties:
-      toUser:
-        # User who received the connection request
-        $ref: '#/definitions/V4User'
-  V4ConnectionAccepted:
-    type: object
-    properties:
-      fromUser:
-        # User who sent the connection request
-        $ref: '#/definitions/V4User'
-  V4MessageSuppressed:
-    type: object
-    properties:
-      messageId:
-        type: string
-      stream:
-        # the stream holding the suppressed message
-        $ref: '#/definitions/V4Stream'
-  V4SymphonyElementsAction:
-    type: object
-    properties:
-      stream:
-        description: "The stream where the Form message was posted"
-        $ref: '#/definitions/V4Stream'
-      formMessageId:
-        description: "The id of the message that contains the Form"
-        type: string
-      formId:
-        description: "The id of the Form element"
-        type: string
-      formValues:
-        description: "The values (in JSON format) answered on the Form"
-        type: object
-  V4UserRequestedToJoinRoom:
-    type: object
-    properties:
-      stream:
-        description: "The stream that the user requested to join"
-        $ref: '#/definitions/V4Stream'
-      affectedUsers:
-        type: array
-        description: "List of affected users by the action (i.e. owners of the room)"
-        items:
-          $ref: '#/definitions/V4User'
-  V4Payload:
-    type: object
-    properties:
-      messageSent:
-        $ref: '#/definitions/V4MessageSent'
-      sharedPost:
-        $ref: '#/definitions/V4SharedPost'
-      instantMessageCreated:
-        $ref: '#/definitions/V4InstantMessageCreated'
-      roomCreated:
-        $ref: '#/definitions/V4RoomCreated'
-      roomUpdated:
-        $ref: '#/definitions/V4RoomUpdated'
-      roomDeactivated:
-        $ref: '#/definitions/V4RoomDeactivated'
-      roomReactivated:
-        $ref: '#/definitions/V4RoomReactivated'
-      userJoinedRoom:
-        $ref: '#/definitions/V4UserJoinedRoom'
-      userLeftRoom:
-        $ref: '#/definitions/V4UserLeftRoom'
-      roomMemberPromotedToOwner:
-        $ref: '#/definitions/V4RoomMemberPromotedToOwner'
-      roomMemberDemotedFromOwner:
-        $ref: '#/definitions/V4RoomMemberDemotedFromOwner'
-      connectionRequested:
-        $ref: '#/definitions/V4ConnectionRequested'
-      connectionAccepted:
-        $ref: '#/definitions/V4ConnectionAccepted'
-      messageSuppressed:
-        $ref: '#/definitions/V4MessageSuppressed'
-      symphonyElementsAction:
-        $ref: '#/definitions/V4SymphonyElementsAction'
-      userRequestedToJoinRoom:
-        $ref: '#/definitions/V4UserRequestedToJoinRoom'
-  V4Event:
-    type: object
-    properties:
-      id:
-        type: string
-        description: Event ID
-      messageId:
-        type: string
-        description: Message ID
-      timestamp:
-        type: integer
-        format: int64
-        description: Timestamp of event
-      type:
-        type: string
-        description: |
-          Event type, possible events are:
-            - MESSAGESENT
-            - SHAREDPOST
-            - INSTANTMESSAGECREATED
-            - ROOMCREATED
-            - ROOMUPDATED
-            - ROOMDEACTIVATED
-            - ROOMREACTIVATED
-            - USERJOINEDROOM
-            - USERLEFTROOM
-            - ROOMMEMBERPROMOTEDTOOWNER
-            - ROOMMEMBERDEMOTEDFROMOWNER
-            - CONNECTIONREQUESTED
-            - CONNECTIONACCEPTED
-            - MESSAGESUPPRESSED
-            - SYMPHONYELEMENTSACTION
-            - USERREQUESTEDTOJOINROOM
-      diagnostic:
-        type: string
-        description: |
-          Details if event failed to parse for any reason.  The contents of this field may not be useful,
-          depending on the nature of the error. Only present when error occurs.
-      initiator:
-        # Actor who initiated the event
-        $ref: '#/definitions/V4Initiator'
-      payload:
-        # Holds payload for all event types
-        $ref: '#/definitions/V4Payload'
-  V4EventList:
-    type: array
-    items:
-      $ref: '#/definitions/V4Event'
-  BaseSignal:
-    type: object
-    properties:
-      name:
-        type: string
-        description: Signal name
-      query:
-        type: string
-        description: |
-          The query used to define this signal. The query is defined as "field:value" pairs combined by the operators
-          "AND" or "OR". Supported fields are (case-insensitive): "author", "hashtag" and "cashtag".
-          MUST contain at least one "hashtag" or "cashtag" definition.
-      visibleOnProfile:
-        type: boolean
-        description: Whether the signal is visible on its creator's profile
-      companyWide:
-        type: boolean
-        description: Whether the signal is a push signal
-  Signal:
-    allOf:
-      - $ref: '#/definitions/BaseSignal'
-      - type: object
-        properties:
-          id:
-            type: string
-            description: Signal ID
-          timestamp:
-            type: integer
-            format: int64
-            description: Timestamp when the signal was created, in milliseconds since Jan 1 1970
-          companyWide:
-            type: boolean
-            description: Whether the signal is a push signal
-  SignalList:
-    type: array
-    items:
-      $ref: '#/definitions/Signal'
-  ChannelSubscriptionResponse:
-    type: object
-    properties:
-      requestedSubscription:
-        type: integer
-        format: int64
-        description: The number of requested userIds to subscribe
-      successfulSubscription:
-        type: integer
-        format: int64
-        description: The number of successful subscriptions done
-      failedSubscription:
-        type: integer
-        format: int64
-        description: The number of subscription failures
-      subscriptionErrors:
-        type: array
-        items:
-          $ref: '#/definitions/ChannelSubscriptionError'
-  ChannelSubscriptionError:
-    type: object
-    properties:
-      userId:
-        type: integer
-        format: int64
-        description: The userId on which failure happened
-      code:
-        type: string
-        description: subscription failure code
-      message:
-        type: string
-        description: subscription failure message
-  ChannelSubscriberResponse:
-    type: object
-    properties:
-      offset:
-        type: integer
-        format: int64
-        description: The number of subscribers skipped
-      hasMore:
-        type: boolean
-        description: True if there are more subscribers
-      total:
-        type: integer
-        description: The total number of subscribers
-      data:
-        type: array
-        items:
-          $ref: '#/definitions/ChannelSubscriber'
-  ChannelSubscriber:
-    type: object
-    properties:
-      subscriptionId:
-        type: string
-      pushed:
-        type: boolean
-        description: True if the subscriber is allowed to unsubscribe
-      owner:
-        type: boolean
-        description: True if the subscriber is the creator
-      subscriberName:
-        type: string
-        description: User display name
-      userId:
-        type: integer
-        format: int64
-        description: The user ID of the subscriber
-      timestamp:
-        type: integer
-        format: int64
-        description: Timestamp when the signal was subscribed, in milliseconds since Jan 1 1970
-  AgentInfo:
-    type: object
-    properties:
-      ipAddress:
-        type: string
-        description: The IP address of the Agent server.
-      hostname:
-        type: string
-        description: The hostname of the Agent server.
-      serverFqdn:
-        type: string
-        description: The fully-qualified domain name of the Agent server. Must be set by the user at startup.
-      version:
-        type: string
-        description: The version of the Agent.
-      url:
-        type: string
-        description: The URL under which the Agent is available.
-      onPrem:
-        type: boolean
-        description: Whether this is an on-prem or cloud installation.
-      commitId:
-        type: string
-        description: The Git commit ID of the running revision.
-  V1DLPPoliciesCollectionResponse:
-    type: object
-    properties:
-      policies:
-        type: array
-        description: List of policies
-        items:
-          $ref: '#/definitions/V1DLPPolicy'
-      page:
-        type: integer
-        format: int32
-        description: Page number of current page
-      pageCount:
-        type: integer
-        format: int32
-        description: Total number of pages available
-    description: List of policies
-  V1DLPPolicy:
-    type: object
-    required:
-    - "contentTypes"
-    - "name"
-    - "scopes"
-    - "type"
-    properties:
-      active:
-        type: boolean
-        description: Indicate whether the policy is active or not
-      contentTypes:
-        type: array
-        description: |
-          The list of content types that policy should apply to. Cannot be empty. Policy content types could be either of "Messages", "RoomMeta", "SignalMeta".
-          Default is set to ["Messages"] if not specified.
-        items:
+          description: |
+            Event type, possible events are:
+              - MESSAGESENT
+              - SHAREDPOST
+              - INSTANTMESSAGECREATED
+              - ROOMCREATED
+              - ROOMUPDATED
+              - ROOMDEACTIVATED
+              - ROOMREACTIVATED
+              - USERJOINEDROOM
+              - USERLEFTROOM
+              - ROOMMEMBERPROMOTEDTOOWNER
+              - ROOMMEMBERDEMOTEDFROMOWNER
+              - CONNECTIONREQUESTED
+              - CONNECTIONACCEPTED
+              - MESSAGESUPPRESSED
+              - SYMPHONYELEMENTSACTION
+              - USERREQUESTEDTOJOINROOM
+        diagnostic:
           type: string
-      creationDate:
-        type: integer
-        format: int64
-        description: |
-          Creation time of the policy in milliseconds elapsed as of epoch time.
-      creatorId:
-        type: string
-        description: Numeric userId of the creator
-      dictionaryRefs:
-        type: array
-        description: List of dictionaries.
-        items:
-          $ref: '#/definitions/V1DLPDictionaryRef'
-      lastDisabledDate:
-        type: integer
-        format: int64
-        description: |
-          Recent disable time of the policy in milliseconds elapsed as of epoch time.
-      lastUpdatedDate:
-        type: integer
-        format: int64
-        description: Recent update time of the policy in milliseconds elapsed as of epoch time.
-      name:
-        type: string
-        description: Unique name of a policy, max 30 characters. Cannot be empty. All the leading and trailing blank spaces are trimmed.
-      policyId:
-        type: string
-        description: Policy Id
-      scopes:
-        type: array
-        description: |
-          List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
-          You can apply both scopes if you set it to ["Internal", "External"].
-        items:
-          type: string
-      type:
-        type: string
-        description: Type of policy. Possible values "Block" or "Warn".
-      version:
-        type: string
-        description: |
-          The version of a dictionary, in format "major.minor". Initial value will set by backend as "1.0" when created.
-          Whenever the dictionary version needs to be changed, the minor version by 1 unless minor == 999, then the major version is increased by 1 until it reaches 999.
-    description: The policy object for expression filter, one policy can have multiple dictionaries
-  V1DLPPolicyRequest:
-    type: object
-    required:
-    - "contentTypes"
-    - "name"
-    - "scopes"
-    - "type"
-    properties:
-      contentTypes:
-        type: array
-        description: |
-          The list of content types that policy should apply to. Cannot be empty. Policy content types could be either of "Messages", "RoomMeta", "SignalMeta".
-          Default is set to ["Messages"] if not specified.
-        items:
-          type: string
-      dictionaryIds:
-        type: array
-        description: List of dictionaries Ids for the policy.
-        items:
-          type: string
-      name:
-        type: string
-        description: Unique name of a policy, max 30 characters. Cannot be empty. All the leading and trailing blank spaces are trimmed.
-      scopes:
-        type: array
-        description: |
-          List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
-          You can apply both scopes if you set it to ["Internal", "External"].
-        items:
-          type: string
-      type:
-        type: string
-        description: Type of policy. Possible values "Block" or "Warn".
-    description: The policy object to use for creating/updating a policy.
-  V1DLPPolicyResponse:
-    type: object
-    properties:
-      data:
-        $ref: '#/definitions/V1DLPPolicy'
-    description: Policy Response
-  V1DLPDictionary:
-    type: object
-    required:
-    - dictionaryMetadata
-    properties:
-      content:
-        $ref: '#/definitions/V1DLPDictionaryContent'
-      dictionaryMetadata:
-        $ref: '#/definitions/V1DLPDictionaryMetadata'
-    description: Dictionary object
-  V1DLPDictionaryContent:
-    type: object
-    properties:
-      data:
-        type: string
-        description: |
-          A comma separated string which contains a lot of keywords/regexes.
-      numKeywords:
-        type: integer
-        format: int32
-        description: Number of Keywords in dictionary
-      md5:
-        type: string
-        description: MD5 value of the content
-    description: Content of a dictionary
-  V1DLPDictionaryMetadataCollectionResponse:
-    type: object
-    properties:
+          description: |
+            Details if event failed to parse for any reason.  The contents of this field may not be useful,
+            depending on the nature of the error. Only present when error occurs.
+        initiator:
+          $ref: '#/components/schemas/V4Initiator'
+        payload:
+          $ref: '#/components/schemas/V4Payload'
+    V4EventList:
+      type: array
       items:
-        type: array
-        description: List of dictionary metadata
+        $ref: '#/components/schemas/V4Event'
+    BaseSignal:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Signal name
+        query:
+          type: string
+          description: |
+            The query used to define this signal. The query is defined as "field:value" pairs combined by the operators
+            "AND" or "OR". Supported fields are (case-insensitive): "author", "hashtag" and "cashtag".
+            MUST contain at least one "hashtag" or "cashtag" definition.
+        visibleOnProfile:
+          type: boolean
+          description: Whether the signal is visible on its creator's profile
+        companyWide:
+          type: boolean
+          description: Whether the signal is a push signal
+    Signal:
+      allOf:
+        - $ref: '#/components/schemas/BaseSignal'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: Signal ID
+            timestamp:
+              type: integer
+              description: Timestamp when the signal was created, in milliseconds since
+                Jan 1 1970
+              format: int64
+            companyWide:
+              type: boolean
+              description: Whether the signal is a push signal
+    SignalList:
+      type: array
+      items:
+        $ref: '#/components/schemas/Signal'
+    ChannelSubscriptionResponse:
+      type: object
+      properties:
+        requestedSubscription:
+          type: integer
+          description: The number of requested userIds to subscribe
+          format: int64
+        successfulSubscription:
+          type: integer
+          description: The number of successful subscriptions done
+          format: int64
+        failedSubscription:
+          type: integer
+          description: The number of subscription failures
+          format: int64
+        subscriptionErrors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChannelSubscriptionError'
+    ChannelSubscriptionError:
+      type: object
+      properties:
+        userId:
+          type: integer
+          description: The userId on which failure happened
+          format: int64
+        code:
+          type: string
+          description: subscription failure code
+        message:
+          type: string
+          description: subscription failure message
+    ChannelSubscriberResponse:
+      type: object
+      properties:
+        offset:
+          type: integer
+          description: The number of subscribers skipped
+          format: int64
+        hasMore:
+          type: boolean
+          description: True if there are more subscribers
+        total:
+          type: integer
+          description: The total number of subscribers
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChannelSubscriber'
+    ChannelSubscriber:
+      type: object
+      properties:
+        subscriptionId:
+          type: string
+        pushed:
+          type: boolean
+          description: True if the subscriber is allowed to unsubscribe
+          default: false
+        owner:
+          type: boolean
+          description: True if the subscriber is the creator
+          default: false
+        subscriberName:
+          type: string
+          description: User display name
+        userId:
+          type: integer
+          description: The user ID of the subscriber
+          format: int64
+        timestamp:
+          type: integer
+          description: Timestamp when the signal was subscribed, in milliseconds since
+            Jan 1 1970
+          format: int64
+    AgentInfo:
+      type: object
+      properties:
+        ipAddress:
+          type: string
+          description: The IP address of the Agent server.
+        hostname:
+          type: string
+          description: The hostname of the Agent server.
+        serverFqdn:
+          type: string
+          description: The fully-qualified domain name of the Agent server. Must be
+            set by the user at startup.
+        version:
+          type: string
+          description: The version of the Agent.
+        url:
+          type: string
+          description: The URL under which the Agent is available.
+        onPrem:
+          type: boolean
+          description: Whether this is an on-prem or cloud installation.
+        mt:
+          type: boolean
+          description: Whether this is a multi tenant instance.
+        commitId:
+          type: string
+          description: The Git commit ID of the running revision.
+    V1DLPPoliciesCollectionResponse:
+      type: object
+      required:
+        - policies
+      properties:
+        policies:
+          type: array
+          description: List of policies
+          items:
+            $ref: '#/components/schemas/V1DLPPolicy'
+        page:
+          type: integer
+          description: Page number of current page
+          format: int32
+        pageCount:
+          type: integer
+          description: Total number of pages available
+          format: int32
+      description: List of policies
+    V1DLPPolicy:
+      required:
+        - contentTypes
+        - name
+        - scopes
+        - dictionaryRefs
+        - type
+      type: object
+      properties:
+        active:
+          type: boolean
+          description: Indicate whether the policy is active or not
+        contentTypes:
+          type: array
+          description: |
+            The list of content types that policy should apply to. Cannot be empty. Policy content types could be either of "Messages", "RoomMeta", "SignalMeta".
+            Default is set to ["Messages"] if not specified.
+          items:
+            type: string
+        creationDate:
+          type: integer
+          description: Creation time of the policy in milliseconds elapsed as of epoch time.
+          format: int64
+        creatorId:
+          type: string
+          description: Numeric userId of the creator
+        dictionaryRefs:
+          type: array
+          description: List of dictionaries.
+          items:
+            $ref: '#/components/schemas/V1DLPDictionaryRef'
+        lastDisabledDate:
+          type: integer
+          description: Recent disable time of the policy in milliseconds elapsed as of epoch time.
+          format: int64
+        lastUpdatedDate:
+          type: integer
+          description: Recent update time of the policy in milliseconds elapsed as of epoch time.
+          format: int64
+        name:
+          type: string
+          description: Unique name of a policy, max 30 characters. Cannot be empty.
+            All the leading and trailing blank spaces are trimmed.
+        policyId:
+          type: string
+          description: Policy Id
+        scopes:
+          type: array
+          description: |
+            List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
+            You can apply both scopes if you set it to ["Internal", "External"].
+          items:
+            type: string
+        type:
+          type: string
+          description: Type of policy. Possible values "Block" or "Warn".
+        version:
+          type: string
+          description: |
+            The version of a dictionary, in format "major.minor". Initial value will set by backend as "1.0" when created.
+            Whenever the dictionary version needs to be changed, the minor version by 1 unless minor == 999, then the major version is increased by 1 until it reaches 999.
+      description: The policy object for expression filter, one policy can have multiple
+        dictionaries
+    V1DLPPolicyRequest:
+      required:
+        - contentTypes
+        - name
+        - scopes
+        - type
+      type: object
+      properties:
+        contentTypes:
+          type: array
+          description: |
+            The list of content types that policy should apply to. Cannot be empty. Policy content types could be either of "Messages", "RoomMeta", "SignalMeta".
+            Default is set to ["Messages"] if not specified.
+          items:
+            type: string
+        dictionaryIds:
+          type: array
+          description: List of dictionaries Ids for the policy.
+          items:
+            type: string
+        name:
+          type: string
+          description: Unique name of a policy, max 30 characters. Cannot be empty.
+            All the leading and trailing blank spaces are trimmed.
+        scopes:
+          type: array
+          description: |
+            List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
+            You can apply both scopes if you set it to ["Internal", "External"].
+          items:
+            type: string
+        type:
+          type: string
+          description: Type of policy. Possible values "Block" or "Warn".
+      description: The policy object to use for creating/updating a policy.
+    V1DLPPolicyResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/V1DLPPolicy'
+      description: Policy Response
+    V1DLPDictionary:
+      required:
+        - dictionaryMetadata
+      type: object
+      properties:
+        content:
+          $ref: '#/components/schemas/V1DLPDictionaryContent'
+        dictionaryMetadata:
+          $ref: '#/components/schemas/V1DLPDictionaryMetadata'
+      description: Dictionary object
+    V1DLPDictionaryContent:
+      type: object
+      properties:
+        data:
+          type: string
+          description: A comma separated string which contains a lot of keywords/regexes.
+        numKeywords:
+          type: integer
+          description: Number of Keywords in dictionary
+          format: int32
+        md5:
+          type: string
+          description: MD5 value of the content
+      description: Content of a dictionary
+    V1DLPDictionaryMetadataCollectionResponse:
+      type: object
+      required:
+        - items
+      properties:
         items:
-          $ref: '#/definitions/V1DLPDictionaryMetadata'
-      page:
-        type: integer
-        format: int32
-        description: Page number of current page
-      pageCount:
-        type: integer
-        format: int32
-        description: Total number of pages available
-    description: List of dictionary metadata.
-  V1DLPDictionaryMetadataResponse:
-    type: object
-    required:
-    - data
-    properties:
-      data:
-        $ref: '#/definitions/V1DLPDictionaryMetadata'
-    description: Dictionary response containing dictionary metadata.
-  V1DLPDictionaryMetadataCreateRequest:
-    type: object
-    required:
-    - name
-    - type
-    properties:
-      name:
-        type: string
-        description: |
-          The name of dictionary
-      type:
-        type: string
-        description: |
-          The type of dictionary, which specify the content is a list of words or a list of regexes.
-          By default set to "Word" if not specified. Possible values - Word, Regex
-    description: Dictionary's metadata (excluding content) to use for dictionary create operations.
-  V1DLPDictionaryMetadataUpdateRequest:
-    type: object
-    required:
-    - name
-    properties:
-      name:
-        type: string
-        description: |
-          The name of dictionary
-    description: Dictionary's metadata (excluding content) to use for dictionary update operations.
-  V1DLPDictionaryMetadata:
-    type: object
-    required:
-    - dictRef
-    - type
-    properties:
-      creationDate:
-        type: integer
-        format: int64
-        description: Creation time of the dictionary in milliseconds elapsed as of epoch time.
-      creatorId:
-        type: string
-        description: Numeric userId of the creator
-      dictRef:
-        $ref: '#/definitions/V1DLPDictionaryRef'
-      lastUpdatedDate:
-        type: integer
-        format: int64
-        description: The recent update time of the dictionary in milliseconds
-      type:
-        type: string
-        description: |
-          The type of dictionary, which specify the content is a list of words or a list of regexes.
-          By default set to "Word" if not specified. Possible values - Word, Regex
-    description: Dictionary's metadata (excluding content)
-  V1DLPDictionaryRef:
-    type: object
-    required:
-    - name
-    properties:
-      dictId:
-        type: string
-        description: Unique dictionary id
-      name:
-        type: string
-        description: Unique name of a dictionary, max 30 characters, with trimmed leading and trailing blank spaces.
-      version:
-        type: string
-        description: |
-          The version of a dictionary, in format "major.minor".
-          Initial value will set by backend as "1.0" when created.
-          Whenever the dictionary version needs to be changed, the minor version by 1 unless minor == 999, then the major version is increased by 1 until it reaches 999.
-    description: Basic information needed to identify a dictionary
-  V1DLPViolationMessageResponse:
-    type: object
-    properties:
-      violations:
-        type: array
-        description: A representation of list of violations due to messages sent by a user of Symphony
-        items:
-          $ref: '#/definitions/V1DLPViolationMessage'
-      nextOffset:
-        type: string
-        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
-  V1DLPViolationStreamResponse:
-    type: object
-    properties:
-      violations:
-        type: array
-        items:
-          # A representation of list of violations due to rooms creation/update sent by a user of Symphony
-          $ref: '#/definitions/V1DLPViolationStream'
-      nextOffset:
-        type: string
-        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
-  V1DLPViolationSignalResponse:
-    type: object
-    properties:
-      violations:
-        type: array
-        description: A representation of list of violations due to signal creation/update sent by a user of Symphony
-        items:
-          $ref: '#/definitions/V1DLPViolationSignal'
-      nextOffset:
-        type: string
-        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
-  V1DLPViolationMessage:
-    type: object
-    properties:
-      violation:
-        # A representation of a violation due to a message sent by a user of Symphony
-        $ref: '#/definitions/V1DLPViolation'
-      message:
-        # Message details when DLP was enforced
-        $ref: '#/definitions/V4Message'
-      diagnostic:
-        type: string
-        description: |
+          type: array
+          description: List of dictionary metadata
+          items:
+            $ref: '#/components/schemas/V1DLPDictionaryMetadata'
+        page:
+          type: integer
+          description: Page number of current page
+          format: int32
+        pageCount:
+          type: integer
+          description: Total number of pages available
+          format: int32
+      description: List of dictionary metadata.
+    V1DLPDictionaryMetadataResponse:
+      required:
+        - data
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/V1DLPDictionaryMetadata'
+      description: Dictionary response containing dictionary metadata.
+    V1DLPDictionaryMetadataCreateRequest:
+      required:
+        - name
+        - type
+      type: object
+      properties:
+        name:
+          type: string
+          description: |
+            The name of dictionary
+        type:
+          type: string
+          description: |
+            The type of dictionary, which specify the content is a list of words or a list of regexes.
+            By default set to "Word" if not specified. Possible values - Word, Regex
+      description: Dictionary's metadata (excluding content) to use for dictionary
+        create operations.
+    V1DLPDictionaryMetadataUpdateRequest:
+      required:
+        - name
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of dictionary
+      description: Dictionary's metadata (excluding content) to use for dictionary
+        update operations.
+    V1DLPDictionaryMetadata:
+      required:
+        - dictRef
+        - type
+      type: object
+      properties:
+        creationDate:
+          type: integer
+          description: Creation time of the dictionary in milliseconds elapsed as
+            of epoch time.
+          format: int64
+        creatorId:
+          type: string
+          description: Numeric userId of the creator
+        dictRef:
+          $ref: '#/components/schemas/V1DLPDictionaryRef'
+        lastUpdatedDate:
+          type: integer
+          description: The recent update time of the dictionary in milliseconds
+          format: int64
+        type:
+          type: string
+          description: |
+            The type of dictionary, which specify the content is a list of words or a list of regexes.
+            By default set to "Word" if not specified. Possible values - Word, Regex
+      description: Dictionary's metadata (excluding content)
+    V1DLPDictionaryRef:
+      required:
+        - name
+      type: object
+      properties:
+        dictId:
+          type: string
+          description: Unique dictionary id
+        name:
+          type: string
+          description: Unique name of a dictionary, max 30 characters, with trimmed
+            leading and trailing blank spaces.
+        version:
+          type: string
+          description: |
+            The version of a dictionary, in format "major.minor".
+            Initial value will set by backend as "1.0" when created.
+            Whenever the dictionary version needs to be changed, the minor version by 1 unless minor == 999, then the major version is increased by 1 until it reaches 999.
+      description: Basic information needed to identify a dictionary
+    V1DLPViolationMessageResponse:
+      type: object
+      required:
+        - violations
+      properties:
+        violations:
+          type: array
+          description: A representation of list of violations due to messages sent
+            by a user of Symphony
+          items:
+            $ref: '#/components/schemas/V1DLPViolationMessage'
+        nextOffset:
+          type: string
+          description: Offset for the next chunk of violations to be submitted in
+            the next request.  Value is null if there are no further violations.
+    V1DLPViolationStreamResponse:
+      type: object
+      required:
+        - violations
+      properties:
+        violations:
+          type: array
+          items:
+            $ref: '#/components/schemas/V1DLPViolationStream'
+        nextOffset:
+          type: string
+          description: Offset for the next chunk of violations to be submitted in
+            the next request.  Value is null if there are no further violations.
+    V1DLPViolationSignalResponse:
+      type: object
+      required:
+        - violations
+      properties:
+        violations:
+          type: array
+          description: A representation of list of violations due to signal creation/update
+            sent by a user of Symphony
+          items:
+            $ref: '#/components/schemas/V1DLPViolationSignal'
+        nextOffset:
+          type: string
+          description: Offset for the next chunk of violations to be submitted in
+            the next request.  Value is null if there are no further violations.
+    V1DLPViolationMessage:
+      type: object
+      properties:
+        violation:
+          $ref: '#/components/schemas/V1DLPViolation'
+        message:
+          $ref: '#/components/schemas/V4Message'
+        diagnostic:
+          type: string
+          description: |
             A diagnostic message containing an error message in the event there are parsing errors.
             May also be present in the case of a successful call if there is useful narrative to return.
-  V1DLPViolationStream:
-    type: object
-    properties:
-      violation:
-        # A representation of a violation due to rooms creation/update sent by a user of Symphony
-        $ref: '#/definitions/V1DLPViolation'
-      stream:
-        # Room details when DLP was enforced
-        $ref: '#/definitions/V1DLPStream'
-  V1DLPViolationSignal:
-    type: object
-    properties:
-      violation:
-        # A representation of a violation due to signal creation/update sent by a user of Symphony
-        $ref: '#/definitions/V1DLPViolation'
-      signal:
-        # Signal details when DLP was enforced
-        $ref: '#/definitions/V1DLPSignal'
-  V1DLPViolation:
-    type: object
-    description: A representation of a violation due to a message sent by a user of Symphony
-    properties:
-      enforcementEventID:
-        type: string
-        description: Enforcement event ID. Unique ID that identifies this enforcement.
-      entityID:
-        type: string
-        description: Entity ID is the content Id of the violation, for example, for messages, its the Id of the message
-      createTime:
-        type: integer
-        format: int64
-        description: Timestamp of the violation in milliseconds since Jan 1 1970
-      lastModified:
-        type: integer
-        format: int64
-        description: Timestamp of the last modification of violation in milliseconds since Jan 1 1970
-      requesterId:
-        type: integer
-        format: int64
-        description: Id of the requester responsible for the message/stream/signal
-      matchedPolicies:
-        # Policies that matched when DLP was enforced and the list of matched terms decrypted.
-        $ref: '#/definitions/V1DLPMatchedPolicyList'
-      action:
-        type: string
-        description: action taken such as BLOCK or WARN.  See outcome for a more detailed description of the outcome this action.
-      outcome:
-        # Detailed outcome of the DLP enforcement such as REJECTED_VIOLATION, ACCEPTED_WARNING, ACCEPTED_LEGACY_CLIENT etc.
-        $ref: '#/definitions/V1DLPOutcome'
-      version:
-        type: string
-        description: Version of application which processed the message and produced this violation.
-      ignoreDLPwarning:
+    V1DLPViolationStream:
+      type: object
+      properties:
+        violation:
+          $ref: '#/components/schemas/V1DLPViolation'
+        stream:
+          $ref: '#/components/schemas/V1DLPStream'
+    V1DLPViolationSignal:
+      type: object
+      properties:
+        violation:
+          $ref: '#/components/schemas/V1DLPViolation'
+        signal:
+          $ref: '#/components/schemas/V1DLPSignal'
+    V1DLPViolation:
+      type: object
+      properties:
+        enforcementEventID:
+          type: string
+          description: Enforcement event ID. Unique ID that identifies this enforcement.
+        entityID:
+          type: string
+          description: Entity ID is the content Id of the violation, for example,
+            for messages, its the Id of the message
+        createTime:
+          type: integer
+          description: Timestamp of the violation in milliseconds since Jan 1 1970
+          format: int64
+        lastModified:
+          type: integer
+          description: Timestamp of the last modification of violation in milliseconds
+            since Jan 1 1970
+          format: int64
+        requesterId:
+          type: integer
+          description: Id of the requester responsible for the message/stream/signal
+          format: int64
+        matchedPolicies:
+          $ref: '#/components/schemas/V1DLPMatchedPolicyList'
+        action:
+          type: string
+          description: action taken such as BLOCK or WARN.  See outcome for a more
+            detailed description of the outcome this action.
+        outcome:
+          $ref: '#/components/schemas/V1DLPOutcome'
+        contentType:
+          $ref: '#/components/schemas/V1DLPContentType'
+        version:
+          type: string
+          description: Version of application which processed the message and produced
+            this violation.
+        ignoreDLPwarning:
           type: boolean
           description: Did the user chose to ignore DLP warning that was presented?
-  V1DLPMatchedPolicyList:
-    type: array
-    items:
-      $ref: '#/definitions/V1DLPMatchedPolicy'
-    description: List of policies that matched the violation.
-  V1DLPMatchedPolicy:
-    type: object
-    description: A representation of policy that matched the violation with a list of matched keywords in the policy
-    properties:
-      id:
-        type: string
-        description: Id of the policy
-      version:
-        type: string
-        description: Version of the policy
-      policyName:
-        type: string
-        description: Name of the policy
-      type:
-        type: string
-        description: Whether BLOCK or WARN
-      terms:
-        type: string
-        description: List of decrypted matched keywords in the policy
-      diagnostic:
-        type: string
-        description: |
+      description: A representation of a violation due to a message sent by a user
+        of Symphony
+    V1DLPMatchedPolicyList:
+      type: array
+      description: List of policies that matched the violation.
+      items:
+        $ref: '#/components/schemas/V1DLPMatchedPolicy'
+    V1DLPMatchedPolicy:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Id of the policy
+        version:
+          type: string
+          description: Version of the policy
+        policyName:
+          type: string
+          description: Name of the policy
+        type:
+          type: string
+          description: Whether BLOCK or WARN
+        terms:
+          type: string
+          description: List of decrypted matched keywords in the policy
+        diagnostic:
+          type: string
+          description: |
             A diagnostic message containing an error message in the event that the
             decryption of terms failed. May also be present in the case of a successful
             call if there is useful narrative to return.
-  V1DLPOutcome:
-    type: object
-    description: A representation of outcome of DLP message/stream/signal sent by a user of Symphony
-    properties:
-      type:
-        type: string
-        description: Outcome of DLP enforcement
-  V1DLPContentType:
-    type: object
-    description: A representation of content type of message sent by a user of Symphony (message/stream/signal)
-    properties:
-      type:
-        type: string
-        description: content type
-  V1DLPStream:
-    type: object
-    description: Room details in the context of violation.
-    properties:
-        name:
-          type: string
-          description:  Name of the Stream/Room.
-        creatorPrettyName:
-          type: string
-          description:  Name of the creator of the Room.
-        publicRoom:
-          type: boolean
-          description:  Is this a public room?
-        crossPod:
-          type: boolean
-          description:  Is this a cross pod scenario?
-        allowExternal:
-          type: boolean
-          description:  Is external messaging allowed
-        creatorId:
-          type: string
-          description:  Id of the creator of the Room.
-        roomDescription:
-          type: string
-          description:  Description of the Room.
-        streamId:
-          type: string
-          description:  ThreadId of the Room.
-        state:
-          type: string
-          description:  State of the Room (example CREATED etc)
+      description: A representation of policy that matched the violation with a list
+        of matched keywords in the policy
+    V1DLPOutcome:
+      type: object
+      properties:
         type:
           type: string
-          description:  Type of the Room (example ROOM (or IM or Wall))
-        lastDisabled:
-          type: integer
-          format: int64
-          description: Timestamp of last time the room is Disabled
-        memberAddUserEnabled:
-          type: boolean
-          description:  Is memberAddUserEnabled
-        active:
-          type: boolean
-          description:  Is Room Active
-        discoverable:
-          type: boolean
-          description:  Is Room discoverable
-        readOnly:
-          type: boolean
-          description:  Is Room read-only
-        copyDisabled:
-          type: boolean
-          description:  Is Room copyDisabled
-        externalOwned:
-          type: boolean
-          description:  Is Room externalOwned
-        sendMessageDisabled:
-          type: boolean
-          description:  Is sendMessage Disabled for this Room
-        moderated:
-          type: boolean
-          description:  Is room moderated
-        shareHistoryEnabled:
-          type: boolean
-          description:  Is room shareHistoryEnabled
-        diagnostic:
+          description: Outcome of DLP enforcement
+      description: A representation of outcome of DLP message/stream/signal sent by
+        a user of Symphony
+    V1DLPContentType:
+      type: object
+      properties:
+        type:
           type: string
-          description: |
-              A diagnostic message containing an error message in the event that the
-              stream retrieval failed. May also be present in the case of a successful
-              call if there is useful narrative to return.
-  V1DLPSignal:
-    type: object
-    description: Signal details
-    properties:
+          description: content type
+      description: A representation of content type of message sent by a user of Symphony
+        (message/stream/signal)
+    V1DLPStream:
+      type: object
+      properties:
         name:
           type: string
-          description:  Name of the Signal
-        rules:
+          description: Name of the Stream/Room.
+        creatorPrettyName:
           type: string
-          description:  Signal rules decrypted.
+          description: Name of the creator of the Room.
+        publicRoom:
+          type: boolean
+          description: Is this a public room?
+        crossPod:
+          type: boolean
+          description: Is this a cross pod scenario?
+        allowExternal:
+          type: boolean
+          description: Is external messaging allowed
+        creatorId:
+          type: string
+          description: Id of the creator of the Room.
+        roomDescription:
+          type: string
+          description: Description of the Room.
+        streamId:
+          type: string
+          description: ThreadId of the Room.
+        state:
+          type: string
+          description: State of the Room (example CREATED etc)
+        type:
+          type: string
+          description: Type of the Room (example ROOM (or IM or Wall))
+        lastDisabled:
+          type: integer
+          description: Timestamp of last time the room is Disabled
+          format: int64
+        memberAddUserEnabled:
+          type: boolean
+          description: Is memberAddUserEnabled
+        active:
+          type: boolean
+          description: Is Room Active
+        discoverable:
+          type: boolean
+          description: Is Room discoverable
+        readOnly:
+          type: boolean
+          description: Is Room read-only
+        copyDisabled:
+          type: boolean
+          description: Is Room copyDisabled
+        externalOwned:
+          type: boolean
+          description: Is Room externalOwned
+        sendMessageDisabled:
+          type: boolean
+          description: Is sendMessage Disabled for this Room
+        moderated:
+          type: boolean
+          description: Is room moderated
+        shareHistoryEnabled:
+          type: boolean
+          description: Is room shareHistoryEnabled
         diagnostic:
           type: string
           description: |
-              A diagnostic message containing an error message in the event that the
-              signal decryption failed. May also be present in the case of a successful
-              call if there is useful narrative to return.
-
-#
-# V3 Policies definitions
-#
-  V3DLPPolicyRequest:
-    type: object
-    required:
-      - "name"
-      - "scopes"
-      - "appliesTo"
-    properties:
-      name:
-        type: string
-        description: |
-          Unique name of a policy, max 30 characters. Cannot be empty. All the leading and trailing blank spaces are trimmed.
-      scopes:
-        type: array
-        description: |
-          List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
-          You can apply both scopes if you set it to ["Internal", "External"].
-        items:
+            A diagnostic message containing an error message in the event that the
+            stream retrieval failed. May also be present in the case of a successful
+            call if there is useful narrative to return.
+      description: Room details in the context of violation.
+    V1DLPSignal:
+      type: object
+      properties:
+        name:
           type: string
-      appliesTo:
-        type: array
-        items:
-          $ref: '#/definitions/V3DLPPolicyAppliesTo'
-    description: Request to be used to get policies.
-  V3DLPPolicy:
-    type: object
-    properties:
-      id:
-        type: string
-        description: Unique identifier for policy.
-      policyId:
-        type: string
-        description: Policy Id.
-      version:
-        type: string
-        description: |
-          The version of the policy, in format "major.minor". Initial value will set by backend as "3.0" when created.
-          Whenever the policy version needs to be changed, the minor version by 1 unless minor == 999,
-          then the major version is increased by 1 until it reaches 999.
-      name:
-        type: string
-        description: |
-          Unique name of policy, max 30 characters. Cannot be empty. All the leading and trailing blank spaces are trimmed.
-      creatorId:
-        type: integer
-        format: int64
-        description: Numeric userId of the creator.
-      scopes:
-        type: array
-        description: |
-          List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
-          You can apply both scopes if you set it to ["Internal", "External"].
-        items:
+          description: Name of the Signal
+        rules:
           type: string
-      appliesTo:
-        type: array
-        items:
-          $ref: '#/definitions/V3DLPPolicyAppliesTo'
-      active:
-        type: boolean
-        description: Indicate whether the policy is active or not.
-      deleted:
-        type: boolean
-        description: Indicate whether the policy is deleted or not.
-      creationDate:
-        type: integer
-        format: int64
-        description: |
-          Creation time of the policy in milliseconds elapsed as of epoch time.
-      lastUpdatedDate:
-        type: integer
-        format: int64
-        description: |
-          Recent update time of the policy in milliseconds elapsed as of epoch.
-          time.
-      lastDisabledDate:
-        type: integer
-        format: int64
-        description: |
-          Recent disable time of the policy in milliseconds elapsed as of epoch.
-          time.
-      systemPolicy:
-        type: boolean
-    description : |
-      A policy is the main entity of V3 policy/rule system. It is responsible to define rules and add scope constraints to the engine.
-  V3DLPRule:
-    type: object
-    required:
-     - "type"
-     - "name"
-    properties:
-      id:
-        type: string
-      type:
-        type: string
-        description: Type of a rule used by policy. Can be ["UNKNOWN", "TEXT_MATCH", "FILE_EXTENSION", "FILE_SIZE", "FILE_PASSWORD", "FILE_CLASSIFIER"].
-      name:
-        type: string
-        description: Name for rule.
-      textMatchConfig:
-        $ref: '#/definitions/V3DLPTextMatchConfig'
-      fileSizeConfig:
-        $ref: '#/definitions/V3DLPFileSizeConfig'
-      fileExtensionConfig:
-        $ref: '#/definitions/V3DLPFileExtensionConfig'
-      filePasswordConfig:
-        $ref: '#/definitions/V3DLPFilePasswordConfig'
-      fileClassifierConfig:
-        $ref: '#/definitions/V3DLPFileClassifierConfig'
-    description: |
-     A Rule defines the actual matching specification for policies. It holds a type and a configuration
-     for the rule, these properties should be used to build the corresponding matching implementation.
-     Only one of the configuration property should be set [textMatchConfig, fileSizeConfig, fileExtensionConfig, filePasswordConfig, fileClassifierConfig].
-  V3DLPFilePasswordConfig:
-    type: object
-    required:
-      - "applicableFileTypes"
-      - "matchCriteria"
-    properties:
-        applicableFileTypes:
+          description: Signal rules decrypted.
+        diagnostic:
+          type: string
+          description: |
+            A diagnostic message containing an error message in the event that the
+            signal decryption failed. May also be present in the case of a successful
+            call if there is useful narrative to return.
+      description: Signal details
+    V3DLPPolicyRequest:
+      required:
+        - appliesTo
+        - name
+        - scopes
+      type: object
+      properties:
+        name:
+          type: string
+          description: |
+            Unique name of a policy, max 30 characters. Cannot be empty. All the leading and trailing blank spaces are trimmed.
+        scopes:
           type: array
+          description: |
+            List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
+            You can apply both scopes if you set it to ["Internal", "External"].
           items:
             type: string
-          description: File types that can be applied. Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
+        appliesTo:
+          type: array
+          items:
+            $ref: '#/components/schemas/V3DLPPolicyAppliesTo'
+      description: Request to be used to get policies.
+    V3DLPPolicy:
+      type: object
+      required:
+        - appliesTo
+      properties:
+        id:
+          type: string
+          description: Unique identifier for policy.
+        policyId:
+          type: string
+          description: Policy Id.
+        version:
+          type: string
+          description: |
+            The version of the policy, in format "major.minor". Initial value will set by backend as "3.0" when created.
+            Whenever the policy version needs to be changed, the minor version by 1 unless minor == 999,
+            then the major version is increased by 1 until it reaches 999.
+        name:
+          type: string
+          description: |
+            Unique name of policy, max 30 characters. Cannot be empty. All the leading and trailing blank spaces are trimmed.
+        creatorId:
+          type: integer
+          description: Numeric userId of the creator.
+          format: int64
+        scopes:
+          type: array
+          description: |
+            List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
+            You can apply both scopes if you set it to ["Internal", "External"].
+          items:
+            type: string
+        appliesTo:
+          type: array
+          items:
+            $ref: '#/components/schemas/V3DLPPolicyAppliesTo'
+        active:
+          type: boolean
+          description: Indicate whether the policy is active or not.
+        deleted:
+          type: boolean
+          description: Indicate whether the policy is deleted or not.
+        creationDate:
+          type: integer
+          description: Creation time of the policy in milliseconds elapsed as of epoch time.
+          format: int64
+        lastUpdatedDate:
+          type: integer
+          description: Recent update time of the policy in milliseconds elapsed as of epoch time.
+          format: int64
+        lastDisabledDate:
+          type: integer
+          description: Recent disable time of the policy in milliseconds elapsed as of epoch time.
+          format: int64
+        systemPolicy:
+          type: boolean
+      description: |
+        A policy is the main entity of V3 policy/rule system. It is responsible to define rules and add scope constraints to the engine.
+    V3DLPRule:
+      required:
+        - name
+        - type
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          description: Type of a rule used by policy. Can be ["UNKNOWN", "TEXT_MATCH",
+            "FILE_EXTENSION", "FILE_SIZE", "FILE_PASSWORD", "FILE_CLASSIFIER"].
+        name:
+          type: string
+          description: Name for rule.
+        textMatchConfig:
+          $ref: '#/components/schemas/V3DLPTextMatchConfig'
+        fileSizeConfig:
+          $ref: '#/components/schemas/V3DLPFileSizeConfig'
+        fileExtensionConfig:
+          $ref: '#/components/schemas/V3DLPFileExtensionConfig'
+        filePasswordConfig:
+          $ref: '#/components/schemas/V3DLPFilePasswordConfig'
+        fileClassifierConfig:
+          $ref: '#/components/schemas/V3DLPFileClassifierConfig'
+      description: |
+        A Rule defines the actual matching specification for policies. It holds a type and a configuration
+        for the rule, these properties should be used to build the corresponding matching implementation.
+        Only one of the configuration property should be set [textMatchConfig, fileSizeConfig, fileExtensionConfig, filePasswordConfig, fileClassifierConfig].
+    V3DLPFilePasswordConfig:
+      required:
+        - applicableFileTypes
+        - matchCriteria
+      type: object
+      properties:
+        applicableFileTypes:
+          type: array
+          description: File types that can be applied. Can be ["PDF", "WORD", "EXCEL",
+            "POWERPOINT", "ZIP", "CSV", "TXT"].
+          items:
+            type: string
         matchCriteria:
           type: string
           description: |
-           Based on the criteria, whether a file is password protected or not means a match.
-           Can be ["PASSWORD_PROTECTED", "NOT_PASSWORD_PROTECTED"]. The default is "NOT_PASSWORD_PROTECTED".
-    description: Password protected detection config for files that are password protected or not.
-  V3DLPFileExtensionConfig:
-    type: object
-    required:
-      - "allowLists"
-    properties:
-      allowLists:
-        type: array
-        items:
+            Based on the criteria, whether a file is password protected or not means a match.
+            Can be ["PASSWORD_PROTECTED", "NOT_PASSWORD_PROTECTED"]. The default is "NOT_PASSWORD_PROTECTED".
+      description: Password protected detection config for files that are password
+        protected or not.
+    V3DLPFileExtensionConfig:
+      required:
+        - allowLists
+        - blockLists
+      type: object
+      properties:
+        allowLists:
+          type: array
+          description: File extensions that are allowed.
+          items:
+            type: string
+        blockLists:
+          type: array
+          description: File extensions that are blocked.
+          items:
+            type: string
+      description: Extension detection config for allowed and blocked types of file
+        extensions.
+    V3DLPFileSizeConfig:
+      type: object
+      properties:
+        sizeLimit:
+          type: integer
+          format: int32
+      description: File size config defines maximum allowed size of file. Default max size limit is 20 MB.
+    V3DLPTextMatchConfig:
+      type: object
+      required:
+        - dictionaries
+        - applicableFileTypes
+      properties:
+        dictionaries:
+          type: array
+          items:
+            $ref: '#/components/schemas/V3DLPDictionaryMeta'
+        countUniqueOccurrences:
+          type: integer
+          format: int32
+        applicableFileTypes:
+          type: array
+          description: |
+            File types must be applied only for rule type "FileContent", otherwise must be empty.
+            Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
+          items:
+            type: string
+      description: |
+        This is a configuration that can be used to match text or regex.
+        Configuration that can be used by a rule. This is a configuration that can be used to match text or regex.
+        This configuration also corresponds to V2 TextMatch/RegexMatch of dictionaries.
+    V3DLPDictionaryMeta:
+      required:
+        - dictId
+        - name
+        - version
+      type: object
+      properties:
+        dictId:
           type: string
-        description: File extensions that are allowed.
-      blockLists:
-        type: array
-        items:
+        version:
           type: string
-        description: File extensions that are blocked.
-    description: Extension detection config for allowed and blocked types of file extensions.
-  V3DLPFileSizeConfig:
-    type: object
-    properties:
-      sizeLimit:
-        type: integer
-        format: int32
-    description: File size config defines maximum allowed size of file. Default max size limit is 20 MB.
-  V3DLPTextMatchConfig:
-    type: object
-    properties:
-      dictionaries:
-        type: array
-        items:
-         $ref: '#/definitions/V3DLPDictionaryMeta'
-      countUniqueOccurrences:
-        type: integer
-        format: int32
-      applicableFileTypes:
-        type: array
-        items:
-         type: string
-        description: |
-          File types must be applied only for rule type "FileContent", otherwise must be empty.
-          Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
-    description: |
-      This is a configuration that can be used to match text or regex.
-      Configuration that can be used by a rule. This is a configuration that can be used to match text or regex.
-      This configuration also corresponds to V2 TextMatch/RegexMatch of dictionaries.
-  V3DLPDictionaryMeta:
-    type: object
-    required:
-      - "dictId"
-      - "version"
-      - "name"
-    properties:
-      dictId:
-        type: string
-      version:
-        type: string
-      name:
-        type: string
-    description: Identity of a dictionary.
-  V3DLPFileClassifierConfig:
-    type: object
-    required:
-      - "classifiers"
-      - "applicableFileTypes"
-    properties:
-      classifiers:
-        type: object
-        additionalProperties:
-         type: string
-        description: |
-         Classifier is defined as a Key and its Value: e.g.: "classification": "Internal".
-         Name and value can contain UTF-8 characters. Neither the name nor value cannot be left empty.
-         Maximum 30 characters for the name and value, case insensitive.
-         If files contains k-v pairs in the classifers map, it means a match. Maximum 30 classifiers per policy.
-      applicableFileTypes:
-        type: array
-        items:
-         type: string
-        description: |
-          File types that can be applied. Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
-  V3DLPPolicyAppliesTo:
-    type: object
-    required:
-      - "dataType"
-      - "action"
-      - "rules"
-    properties:
-      dataType:
-        type: string
-        description: |
-          The list of data types that policy should apply to. Can't be empty.
-          Can be ["Messages","RoomMeta", "SignalMeta", "FileContent", "FileMeta"].
-      action:
-        type: string
-        description: |
-          Action to be taken on violation detection.
-          Can be ["Block", "Warn", "LogOnly"]. The default is "LogOnly".
-      rules:
-        type: array
-        items:
-          $ref: '#/definitions/V3DLPRule'
-  V3DLPPolicyResponse:
-    type: object
-    properties:
-      data:
-        $ref: '#/definitions/V3DLPPolicy'
-    description: Policy Response.
-  V3DLPPoliciesCollectionResponse:
-    type: object
-    properties:
-      policies:
-        type: array
-        description: List of policies.
-        items:
-          $ref: '#/definitions/V3DLPPolicy'
-      page:
-        type: integer
-        format: int32
-        description: The starting page for pagination.
-      size:
-        type: integer
-        format: int32
-        description: Size of policies displayed per page.
-      pageCount:
-        type: integer
-        format: int32
-        description: Total number of pages available.
-    description: List of policies.
-  V3DLPViolationMessageResponse:
-    type: object
-    properties:
-      violations:
-        type: array
-        description: A representation of list of violations due to messages sent by a user of Symphony
-        items:
-          $ref: '#/definitions/V3DLPViolationMessage'
-      nextOffset:
-        type: string
-        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
-  V3DLPViolationStreamResponse:
-    type: object
-    properties:
-      violations:
-        type: array
-        items:
-          # A representation of list of violations due to rooms creation/update sent by a user of Symphony
-          $ref: '#/definitions/V3DLPViolationStream'
-      nextOffset:
-        type: string
-        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
-  V3DLPViolationSignalResponse:
-    type: object
-    properties:
-      violations:
-        type: array
-        description: A representation of list of violations due to signal creation/update sent by a user of Symphony
-        items:
-          $ref: '#/definitions/V3DLPViolationSignal'
-      nextOffset:
-        type: string
-        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
-  V3DLPViolationMessage:
-    type: object
-    properties:
-      violation:
-        # A representation of a violation due to a message sent by a user of Symphony
-        $ref: '#/definitions/V3DLPViolation'
-      message:
-        # Message details when DLP was enforced
-        $ref: '#/definitions/V4Message'
-      sharedMessage:
-              description: Shared message details if present in message.
-              $ref: '#/definitions/V4Message'
-      diagnostic:
-        type: string
-        description: |
-          A diagnostic message containing an error message in the event there are parsing errors.
-          May also be present in the case of a successful call if there is useful narrative to return.
-  V3DLPViolationStream:
-    type: object
-    properties:
-      violation:
-        # A representation of a violation due to rooms creation/update sent by a user of Symphony
-        $ref: '#/definitions/V3DLPViolation'
-      stream:
-        # Room details when DLP was enforced
-        $ref: '#/definitions/V1DLPStream'
-  V3DLPViolationSignal:
-    type: object
-    properties:
-      violation:
-        # A representation of a violation due to signal creation/update sent by a user of Symphony
-        $ref: '#/definitions/V3DLPViolation'
-      signal:
-        # Signal details when DLP was enforced
-        $ref: '#/definitions/V1DLPSignal'
-  V3DLPViolation:
-    type: object
-    description: A representation of a violation due to an event created by a user of Symphony
-    properties:
-      enforcementEventID:
-        type: string
-        description: Enforcement event ID. Unique ID that identifies this enforcement.
-      entityID:
-        type: string
-        description: Entity ID is the content Id of the violation, for example, for messages, its the Id of the message
-      createTime:
-        type: integer
-        format: int64
-        description: Timestamp of the violation in milliseconds since Jan 1 1970
-      lastModified:
-        type: integer
-        format: int64
-        description: Timestamp of the last modification of violation in milliseconds since Jan 1 1970
-      requesterId:
-        type: integer
-        format: int64
-        description: Id of the requester responsible for the message/stream/signal
-      details:
-        type: array
-        description: JSON representation of the details of the violation.
-        items:
+        name:
+          type: string
+      description: Identity of a dictionary.
+    V3DLPFileClassifierConfig:
+      required:
+        - applicableFileTypes
+        - classifiers
+      type: object
+      properties:
+        classifiers:
           type: object
-      action:
-        type: string
-        description: action taken such as BLOCK or WARN.  See outcome for a more detailed description of the outcome this action.
-      outcome:
-        # Detailed outcome of the DLP enforcement such as REJECTED_VIOLATION, ACCEPTED_WARNING, ACCEPTED_LEGACY_CLIENT etc.
-        $ref: '#/definitions/V1DLPOutcome'
-      version:
-        type: string
-        description: Version of application which processed the message and produced this violation.
-      ignoreDLPwarning:
+          additionalProperties:
+            type: string
+          description: |
+            Classifier is defined as a Key and its Value: e.g.: "classification": "Internal".
+            Name and value can contain UTF-8 characters. Neither the name nor value cannot be left empty.
+            Maximum 30 characters for the name and value, case insensitive.
+            If files contains k-v pairs in the classifers map, it means a match. Maximum 30 classifiers per policy.
+        applicableFileTypes:
+          type: array
+          description: File types that can be applied. Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
+          items:
+            type: string
+    V3DLPPolicyAppliesTo:
+      required:
+        - action
+        - dataType
+        - rules
+      type: object
+      properties:
+        dataType:
+          type: string
+          description: |
+            The list of data types that policy should apply to. Can't be empty.
+            Can be ["Messages","RoomMeta", "SignalMeta", "FileContent", "FileMeta"].
+        action:
+          type: string
+          description: |
+            Action to be taken on violation detection.
+            Can be ["Block", "Warn", "LogOnly"]. The default is "LogOnly".
+        rules:
+          type: array
+          items:
+            $ref: '#/components/schemas/V3DLPRule'
+    V3DLPPolicyResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/V3DLPPolicy'
+      description: Policy Response.
+    V3DLPPoliciesCollectionResponse:
+      type: object
+      required:
+        - policies
+      properties:
+        policies:
+          type: array
+          description: List of policies.
+          items:
+            $ref: '#/components/schemas/V3DLPPolicy'
+        page:
+          type: integer
+          description: The starting page for pagination.
+          format: int32
+        size:
+          type: integer
+          description: Size of policies displayed per page.
+          format: int32
+        pageCount:
+          type: integer
+          description: Total number of pages available.
+          format: int32
+      description: List of policies.
+    V3DLPViolationMessageResponse:
+      type: object
+      required:
+        - violations
+      properties:
+        violations:
+          type: array
+          description: A representation of list of violations due to messages sent
+            by a user of Symphony
+          items:
+            $ref: '#/components/schemas/V3DLPViolationMessage'
+        nextOffset:
+          type: string
+          description: |
+            Offset for the next chunk of violations to be submitted in the next request. 
+            Value is null if there are no further violations.
+    V3DLPViolationStreamResponse:
+      type: object
+      required:
+        - violations
+      properties:
+        violations:
+          type: array
+          items:
+            $ref: '#/components/schemas/V3DLPViolationStream'
+        nextOffset:
+          type: string
+          description: |
+            Offset for the next chunk of violations to be submitted in the next request.
+            Value is null if there are no further violations.
+    V3DLPViolationSignalResponse:
+      type: object
+      required:
+        - violations
+      properties:
+        violations:
+          type: array
+          description: A representation of list of violations due to signal creation/update sent by a user of Symphony
+          items:
+            $ref: '#/components/schemas/V3DLPViolationSignal'
+        nextOffset:
+          type: string
+          description: |
+            Offset for the next chunk of violations to be submitted in the next request.
+            Value is null if there are no further violations.
+    V3DLPViolationMessage:
+      type: object
+      properties:
+        violation:
+          $ref: '#/components/schemas/V3DLPViolation'
+        message:
+          $ref: '#/components/schemas/V4Message'
+        sharedMessage:
+          $ref: '#/components/schemas/V4Message'
+        diagnostic:
+          type: string
+          description: |
+            A diagnostic message containing an error message in the event there are parsing errors.
+            May also be present in the case of a successful call if there is useful narrative to return.
+    V3DLPViolationStream:
+      type: object
+      properties:
+        violation:
+          $ref: '#/components/schemas/V3DLPViolation'
+        stream:
+          $ref: '#/components/schemas/V1DLPStream'
+    V3DLPViolationSignal:
+      type: object
+      properties:
+        violation:
+          $ref: '#/components/schemas/V3DLPViolation'
+        signal:
+          $ref: '#/components/schemas/V1DLPSignal'
+    V3DLPViolation:
+      type: object
+      properties:
+        enforcementEventID:
+          type: string
+          description: Enforcement event ID. Unique ID that identifies this enforcement.
+        entityID:
+          type: string
+          description: Entity ID is the content Id of the violation. For example, for messages it's the Id of the message
+        createTime:
+          type: integer
+          description: Timestamp of the violation in milliseconds since Jan 1 1970
+          format: int64
+        lastModified:
+          type: integer
+          description: Timestamp of the last modification of violation in milliseconds
+            since Jan 1 1970
+          format: int64
+        requesterId:
+          type: integer
+          description: Id of the requester responsible for the message/stream/signal
+          format: int64
+        details:
+          type: array
+          description: JSON representation of the details of the violation.
+          items:
+            type: object
+        action:
+          type: string
+          description: action taken such as BLOCK or WARN.  See outcome for a more detailed description of the outcome this action.
+        outcome:
+          $ref: '#/components/schemas/V1DLPOutcome'
+        version:
+          type: string
+          description: Version of application which processed the message and produced
+            this violation.
+        ignoreDLPwarning:
           type: boolean
           description: Did the user chose to ignore DLP warning that was presented?
-  Pagination:
-    type: object
-    required:
-      - cursors
-    properties:
-      cursors:
-        type: object
-        properties:
-          before:
-            type: string
-            description: |
-              This is the opaque url-safe string that points to the start of the page of data
-              that has been returned.
-            example: "MTAxNTExOTQ1MjAwNzI5NDE="
-          after:
-            type: string
-            description: |
-              This is the opaque url-safe string that points to the end of the page of data
-              that has been returned.
-            example: "NDMyNzQyODI3OTQw"
-      previous:
-        type: string
-        description: |
-          API endpoint that will return the previous page of data. If not included, this is
-          the first page of data.
-        example: "https://tenantapi.d.isym.io/v1/tenantinfo?limit=25&before=MTAxNTExOTQ1MjAwNzI5NDE="
-      next:
-        type: string
-        description: |
-          API endpoint that will return the next page of data. If not included, this is the
-          last page of data. Due to how pagination works with visibility and privacy, it is
-          possible that a page may be empty but contain a 'next' paging link. Stop paging when
-          the 'next' link no longer appears.
-        example: "https://tenantapi.d.isym.io/v1/tenantinfo?limit=25&after=NDMyNzQyODI3OTQw"
-  V1AuditTrailInitiatorResponse:
-    description: |
-      Audit Trail Initiator object response.
-      The attributes may vary according to the action.
-      There are different types of action and each action could have specific attributes.
-    type: object
-    properties:
-      action:
-        description: The audit trail action that has peformed
-        type: string
-      actionName:
-        description: The audit trail action name that has peformed
-        type: string
-      timestamp:
-        description: The timestamp when the action has occurred
-        type: string
-      initiatorId:
-        description: The user's id that has performed the action
-        type: string
-      initiatorUsername:
-        description: The username that has performed the action
-        type: string
-      initiatorEmailAddress:
-        description: The user's e-mail address that has performed the action
-        type: string
-    additionalProperties: true
-  V1AuditTrailInitiatorList:
-    type: object
-    properties:
-      items:
-        type: array
-        items:
-          $ref: '#/definitions/V1AuditTrailInitiatorResponse'
-      pagination:
-        type: object
-        $ref: "#/definitions/Pagination"
-  V5Datafeed:
-    type: object
-    properties:
-      id:
-        type: string
-        description: ID of the datafeed
-      createdAt:
-        type: integer
-        format: int64
-        description: Datafeed creation timestamp
-    description: Container for the feed ID
-    example:
-      id: '8e7c8672-220...'
-  V5DatafeedCreateBody:
-    type: object
-    properties:
-      tag:
-        type: string
-        maxLength: 100
-        description: A unique identifier to ensure uniqueness of the datafeed.
-  AckId:
-    description: An object containing the ackId (and parameters) associated with events that the
-      client has received through an individual feed.
-    type: object
-    properties:
-      ackId:
-        type: string
-        description: A unique id for events that can be deleted from a client's. Empty for the first read. If set to null or missing, it will be considered empty.
-          feed.
-      updatePresence:
-        type: boolean
-        default: true
-        description: Set to false to avoid updating the user's presence when reading events. Default is true.
-  V5EventList:
-    type: object
-    properties:
-      events:
-        type: array
-        items:
-          $ref: '#/definitions/V4Event'
-      ackId:
-        type: string
-        description: The ackId which acknowledges that the current batch of messages have been successfully received by the client
-  V5EventsReadBody:
-    type: object
-    properties:
-      type:
-        type: string
-        description: type of the feed. Allowed values are "fanout" and "datahose"
-      tag:
-        type: string
-        minLength: 1
-        maxLength: 80
-        description: A unique identifier to ensure uniqueness of the datafeed.
-      eventTypes:
-        type: array
-        description: |
-          At least one value is required if the type of feed is "datahose". Values must be a valid Real-Time Event type, i.e. one of:
-          * MESSAGESENT
-          * MESSAGESUPPRESSED
-          * SYMPHONYELEMENTSACTION
-          * SHAREDPOST
-          * INSTANTMESSAGECREATED
-          * ROOMCREATED
-          * ROOMUPDATED
-          * ROOMDEACTIVATED
-          * ROOMREACTIVATED
-          * USERREQUESTEDTOJOINROOM
-          * USERJOINEDROOM
-          * USERLEFTROOM
-          * ROOMMEMBERPROMOTEDTOOWNER
-          * ROOMMEMBERDEMOTEDFROMOWNER
-          * CONNECTIONREQUESTED
-          * CONNECTIONACCEPTED
-        items:
+      description: A representation of a violation due to an event created by a user
+        of Symphony
+    Pagination:
+      required:
+        - cursors
+      type: object
+      properties:
+        cursors:
+          type: object
+          properties:
+            before:
+              type: string
+              description: |
+                This is the opaque url-safe string that points to the start of the page of data
+                that has been returned.
+              example: MTAxNTExOTQ1MjAwNzI5NDE=
+            after:
+              type: string
+              description: |
+                This is the opaque url-safe string that points to the end of the page of data
+                that has been returned.
+              example: NDMyNzQyODI3OTQw
+        previous:
           type: string
-        x-since: 22.7
-      ackId:
-        type: string
-        description: should be empty for the first call, acknowledges that the current batch of messages have been successfully received by the client.
-      updatePresence:
-        type: boolean
-        description: whether to update the presence status of the account to AVAILABLE when calling the endpoint. Default value is true.
-    required:
-      - type
-      - tag
-  V3Health:
+          description: |
+            API endpoint that will return the previous page of data. If not included, this is
+            the first page of data.
+          example: https://tenantapi.d.isym.io/v1/tenantinfo?limit=25&before=MTAxNTExOTQ1MjAwNzI5NDE=
+        next:
+          type: string
+          description: |
+            API endpoint that will return the next page of data. If not included, this is the
+            last page of data. Due to how pagination works with visibility and privacy, it is
+            possible that a page may be empty but contain a 'next' paging link. Stop paging when
+            the 'next' link no longer appears.
+          example: https://tenantapi.d.isym.io/v1/tenantinfo?limit=25&after=NDMyNzQyODI3OTQw
+    V1AuditTrailInitiatorResponse:
+      type: object
+      properties:
+        action:
+          type: string
+          description: The audit trail action that has peformed
+        actionName:
+          type: string
+          description: The audit trail action name that has peformed
+        timestamp:
+          type: string
+          description: The timestamp when the action has occurred
+        initiatorId:
+          type: string
+          description: The user's id that has performed the action
+        initiatorUsername:
+          type: string
+          description: The username that has performed the action
+        initiatorEmailAddress:
+          type: string
+          description: The user's e-mail address that has performed the action
+      description: |
+        Audit Trail Initiator object response.
+        The attributes may vary according to the action.
+        There are different types of action and each action could have specific attributes.
+    V1AuditTrailInitiatorList:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/V1AuditTrailInitiatorResponse'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+    V5Datafeed:
+      type: object
+      properties:
+        id:
+          type: string
+          description: ID of the datafeed
+        createdAt:
+          type: integer
+          description: Datafeed creation timestamp
+          format: int64
+        type:
+          type: string
+          description: type of the feed. Known values are "fanout" and "datahose"
+      description: Container for the feed ID
+      example:
+        id: 8e7c8672-220...
+    V5DatafeedCreateBody:
+      type: object
+      properties:
+        tag:
+          maxLength: 100
+          type: string
+          description: A unique identifier to ensure uniqueness of the datafeed.
+    AckId:
+      type: object
+      properties:
+        ackId:
+          type: string
+          description: |
+            A unique id for events that can be deleted from a client's.
+            Empty for the first read. If set to null or missing, it will be considered empty feed.
+        updatePresence:
+          type: boolean
+          description: Set to false to avoid updating the user's presence when reading events. Default is true.
+          default: true
+      description: |
+        An object containing the ackId (and parameters) associated with 
+        events that the client has received through an individual feed.
+    V5EventList:
+      type: object
+      required:
+        - events
+      properties:
+        events:
+          type: array
+          items:
+            $ref: '#/components/schemas/V4Event'
+        ackId:
+          type: string
+          description: |
+            The ackId which acknowledges that the current batch of messages 
+            have been successfully received by the client
+    V5EventsReadBody:
+      required:
+        - tag
+        - type
+      type: object
+      properties:
+        type:
+          type: string
+          description: Type of the feed. Allowed values are "fanout" and "datahose"
+        tag:
+          maxLength: 80
+          minLength: 1
+          type: string
+          description: A unique identifier to ensure uniqueness of the datafeed.
+        eventTypes:
+          type: array
+          description: |
+            At least one value is required if the type of feed is "datahose". Values must be a valid Real-Time Event type, i.e. one of:
+            * MESSAGESENT
+            * MESSAGESUPPRESSED
+            * SYMPHONYELEMENTSACTION
+            * SHAREDPOST
+            * INSTANTMESSAGECREATED
+            * ROOMCREATED
+            * ROOMUPDATED
+            * ROOMDEACTIVATED
+            * ROOMREACTIVATED
+            * USERREQUESTEDTOJOINROOM
+            * USERJOINEDROOM
+            * USERLEFTROOM
+            * ROOMMEMBERPROMOTEDTOOWNER
+            * ROOMMEMBERDEMOTEDFROMOWNER
+            * CONNECTIONREQUESTED
+            * CONNECTIONACCEPTED
+          items:
+            type: string
+          x-since: 22.7
+        ackId:
+          type: string
+          description: |
+            Should be empty for the first call, acknowledges that the current
+            batch of messages have been successfully received by the client.
+        updatePresence:
+          type: boolean
+          description: |
+            Whether to update the presence status of the account to AVAILABLE 
+            when calling the endpoint. Default value is true.
+          default: true
+    V3Health:
+      type: object
       properties:
         services:
-          additionalProperties:
-            $ref: '#/definitions/V3HealthComponent'
           type: object
+          additionalProperties:
+            $ref: '#/components/schemas/V3HealthComponent'
         status:
-          $ref: '#/definitions/V3HealthStatus'
+          $ref: '#/components/schemas/V3HealthStatus'
         users:
-          additionalProperties:
-            $ref: '#/definitions/V3HealthComponent'
           type: object
+          additionalProperties:
+            $ref: '#/components/schemas/V3HealthComponent'
         version:
-          description: Required Agent verison
           type: string
+          description: Required Agent verison
+    V3HealthAuthType:
+      type: string
+      description: Type of authentication
+      enum:
+        - RSA
+        - CERT
+    V3HealthComponent:
       type: object
-  V3HealthAuthType:
-    description: Type of authentication
-    enum:
-      - RSA
-      - CERT
-    type: string
-  V3HealthComponent:
-    properties:
-      authType:
-        $ref: '#/definitions/V3HealthAuthType'
-      message:
-        description: 'An error message, if the component status is DOWN'
-        type: string
-      status:
-        $ref: '#/definitions/V3HealthStatus'
-      version:
-        description: Optional component version
-        type: string
-    type: object
-  V3HealthStatus:
-    description: Application health status.
-    enum:
-      - UP
-      - DOWN
-    type: string
-#
-# Deprecated definitions
-#
-  MessageSubmission:
-    type: object
-    properties:
-      format:
-        type: string
-        enum:
-          - TEXT
-          - MESSAGEML
-      message:
-        type: string
-  V2MessageSubmission:
-    type: object
-    properties:
-      format:
-        type: string
-        enum:
-          - TEXT
-          - MESSAGEML
-      message:
-        type: string
-      attachments:
-        type: array
-        items:
-          $ref: '#/definitions/AttachmentInfo'
-  MessageImportList:
-    description: |
-      An ordered list of historic messages to be imported.
-      A list of import responsees will be returned in the same order.
-    type: array
-    items:
-      $ref: '#/definitions/ImportedMessage'
-  ImportedMessage:
-    description: |
-      A historic message to be imported into the system.
-      The importing user must have the Content Management role.
-      Also, the importing user must be a member of the conversation it is importing into.
-      The user that the message is intended to have come from must also be present in the conversation.
-      The intended message timestamp must be a valid time from the past. It cannot be a future timestamp.
-      By design, imported messages do not stream to datafeed or firehose endpoints.
-    type: object
-    properties:
-      message:
-        type: string
-        format: MessageML
-        description: Message text in MessageML
-      format:
-        type: string
-        enum:
-          - TEXT
-          - MESSAGEML
-      intendedMessageTimestamp:
-        description: |
-          The timestamp representing the time when the message was sent in the original system
-          in milliseconds since Jan 1st 1970.
-        type: integer
-        format: int64
-      intendedMessageFromUserId:
-        description: |
-          The long integer userid of the Symphony user who you intend to show sent the message.
-        type: integer
-        format: int64
-      originatingSystemId:
-        description: |
-          The ID of the system through which the message was originally sent.
-        type: string
-      streamId:
-        type: string
-    required:
-    - message
-    - intendedMessageTimestamp
-    - intendedMessageFromUserId
-    - originatingSystemId
-    - streamId
-  V2MessageImportList:
+      properties:
+        authType:
+          $ref: '#/components/schemas/V3HealthAuthType'
+        message:
+          type: string
+          description: An error message, if the component status is DOWN
+        status:
+          $ref: '#/components/schemas/V3HealthStatus'
+        version:
+          type: string
+          description: Optional component version
+    V3HealthStatus:
+      type: string
+      description: Application health status.
+      enum:
+        - UP
+        - DOWN  #
+    # Deprecated definitions
+    #
+    MessageSubmission:
+      type: object
+      properties:
+        format:
+          type: string
+          enum:
+            - TEXT
+            - MESSAGEML
+        message:
+          type: string
+    V2MessageSubmission:
+      type: object
+      required:
+        - attachments
+      properties:
+        format:
+          type: string
+          enum:
+            - TEXT
+            - MESSAGEML
+        message:
+          type: string
+        attachments:
+          type: array
+          items:
+            $ref: '#/components/schemas/AttachmentInfo'
+    MessageImportList:
+      type: array
       description: |
         An ordered list of historic messages to be imported.
         A list of import responsees will be returned in the same order.
-      type: array
       items:
-        $ref: '#/definitions/V2ImportedMessage'
-  V2ImportedMessage:
-    description: |
-      A historic message to be imported into the system.
-      The importing user must have the Content Management role.
-      Also, the importing user must be a member of the conversation it is importing into.
-      The user that the message is intended to have come from must also be present in the conversation.
-      The intended message timestamp must be a valid time from the past. It cannot be a future timestamp.
-      By design, imported messages do not stream to datafeed or firehose endpoints.
-    type: object
-    properties:
-      message:
-        type: string
-        format: MessageML
-        description: Message text in MessageML
-      format:
-        type: string
-        enum:
-          - TEXT
-          - MESSAGEML
-      intendedMessageTimestamp:
-        description: |
-          The timestamp representing the time when the message was sent in the original system
-          in milliseconds since Jan 1st 1970.
-        type: integer
-        format: int64
-      intendedMessageFromUserId:
-        description: |
-          The long integer userid of the Symphony user who you intend to show sent the message.
-        type: integer
-        format: int64
-      originatingSystemId:
-        description: |
-          The ID of the system through which the message was originally sent.
-        type: string
-      originalMessageId:
-        description: |
-          The ID of the message in the original system.
-        type: string
-      streamId:
-        type: string
-    required:
-    - message
-    - intendedMessageTimestamp
-    - intendedMessageFromUserId
-    - originatingSystemId
-    - streamId
-  ImportResponseList:
-    type: array
-    items:
-      $ref: '#/definitions/ImportResponse'
-  ImportResponse:
-    type: object
-    properties:
-      messageId:
-        description: |
-          If the message was successfully imported then the message ID in the system
-          of the newly created message.
-        type: string
-      diagnostic:
-        description: |
-          A diagnostic message containing an error message in the event that the
-          message import failed. May also be present in the case of a successful
-          call if there is useful narrative to return.
-        type: string
-  V2ImportResponseList:
-    type: array
-    items:
-      $ref: '#/definitions/V2ImportResponse'
-  V2ImportResponse:
-    type: object
-    properties:
-      messageId:
-        description: |
-          If the message was successfully imported then the message ID in the system
-          of the newly created message.
-        type: string
-      originatingSystemId:
-        description: |
-          The ID of the system through which the message was originally sent.
-        type: string
-      originalMessageId:
-        description: |
-          The ID of the message in the original system.
-        type: string
-      diagnostic:
-        description: |
-          A diagnostic message containing an error message in the event that the
-          message import failed. May also be present in the case of a successful
-          call if there is useful narrative to return.
-        type: string
-  BaseMessage:
-    type: object
-    discriminator: messageType
-    properties:
-      id:
-        type: string
-        description: The messageId is assigned by the ingestor service when a message is sent.
-      timestamp:
-        type: string
-      messageType:
-        type: string
-      streamId:
-        type: string
-    required:
-    - messageType
-    - timestamp
-    - streamId
-  V1HealthCheckResponse:
-    type: object
-    properties:
-      podConnectivity:
-        type: boolean
-        description: Indicates whether the Agent server can connect to the Pod
-      podConnectivityError:
-        type: string
-        description: Error details in case of no Pod connectivity
-      keyManagerConnectivity:
-        type: boolean
-        description: Indicates whether the Agent server can connect to the Key Manager
-      keyManagerConnectivityError:
-        type: string
-        description: Error details in case of no Key Manager connectivity
-      version:
-        type: string
-        description: The version number of the Agent server
-  Message:
-    type: object
-    description: A representation of a message sent by a user of Symphony.
-    allOf:
-    - $ref: '#/definitions/BaseMessage'
-    - type: object
+        $ref: '#/components/schemas/ImportedMessage'
+    ImportedMessage:
+      required:
+        - intendedMessageFromUserId
+        - intendedMessageTimestamp
+        - message
+        - originatingSystemId
+        - streamId
+      type: object
       properties:
         message:
           type: string
-          format: MessageML
           description: Message text in MessageML
-        fromUserId:
+          format: MessageML
+        format:
+          type: string
+          enum:
+            - TEXT
+            - MESSAGEML
+        intendedMessageTimestamp:
           type: integer
+          description: |
+            The timestamp representing the time when the message was sent in the original system
+            in milliseconds since Jan 1st 1970.
           format: int64
-          description: the Symphony userId of the user who sent the message. This will be populated by the server (and actually ignored if included when sending a message).
+        intendedMessageFromUserId:
+          type: integer
+          description: The long integer userid of the Symphony user who you intend to show sent the message.
+          format: int64
+        originatingSystemId:
+          type: string
+          description: The ID of the system through which the message was originally sent.
+        streamId:
+          type: string
+      description: |
+        A historic message to be imported into the system.
+        The importing user must have the Content Management role.
+        Also, the importing user must be a member of the conversation it is importing into.
+        The user that the message is intended to have come from must also be present in the conversation.
+        The intended message timestamp must be a valid time from the past. It cannot be a future timestamp.
+        By design, imported messages do not stream to datafeed or firehose endpoints.
+    V2MessageImportList:
+      type: array
+      description: |
+        An ordered list of historic messages to be imported.
+        A list of import responsees will be returned in the same order.
+      items:
+        $ref: '#/components/schemas/V2ImportedMessage'
+    V2ImportedMessage:
       required:
-      - message
-      - fromUserId
-  MessageList:
-    type: array
-    items:
-      $ref: '#/definitions/Message'
-  Datafeed:
-    type: object
-    properties:
-      id:
-        type: string
+        - intendedMessageFromUserId
+        - intendedMessageTimestamp
+        - message
+        - originatingSystemId
+        - streamId
+      type: object
+      properties:
+        message:
+          type: string
+          description: Message text in MessageML
+          format: MessageML
+        format:
+          type: string
+          enum:
+            - TEXT
+            - MESSAGEML
+        intendedMessageTimestamp:
+          type: integer
+          description: |
+            The timestamp representing the time when the message was sent in the original system
+            in milliseconds since Jan 1st 1970.
+          format: int64
+        intendedMessageFromUserId:
+          type: integer
+          description: The long integer userid of the Symphony user who you intend to show sent the message.
+          format: int64
+        originatingSystemId:
+          type: string
+          description: The ID of the system through which the message was originally sent.
+        originalMessageId:
+          type: string
+          description: The ID of the message in the original system.
+        streamId:
+          type: string
+      description: |
+        A historic message to be imported into the system.
+        The importing user must have the Content Management role.
+        Also, the importing user must be a member of the conversation it is importing into.
+        The user that the message is intended to have come from must also be present in the conversation.
+        The intended message timestamp must be a valid time from the past. It cannot be a future timestamp.
+        By design, imported messages do not stream to datafeed or firehose endpoints.
+    ImportResponseList:
+      type: array
+      items:
+        $ref: '#/components/schemas/ImportResponse'
+    ImportResponse:
+      type: object
+      properties:
+        messageId:
+          type: string
+          description: |
+            If the message was successfully imported then the message ID in the system
+            of the newly created message.
+        diagnostic:
+          type: string
+          description: |
+            A diagnostic message containing an error message in the event that the
+            message import failed. May also be present in the case of a successful
+            call if there is useful narrative to return.
+    V2ImportResponseList:
+      type: array
+      items:
+        $ref: '#/components/schemas/V2ImportResponse'
+    V2ImportResponse:
+      type: object
+      properties:
+        messageId:
+          type: string
+          description: |
+            If the message was successfully imported then the message ID in the system
+            of the newly created message.
+        originatingSystemId:
+          type: string
+          description: The ID of the system through which the message was originally sent.
+        originalMessageId:
+          type: string
+          description: The ID of the message in the original system.
+        diagnostic:
+          type: string
+          description: |
+            A diagnostic message containing an error message in the event that the
+            message import failed. May also be present in the case of a successful
+            call if there is useful narrative to return.
+    BaseMessage:
+      required:
+        - messageType
+        - streamId
+        - timestamp
+      type: object
+      properties:
+        id:
+          type: string
+          description: The messageId is assigned by the ingestor service when a message is sent.
+        timestamp:
+          type: string
+        messageType:
+          type: string
+        streamId:
+          type: string
+      discriminator:
+        propertyName: messageType
+    V1HealthCheckResponse:
+      type: object
+      properties:
+        podConnectivity:
+          type: boolean
+          description: Indicates whether the Agent server can connect to the Pod
+        podConnectivityError:
+          type: string
+          description: Error details in case of no Pod connectivity
+        keyManagerConnectivity:
+          type: boolean
+          description: Indicates whether the Agent server can connect to the Key Manager
+        keyManagerConnectivityError:
+          type: string
+          description: Error details in case of no Key Manager connectivity
+        version:
+          type: string
+          description: The version number of the Agent server
+    Message:
+      description: A representation of a message sent by a user of Symphony.
+      allOf:
+        - $ref: '#/components/schemas/BaseMessage'
+        - required:
+            - fromUserId
+            - message
+          type: object
+          properties:
+            message:
+              type: string
+              description: Message text in MessageML
+              format: MessageML
+            fromUserId:
+              type: integer
+              description: the Symphony userId of the user who sent the message. This
+                will be populated by the server (and actually ignored if included when
+                sending a message).
+              format: int64
+    MessageList:
+      type: array
+      items:
+        $ref: '#/components/schemas/Message'
+    Datafeed:
+      type: object
+      properties:
+        id:
+          type: string

--- a/agent/agent-api-public.yaml
+++ b/agent/agent-api-public.yaml
@@ -1,6 +1,5 @@
-swagger: '2.0'
+openapi: 3.0.1
 info:
-  version: '22.7.1'
   title: Agent API
   description: |
     This document refers to Symphony API calls to send and receive messages
@@ -10,9 +9,6 @@ info:
     - sessionToken and keyManagerToken can be obtained by calling the
     authenticationAPI on the symphony back end and the key manager
     respectively. Refer to the methods described in authenticatorAPI.yaml.
-    - A new authorizationToken has been introduced in the authenticationAPI
-    response payload. It can be used to replace the sessionToken in any of
-    the API calls and can be passed as "Authorization" header.
     - Actions are defined to be atomic, ie will succeed in their entirety
     or fail and have changed nothing.
     - If it returns a 40X status then it will have sent no message to any
@@ -28,29 +24,31 @@ info:
     To know more about the endpoints, refer to Create Messages/Events
     Stream and Read Messages/Events Stream. Unless otherwise specified,
     all events were added in 1.46.
-
+  version: '22.9.1'
+servers:
+  - url: /
 paths:
-  '/v3/health':
+  /v3/health:
     get:
+      tags:
+        - System
       summary: Checks health status
       description: |
         _Available on Agent 2.57.0 and above._
 
         Returns the connectivity status of your Agent server. If your Agent server is started and running, the status value will be `UP`
       operationId: v3Health
-      consumes:
-        - application/json
-      produces:
-        - application/json
+      responses:
+        200:
+          description: Agent application is alive.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3Health'
+  /v3/health/extended:
+    get:
       tags:
         - System
-      responses:
-        '200':
-          description: Agent application is alive.
-          schema:
-            $ref: '#/definitions/V3Health'
-  '/v3/health/extended':
-    get:
       summary: Checks health status of services and users
       description: |
         _Available on Agent 2.57.0 and above._
@@ -60,23 +58,23 @@ paths:
 
         The global status will be set to `DOWN` if at least one of the sub-status is also `DOWN`.
       operationId: v3ExtendedHealth
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      tags:
-        - System
       responses:
-        '200':
+        200:
           description: Agent is healthy, all components are `UP`.
-          schema:
-            $ref: '#/definitions/V3Health'
-        '503':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3Health'
+        503:
           description: Agent is unhealthy, some components are `DOWN`.
-          schema:
-            $ref: '#/definitions/V3Health'
-  '/v4/message/import':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3Health'
+  /v4/message/import:
     post:
+      tags:
+        - Messages
       summary: Import messages from other systems into Symphony.
       description: |
         Sends a message to be imported into the system.
@@ -85,51 +83,61 @@ paths:
         The user that the message is intended to have come from must also be present in the conversation.
         The intended message timestamp must be a valid time from the past. It cannot be a future timestamp.
         Optionally the original message ID can be specified to identify the imported message for the purpose of repeat imports.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: messageList
-          in: body
           required: true
           schema:
-            $ref: '#/definitions/V4MessageImportList'
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V4MessageImportList'
+        required: true
+      responses:
+        200:
+          description: Message sent.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V4ImportResponseList'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+      x-codegen-request-body-name: messageList
+  /v4/message/blast:
+    post:
       tags:
         - Messages
-      responses:
-        '200':
-          description: Message sent.
-          schema:
-            $ref: '#/definitions/V4ImportResponseList'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v4/message/blast':
-    post:
       summary: Post a message to multiple existing streams.
       description: |
         Post a new message to the given list of streams. The stream can be a chatroom,
@@ -153,422 +161,483 @@ paths:
 
         Regarding authentication, you must either use the sessionToken which was created for delegated app access
         or both the sessionToken and keyManagerToken together.
-      consumes:
-        - multipart/form-data
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Authorization token used to make delegated calls.
-          in: header
           required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          type: string
-          required: false
-        - name: sids
-          description: A comma-separated list of Stream IDs
-          in: formData
-          required: true
-          type: array
-          items:
+          schema:
             type: string
-        - name: message
-          description: The message payload in MessageML.
-          in: formData
-          type: string
-          required: false
-        - name: data
-          description: Optional message data in EntityJSON.
-          in: formData
-          type: string
-          required: false
-        - name: version
-          description: |
-            Optional message version in the format "major.minor". If empty, defaults to the latest supported version.
-          in: formData
-          type: string
-          required: false
-        - name: attachment
-          description: Optional file attachment.
-          in: formData
-          type: file
-          required: false
-        - name: preview
-          description: Optional attachment preview.
-          in: formData
-          type: file
-          required: false
-      tags:
-        - Messages
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          schema:
+            type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              required:
+                - sids
+              properties:
+                sids:
+                  type: array
+                  description: A comma-separated list of Stream IDs
+                  items:
+                    type: string
+                message:
+                  type: string
+                  description: The message payload in MessageML.
+                data:
+                  type: string
+                  description: Optional message data in EntityJSON.
+                version:
+                  type: string
+                  description: |
+                    Optional message version in the format "major.minor". If empty, defaults to the latest supported version.
+                attachment:
+                  type: string
+                  description: Optional file attachment.
+                  format: binary
+                preview:
+                  type: string
+                  description: Optional attachment preview.
+                  format: binary
       responses:
-        '200':
+        200:
           description: Blast message sent.
-          schema:
-            $ref: '#/definitions/V4MessageBlastResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V4MessageBlastResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '451':
-          description: 'Compliance Issues found in message or file'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/message/{id}':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        451:
+          description: Compliance Issues found in message or file
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+  /v1/message/{id}:
     get:
+      tags:
+        - Messages
       summary: Get a message by ID
-      produces:
-        - application/json
       parameters:
-          - name: sessionToken
-            description: Session authentication token.
-            in: header
-            required: true
-            type: string
-          - name: keyManagerToken
-            description: Key Manager authentication token.
-            in: header
-            required: true
-            type: string
-          - name: id
-            description: Message ID as a URL-safe string
-            in: path
-            required: true
-            type: string
-      tags:
-        - Messages
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/V4Message'
-        '204':
-          description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/message/search':
-    get:
-      summary: Search messages
-      description: |
-          Search messages according to the specified criteria. The "query" parameter takes a search query defined as
-          "field:value" pairs combined by the operator "AND" (e.g. "text:foo AND autor:bar"). Supported fields are
-           (case-insensitive): "text", "author", "hashtag", "cashtag", "mention", "signal", "fromDate", "toDate",
-           "streamId", "streamType".
-           "text" search requires a "streamId" to be specified.
-           "streamType" accepts one of the following values: "chat" (IMs and MIMs), "im", "mim", "chatroom", "post".
-           "signal" queries can only be combined with "fromDate", "toDate", "skip" and "limit" parameters.
-      produces:
-        - application/json
-      parameters:
-        - name: query
-          description: The search query. See above for the query syntax.
-          in: query
-          type: string
-          required: true
-        - name: skip
-          description: |
-            No. of results to skip.
-          in: query
-          type: integer
-        - name: limit
-          description: |
-            Max no. of results to return. If no value is provided, 50 is the default.
-          in: query
-          type: integer
-          required: false
-        - name: scope
-          description: |
-            Describes where content should be searched for that query.
-            It can exclusively apply to Symphony content or to one Connector.
-          in: query
-          type: string
-        - name: sortDir
-          description: |
-            Messages sort direction : ASC or DESC (default to DESC)
-          in: query
-          type: string
-          required: false
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
+          in: header
           description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-      tags:
-        - Messages
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/V4MessageList'
-        '204':
-          description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-    post:
-      summary: Search messages
-      description: |
-          Search messages according to the specified criteria.
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - name: query
-          description: The search query. See above for the query syntax.
-          in: body
           required: true
           schema:
-            $ref: '#/definitions/MessageSearchQuery'
-        - name: skip
-          description: |
-            No. of results to skip.
-          in: query
-          type: integer
-        - name: limit
-          description: |
-            Max no. of results to return. If no value is provided, 50 is the default.
-          in: query
-          type: integer
-          required: false
-        - name: scope
-          description: |
-            Describes where content should be searched for that query.
-            It can exclusively apply to Symphony content or to one Connector.
-          in: query
-          type: string
-        - name: sortDir
-          description: |
-            Messages sort direction : ASC or DESC (default to DESC)
-          in: query
-          type: string
-          required: false
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-      tags:
-        - Messages
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/V4MessageList'
-        '204':
-          description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/stream/{sid}/attachment':
-    get:
-      summary: Download an attachment.
-      description: |
-        Downloads the attachment body by the attachment ID, stream ID, and message ID.
-      consumes:
-        - application/json
-      produces:
-        - application/octet-stream
-      parameters:
-        - name: sid
-          description: Stream ID
+            type: string
+        - name: id
           in: path
+          description: Message ID as a URL-safe string
           required: true
-          type: string
-        - name: fileId
-          description: The attachment ID (Base64-encoded)
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V4Message'
+        204:
+          description: No Messages.
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+  /v1/message/search:
+    get:
+      tags:
+        - Messages
+      summary: Search messages
+      description: |
+        Search messages according to the specified criteria. The "query" parameter takes a search query defined as
+        "field:value" pairs combined by the operator "AND" (e.g. "text:foo AND autor:bar"). Supported fields are
+         (case-insensitive): "text", "author", "hashtag", "cashtag", "mention", "signal", "fromDate", "toDate",
+         "streamId", "streamType".
+         "text" search requires a "streamId" to be specified.
+         "streamType" accepts one of the following values: "chat" (IMs and MIMs), "im", "mim", "chatroom", "post".
+         "signal" queries can only be combined with "fromDate", "toDate", "skip" and "limit" parameters.
+      parameters:
+        - name: query
           in: query
+          description: The search query. See above for the query syntax.
           required: true
-          type: string
-        - name: messageId
-          description: The ID of the message containing the attachment
+          schema:
+            type: string
+        - name: skip
           in: query
-          required: true
-          type: string
+          description: No. of results to skip.
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: Max no. of results to return. If no value is provided, 50 is the default.
+          schema:
+            type: integer
+        - name: scope
+          in: query
+          description: |
+            Describes where content should be searched for that query.
+            It can exclusively apply to Symphony content or to one Connector.
+          schema:
+            type: string
+        - name: sortDir
+          in: query
+          description: |
+            Messages sort direction : ASC or DESC (default to DESC)
+          schema:
+            type: string
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V4MessageList'
+        204:
+          description: No Messages.
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+    post:
+      tags:
+        - Messages
+      summary: Search messages
+      description: Search messages according to the specified criteria.
+      parameters:
+        - name: skip
+          in: query
+          description: No. of results to skip.
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: Max no. of results to return. If no value is provided, 50 is the default.
+          schema:
+            type: integer
+        - name: scope
+          in: query
+          description: |
+            Describes where content should be searched for that query.
+            It can exclusively apply to Symphony content or to one Connector.
+          schema:
+            type: string
+        - name: sortDir
+          in: query
+          description: |
+            Messages sort direction : ASC or DESC (default to DESC)
+          schema:
+            type: string
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: The search query. See above for the query syntax.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MessageSearchQuery'
+        required: true
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V4MessageList'
+        204:
+          description: No Messages.
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+      x-codegen-request-body-name: query
+  /v1/stream/{sid}/attachment:
+    get:
       tags:
         - Attachments
-      responses:
-        '200':
-          description: 'Attachment body as Base64 encoded string.'
-          schema:
-            type: string
-            format: byte
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v4/stream/{sid}/message':
-    get:
-      summary: Get messages from an existing stream.
-      description: |
-          A caller can fetch all unseen messages by passing the timestamp of
-          the last message seen as the since parameter and the number of messages
-          with the same timestamp value already seen as the skip parameter. This
-          means that every message will be seen exactly once even in the case that
-          an additional message is processed with the same timestamp as the last
-          message returned by the previous call, and the case where there are
-          more than maxMessages with the same timestamp value.
-
-          This method is intended for historic queries and is generally reliable
-          but if guaranteed delivery of every message in real time is required
-          then the equivilent firehose method should be called.
-      produces:
-        - application/json
+      summary: Download an attachment.
+      description: Downloads the attachment body by the attachment ID, stream ID, and message ID.
       parameters:
         - name: sid
-          description: |
-            Stream ID
           in: path
+          description: Stream ID
           required: true
-          type: string
-        - name: since
-          description: |
-            Timestamp of first required message.
-
-            This is a long integer value representing milliseconds since
-            Jan 1 1970
+          schema:
+            type: string
+        - name: fileId
           in: query
+          description: The attachment ID (Base64-encoded)
           required: true
-          type: integer
-          format: int64
-        - name: skip
-          description: |
-            No. of messages to skip.
+          schema:
+            type: string
+        - name: messageId
           in: query
-          type: integer
-        - name: limit
-          description: |
-            Max No. of messages to return. If no value is provided, 50 is the default. The maximum supported value is 500.
-          in: query
-          type: integer
-          required: false
+          description: The ID of the message containing the attachment
+          required: true
+          schema:
+            type: string
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
+      responses:
+        200:
+          description: Attachment body as Base64 encoded string.
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: byte
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v4/stream/{sid}/message:
+    get:
       tags:
         - Messages
+      summary: Get messages from an existing stream.
+      description: |
+        A caller can fetch all unseen messages by passing the timestamp of
+        the last message seen as the since parameter and the number of messages
+        with the same timestamp value already seen as the skip parameter. This
+        means that every message will be seen exactly once even in the case that
+        an additional message is processed with the same timestamp as the last
+        message returned by the previous call, and the case where there are
+        more than maxMessages with the same timestamp value.
+
+        This method is intended for historic queries and is generally reliable
+        but if guaranteed delivery of every message in real time is required
+        then the equivilent firehose method should be called.
+      parameters:
+        - name: sid
+          in: path
+          description: Stream ID
+          required: true
+          schema:
+            type: string
+        - name: since
+          in: query
+          description: |
+            Timestamp of first required message.
+            
+            This is a long integer value representing milliseconds since
+            Jan 1 1970
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: skip
+          in: query
+          description: No. of messages to skip.
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: |
+            Max No. of messages to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          schema:
+            type: integer
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
       responses:
-        '200':
+        200:
           description: OK
-          schema:
-            $ref: '#/definitions/V4MessageList'
-        '204':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V4MessageList'
+        204:
           description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v4/stream/{sid}/message/create':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+  /v4/stream/{sid}/message/create:
     post:
+      tags:
+        - Messages
       summary: Post a message to one existing stream.
       description: |
-        Post a new message to the given stream. The stream can be a chatroom,
-        an IM or a multiparty IM.
+        Post a new message to the given stream. The stream can be a chatroom,,an IM or a multiparty IM.
 
         You may include an attachment on the message.
 
@@ -578,90 +647,94 @@ paths:
         If the message contains explicit references to entity data (in "data-entity-id" element attributes),
         this parameter is required.
 
-        If the message is in MessageML and fails schema validation
-        a client error results
+        If the message is in MessageML and fails schema validation a client error will be returned.
 
         If the message is sent then 200 is returned.
 
         Regarding authentication, you must either use the sessionToken which was created for delegated app access
         or both the sessionToken and keyManagerToken together.
-      consumes:
-        - multipart/form-data
-      produces:
-        - application/json
       parameters:
         - name: sid
-          description: Stream ID
           in: path
+          description: Stream ID
           required: true
-          type: string
+          schema:
+            type: string
         - name: sessionToken
+          in: header
           description: Authorization token used to make delegated calls.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
-          type: string
-          required: false
-        - name: message
-          description: The message payload in MessageML.
-          in: formData
-          type: string
-          required: false
-        - name: data
-          description: Optional message data in EntityJSON.
-          in: formData
-          type: string
-          required: false
-        - name: version
-          description: |
-            Optional message version in the format "major.minor". If empty, defaults to the latest supported version.
-          in: formData
-          type: string
-          required: false
-        - name: attachment
-          description: Optional file attachment.
-          in: formData
-          type: file
-          required: false
-        - name: preview
-          description: Optional attachment preview.
-          in: formData
-          type: file
-          required: false
-
+          description: Key Manager authentication token.
+          schema:
+            type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                message:
+                  type: string
+                  description: The message payload in MessageML.
+                data:
+                  type: string
+                  description: Optional message data in EntityJSON.
+                version:
+                  type: string
+                  description: |
+                    Optional message version in the format "major.minor". If empty, defaults to the latest supported version.
+                attachment:
+                  type: string
+                  description: Optional file attachment.
+                  format: binary
+                preview:
+                  type: string
+                  description: Optional attachment preview.
+                  format: binary
+      responses:
+        200:
+          description: Message sent.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V4Message'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        451:
+          description: Compliance Issues found in message or file
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+  /v4/stream/{sid}/message/{mid}/update:
+    post:
       tags:
         - Messages
-      responses:
-        '200':
-          description: Message sent.
-          schema:
-            $ref: '#/definitions/V4Message'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '451':
-          description: 'Compliance Issues found in message or file'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-
-  '/v4/stream/{sid}/message/{mid}/update':
-    post:
       summary: Update an existing message.
       description: |
         Update an existing message. The existing message must be a valid social message, that has not been deleted.
@@ -679,692 +752,810 @@ paths:
 
         Regarding authentication, you must either use the sessionToken which was created for delegated app access
         or both the sessionToken and keyManagerToken together.
-      consumes:
-        - multipart/form-data
-      produces:
-        - application/json
       parameters:
         - name: sid
+          in: path
           description: Stream ID
-          in: path
           required: true
-          type: string
+          schema:
+            type: string
         - name: mid
-          description: Parent message ID
           in: path
+          description: Parent message ID
           required: true
-          type: string
+          schema:
+            type: string
         - name: sessionToken
+          in: header
           description: Authorization token used to make delegated calls.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
-          type: string
-          required: false
-        - name: message
-          description: The message payload in MessageML.
-          in: formData
-          type: string
-          required: false
-        - name: data
-          description: Optional message data in EntityJSON.
-          in: formData
-          type: string
-          required: false
-        - name: version
-          description: |
-            Optional message version in the format "major.minor". If empty, defaults to the latest supported version.
-          in: formData
-          type: string
-          required: false
-        - name: silent
-          in: formData
-          type: string
-          required: false
-          description: |
-            Optional boolean field that will determine if the user/s should receive the message as read or not (true by default). Since Agent 20.14.
-          x-since: 20.14
-      tags:
-        - Messages
+          description: Key Manager authentication token.
+          schema:
+            type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                message:
+                  type: string
+                  description: The message payload in MessageML.
+                data:
+                  type: string
+                  description: Optional message data in EntityJSON.
+                version:
+                  type: string
+                  description: |
+                    Optional message version in the format "major.minor". If empty, defaults to the latest supported version.
+                silent:
+                  type: string
+                  description: |
+                    Optional boolean field that will determine if the user/s should receive the message as read or not (true by default)
       responses:
-        '200':
+        200:
           description: Message sent.
-          schema:
-            $ref: '#/definitions/V4Message'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V4Message'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '451':
-          description: 'Compliance Issues found in message or file'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-
-  '/v3/stream/{sid}/share':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        451:
+          description: Compliance Issues found in message or file
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+  /v3/stream/{sid}/share:
     post:
+      tags:
+        - Share
       summary: PROVISIONAL -  Share a piece of content into Symphony
       description: |
         Given a 3rd party content (eg. news article), it can share to the given stream.
         The stream can be a chatroom, an IM or a multiparty IM.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sid
-          description: Stream ID
           in: path
-          required: true
-          type: string
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: false
-          type: string
-        - name: shareContent
-          in: body
+          description: Stream ID
           required: true
           schema:
-            $ref: '#/definitions/ShareContent'
-      tags:
-        - Share
+            type: string
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ShareContent'
+        required: true
       responses:
-        '200':
+        200:
           description: Success
-          schema:
-            $ref: '#/definitions/V2Message'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Message'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/util/echo':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      x-codegen-request-body-name: shareContent
+  /v1/util/echo:
     post:
-      summary: Test endpoint, returns input.
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: echoInput
-          description: Message in plain text
-          in: body
-          required: true
-          schema:
-            $ref: '#/definitions/SimpleMessage'
       tags:
         - Util
-      responses:
-        '200':
-          description: Message sent.
-          schema:
-            $ref: '#/definitions/SimpleMessage'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/signals/list':
-    get:
-      summary: |
-          List signals for the requesting user. This includes signals that the user has created and public signals
-          to which they subscribed.
-      consumes:
-        - application/json
-      produces:
-        - application/json
+      summary: Test endpoint, returns input.
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
-          required: false
-          type: string
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Message in plain text
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SimpleMessage'
+        required: true
+      responses:
+        200:
+          description: Message sent.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleMessage'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      x-codegen-request-body-name: echoInput
+  /v1/signals/list:
+    get:
+      tags:
+        - Signals
+      summary: |
+        List signals for the requesting user. This includes signals that the user has created and public signals
+        to which they subscribed.
+      parameters:
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          schema:
+            type: string
         - name: skip
-          description: |
-            No. of signals to skip.
           in: query
-          type: integer
+          description: No. of signals to skip.
+          schema:
+            type: integer
         - name: limit
+          in: query
           description: |
             Max no. of signals to return. If no value is provided, 50 is the default. The maximum supported value is 500.
-          in: query
-          type: integer
-          required: false
+          schema:
+            type: integer
+      responses:
+        200:
+          description: List of signals for the requesting user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SignalList'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+  /v1/signals/{id}/get:
+    get:
       tags:
         - Signals
-      responses:
-        '200':
-          description: List of signals for the requesting user.
-          schema:
-            $ref: '#/definitions/SignalList'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/signals/{id}/get':
-    get:
       summary: Get details of the requested signal.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
-          required: false
-          type: string
+          description: Key Manager authentication token.
+          schema:
+            type: string
         - name: id
-          description: |
-            The ID of the signal to display.
           in: path
+          description: The ID of the signal to display.
           required: true
-          type: string
-      tags:
-        - Signals
+          schema:
+            type: string
       responses:
-        '200':
+        200:
           description: List of signals for the requesting user.
-          schema:
-            $ref: '#/definitions/Signal'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Signal'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/signals/create':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+  /v1/signals/create:
     post:
+      tags:
+        - Signals
       summary: Create a signal.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: false
-          type: string
-        - name: signal
-          description: Signal definition.
-          in: body
           required: true
           schema:
-            $ref: '#/definitions/BaseSignal'
-      tags:
-        - Signals
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          schema:
+            type: string
+      requestBody:
+        description: Signal definition.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BaseSignal'
+        required: true
       responses:
-        '200':
+        200:
           description: Signal created.
-          schema:
-            $ref: '#/definitions/Signal'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Signal'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '451':
-          description: 'Compliance Issues found in signal'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/signals/{id}/update':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        451:
+          description: Compliance Issues found in signal
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+      x-codegen-request-body-name: signal
+  /v1/signals/{id}/update:
     post:
+      tags:
+        - Signals
       summary: Update a signal.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: false
-          type: string
-        - name: id
-          description: The id of the signal.
-          in: path
-          required: true
-          type: string
-        - name: signal
-          description: Signal definition.
-          in: body
           required: true
           schema:
-            $ref: '#/definitions/BaseSignal'
-      tags:
-        - Signals
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          schema:
+            type: string
+        - name: id
+          in: path
+          description: The id of the signal.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Signal definition.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BaseSignal'
+        required: true
       responses:
-        '200':
+        200:
           description: Signal updated.
-          schema:
-            $ref: '#/definitions/Signal'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Signal'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '451':
-          description: 'Compliance Issues found in signal'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/signals/{id}/delete':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        451:
+          description: Compliance Issues found in signal
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+      x-codegen-request-body-name: signal
+  /v1/signals/{id}/delete:
     post:
+      tags:
+        - Signals
       summary: Delete a signal.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
-          required: false
-          type: string
+          description: Key Manager authentication token.
+          schema:
+            type: string
         - name: id
-          description: The id of the signal.
           in: path
+          description: The id of the signal.
           required: true
-          type: string
-      tags:
-        - Signals
+          schema:
+            type: string
       responses:
-        '200':
+        200:
           description: Signal deleted.
-          schema:
-            $ref: '#/definitions/SuccessResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/signals/{id}/subscribe':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+  /v1/signals/{id}/subscribe:
     post:
+      tags:
+        - Signals
       summary: Subscribe to a Signal.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
-          required: false
-          type: string
+          description: Key Manager authentication token.
+          schema:
+            type: string
         - name: id
-          description: The id of the signal.
           in: path
+          description: The id of the signal.
           required: true
-          type: string
+          schema:
+            type: string
         - name: pushed
+          in: query
           description: Prevent the user to unsubscribe (only for bulk subscription)
-          in: query
-          required: false
-          type: boolean
-        - name: users
-          description: UserIds to subscribe (only for bulk subscription)
-          in: body
-          required: false
           schema:
-            type: array
-            items:
-              type: integer
-              format: int64
-      tags:
-        - Signals
+            type: boolean
+      requestBody:
+        description: UserIds to subscribe (only for bulk subscription)
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: integer
+                format: int64
+        required: false
       responses:
-        '200':
+        200:
           description: Signal subscribed.
-          schema:
-            $ref: '#/definitions/ChannelSubscriptionResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChannelSubscriptionResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/signals/{id}/unsubscribe':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+      x-codegen-request-body-name: users
+  /v1/signals/{id}/unsubscribe:
     post:
+      tags:
+        - Signals
       summary: Unsubscribe to a Signal.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: false
-          type: string
-        - name: id
-          description: The id of the signal.
-          in: path
-          required: true
-          type: string
-        - name: users
-          description: UserIds to unsubscribe (only for bulk unsubscription)
-          in: body
-          required: false
           schema:
-            type: array
-            items:
-              type: integer
-              format: int64
-      tags:
-        - Signals
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          schema:
+            type: string
+        - name: id
+          in: path
+          description: The id of the signal.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: UserIds to unsubscribe (only for bulk unsubscription)
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: integer
+                format: int64
+        required: false
       responses:
-        '200':
+        200:
           description: Signal unsubscribed.
-          schema:
-            $ref: '#/definitions/ChannelSubscriptionResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChannelSubscriptionResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/signals/{id}/subscribers':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+      x-codegen-request-body-name: users
+  /v1/signals/{id}/subscribers:
     get:
+      tags:
+        - Signals
       summary: Get the subscribers of a signal
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
-          required: false
-          type: string
+          description: Key Manager authentication token.
+          schema:
+            type: string
         - name: id
-          description: The id of the signal.
           in: path
+          description: The id of the signal.
           required: true
-          type: string
+          schema:
+            type: string
         - name: skip
+          in: query
           description: No. of results to skip.
-          in: query
-          required: false
-          type: integer
-          default: 0
+          schema:
+            type: integer
+            default: 0
         - name: limit
-          description: Max No. of subscribers to return. If no value is provided, 100 is the default.
           in: query
-          required: false
-          type: integer
-          default: 100
-      tags:
-        - Signals
+          description: Max No. of subscribers to return. If no value is provided, 100
+            is the default.
+          schema:
+            type: integer
+            default: 100
       responses:
-        '200':
+        200:
           description: Signal Subscribers.
-          schema:
-            $ref: '#/definitions/ChannelSubscriberResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChannelSubscriberResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/info':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+  /v1/info:
     get:
-      summary: Get information about the Agent
-      consumes:
-        - application/json
-      produces:
-        - application/json
       tags:
         - Signals
+      summary: Get information about the Agent
       responses:
-        '200':
+        200:
           description: Agent info.
-          schema:
-            $ref: '#/definitions/AgentInfo'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentInfo'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/V2Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v1/dlp/policies':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+  /v1/dlp/policies:
     get:
+      tags:
+        - DLP Policies and Dictionary Management
       summary: Get all policies
       description: Get all policies
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: page
           in: query
-          required: false
-          type: integer
-          format: int32
           description: Optional parameter to specify which page to return (default is 0)
+          schema:
+            type: integer
+            format: int32
         - name: limit
           in: query
-          required: false
-          type: integer
-          format: int32
           description: |
             Optional parameter to specify the number of result to return per page, default is 50. Maximum is 50.
+          schema:
+            type: integer
+            format: int32
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPPoliciesCollectionResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V1DLPPoliciesCollectionResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-    post:
       summary: Creates a policy
       description: |
         Creates a new policy with dictionary references.
@@ -1372,1513 +1563,1832 @@ paths:
         At the time of policy creation, the caller should only provide - contentTypes, name, scopes and type. The rest of the information is populated automatically.
 
         Note - You need to enable the policy after creation to start enforcing the policy.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: body
-          in: body
           required: true
           schema:
-            $ref: '#/definitions/V1DLPPolicyRequest'
-          description: Details about the policy that should be created.
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Details about the policy that should be created.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V1DLPPolicyRequest'
+        required: true
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      x-codegen-request-body-name: body
+  /v1/dlp/policies/{policyId}:
+    get:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V1DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/dlp/policies/{policyId}':
-    get:
       summary: Get a policy
       description: Get a policy
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: policyId
           in: path
-          required: true
-          type: string
           description: Unique dictionary identifier.
+          required: true
+          schema:
+            type: string
         - name: policyVersion
           in: query
-          required: false
-          type: string
           description: |
-            Optional parameter, if set to be valid policy version number,  will return policy with specified policyVersion. Otherwise, return the latest policy.
+            Optional parameter, if set to be valid policy version number,  will return policy with specified policyVersion. 
+            Otherwise, return the latest policy.
+          schema:
+            type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    put:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V1DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-    put:
       summary: Updates a policy. Cannot be used for creation.
       description: |
         Update the policy (name, type, contentTypes, scopes) and also the dictionaries for a policy.
         Warning: If you send empty list of dictionaries during the update operation, then all the
         dictionaries for this policy are deleted and policy is automatically disabled.
         Note: The policy should already exist.
-      consumes:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: policyId
           in: path
-          required: true
-          type: string
           description: Unique dictionary identifier.
-        - name: body
-          in: body
           required: true
           schema:
-            $ref: '#/definitions/V1DLPPolicyRequest'
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V1DLPPolicyRequest'
+        required: true
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      x-codegen-request-body-name: body
+    delete:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V1DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-    delete:
       summary: Delete a policy
       description: |
         Delete a policy.
         Note: Only disabled policy can be deleted
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: policyId
           in: path
-          required: true
-          type: string
           description: Unique dictionary identifier.
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/dlp/policies/{policyId}/enable:
+    post:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V1DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/dlp/policies/{policyId}/enable':
-    post:
       summary: Enables a policy.
       description: Enables a policy.
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: policyId
           in: path
           required: true
-          type: string
+          schema:
+            type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/dlp/policies/{policyId}/disable:
+    post:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V1DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/dlp/policies/{policyId}/disable':
-    post:
       summary: Disables a policy.
       description: Disables a policy.
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: policyId
           in: path
           required: true
-          type: string
+          schema:
+            type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/dlp/dictionaries:
+    get:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V1DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/dlp/dictionaries':
-    get:
       summary: Get all dictionary metadatas
       description: |
         Get all dictionary metadatas with the latest version. Each dictionary object will only contain meta data of the content.
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: page
           in: query
-          required: false
-          type: integer
-          format: int32
           description: Optional parameter to specify which page to return (default is 0)
+          schema:
+            type: integer
+            format: int32
         - name: limit
           in: query
-          required: false
-          type: integer
-          format: int32
           description: |
             Optional parameter to specify the number of result to return per page, default is 50. Maximum is 50.
+          schema:
+            type: integer
+            format: int32
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPDictionaryMetadataCollectionResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V1DLPDictionaryMetadataCollectionResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-    post:
       summary: Create a dictionary
       description: |
         Creates a dictionary with basic metadata and no content. Only "name" and "type" field is used to create a new dictionary entry.
-      consumes:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: body
-          in: body
           required: true
           schema:
-            $ref: '#/definitions/V1DLPDictionaryMetadataCreateRequest'
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V1DLPDictionaryMetadataCreateRequest'
+        required: true
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPDictionaryMetadataResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      x-codegen-request-body-name: body
+  /v1/dlp/dictionaries/{dictId}:
+    get:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V1DLPDictionaryMetadataResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/dlp/dictionaries/{dictId}':
-    get:
       summary: Get dictionary metadata
       description: Get basic information for a dictionary.
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: dictId
           in: path
-          required: true
-          type: string
           description: Unique dictionary identifier
+          required: true
+          schema:
+            type: string
         - name: dictVersion
           in: query
-          required: false
-          type: string
           description: |
-            If set to be valid dictionary version number, will return dictionary metadata with specified version. Otherwise, return the latest dictionary metadata.
+            If set to be valid dictionary version number, will return dictionary metadata with specified version. 
+            Otherwise, return the latest dictionary metadata.
+          schema:
+            type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPDictionaryMetadataResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    put:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V1DLPDictionaryMetadataResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-    put:
       summary: Updates a dictionary
       description: |
         Updates the dictionary's basic metadata without content.
         This API cannot be used for creating a new dictionary.
         In case of update only "name" can be changed.
         Note: All related policies will also have versions updated.
-      consumes:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: dictId
           in: path
-          required: true
-          type: string
           description: Unique dictionary identifier
-        - name: body
-          in: body
           required: true
           schema:
-            $ref: '#/definitions/V1DLPDictionaryMetadataUpdateRequest'
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V1DLPDictionaryMetadataUpdateRequest'
+        required: true
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPDictionaryMetadataResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      x-codegen-request-body-name: body
+    delete:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V1DLPDictionaryMetadataResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-    delete:
       summary: Delete a dictionary
       description: |
         Deletes a dictionary.
         Note: All related policies will be affected.
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: dictId
-          in: path
-          required: true
-          type: string
-          description: Unique dictionary identifier
-      tags:
-        - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            # Deleted dictionary's metadata.
-            $ref: '#/definitions/V1DLPDictionaryMetadataResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/dlp/dictionaries/{dictId}/data/download':
-    get:
-      summary: Downloads Base 64 encoded dictionary content.
-      description: Downloads Base 64 encoded dictionary content.
-      consumes:
-        - application/json
-      produces:
-        - application/octet-stream
-      parameters:
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: dictId
-          in: path
-          required: true
-          type: string
-          description: Unique dictionary identifier
-        - name: dictVersion
-          in: query
-          required: false
-          type: string
-          description: |
-            If set to be valid dictionary version number, will return dictionary with specified version. Otherwise, return the latest dictionary.
-      tags:
-        - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: 'Attachment body as Base64 encoded string.'
           schema:
             type: string
-            format: byte
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/dlp/dictionaries/{dictId}/data/upload':
-    post:
-      summary: Override dictionary content with provided content.
-      description: Override dictionary content with provided content.
-      consumes:
-        - multipart/form-data
-      parameters:
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: dictId
           in: path
-          required: true
-          type: string
           description: Unique dictionary identifier
-        - name: data
-          in: formData
           required: true
-          type: file
+          schema:
+            type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPDictionaryMetadataResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/dlp/dictionaries/{dictId}/data/download:
+    get:
       tags:
         - DLP Policies and Dictionary Management
+      summary: Downloads Base 64 encoded dictionary content.
+      description: Downloads Base 64 encoded dictionary content.
+      parameters:
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+        - name: dictId
+          in: path
+          description: Unique dictionary identifier
+          required: true
+          schema:
+            type: string
+        - name: dictVersion
+          in: query
+          description: |
+            If set to be valid dictionary version number, will return dictionary with specified version. 
+            Otherwise, return the latest dictionary.
+          schema:
+            type: string
       responses:
-        '200':
+        200:
+          description: Attachment body as Base64 encoded string.
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: byte
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/dlp/dictionaries/{dictId}/data/upload:
+    post:
+      tags:
+        - DLP Policies and Dictionary Management
+      summary: Override dictionary content with provided content.
+      description: Override dictionary content with provided content.
+      parameters:
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+        - name: dictId
+          in: path
+          description: Unique dictionary identifier
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              required:
+                - data
+              properties:
+                data:
+                  type: string
+                  format: binary
+        required: true
+      responses:
+        200:
           description: Success
-          schema:
-            $ref: '#/definitions/V1DLPDictionaryMetadataResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPDictionaryMetadataResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v1/dlp/violations/message':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/dlp/violations/message:
     get:
+      tags:
+        - Violations
       summary: Get violations as a result of policy enforcement on messages.
-      description: |
-        TBD
-      produces:
-        - application/json
       parameters:
         - name: startTime
+          in: query
           description: |
             Timestamp of the first required violation.
             This is a long integer value representing milliseconds since Jan 1 1970
-          in: query
           required: true
-          type: integer
-          format: int64
+          schema:
+            type: integer
+            format: int64
         - name: endTime
+          in: query
           description: |
             Timestamp of the last required violation.
             This is a long integer value representing milliseconds since Jan 1 1970
             If unspecified, it will default to current time of the request.
-          in: query
-          required: false
-          type: integer
-          format: int64
+          schema:
+            type: integer
+            format: int64
         - name: next
-          description: |
-            Offset of the next chunk of violations. Value is null for the first request.
           in: query
-          type: string
-          required: false
+          description: Offset of the next chunk of violations. Value is null for the first request.
+          schema:
+            type: string
         - name: limit
+          in: query
           description: |
             Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
-          in: query
-          type: integer
-          required: false
+          schema:
+            type: integer
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPViolationMessageResponse'
+        204:
+          description: No Messages.
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/dlp/violations/stream:
+    get:
       tags:
         - Violations
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/V1DLPViolationMessageResponse'
-        '204':
-          description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-
-  '/v1/dlp/violations/stream':
-    get:
       summary: Get violations as a result of policy enforcement on streams.
-      description: |
-        TBD
-      produces:
-        - application/json
       parameters:
         - name: startTime
+          in: query
           description: |
             Timestamp of the first required violation.
             This is a long integer value representing milliseconds since Jan 1 1970
-          in: query
           required: true
-          type: integer
-          format: int64
+          schema:
+            type: integer
+            format: int64
         - name: endTime
+          in: query
           description: |
             Timestamp of the last required violation.
             This is a long integer value representing milliseconds since Jan 1 1970
             If unspecified, it will default to current time of the request.
-          in: query
-          required: false
-          type: integer
-          format: int64
+          schema:
+            type: integer
+            format: int64
         - name: next
-          description: |
-            Offset of the next chunk of violations. Value is null for the first request.
           in: query
-          type: string
-          required: false
+          description: Offset of the next chunk of violations. Value is null for the first request.
+          schema:
+            type: string
         - name: limit
+          in: query
           description: |
             Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
-          in: query
-          type: integer
-          required: false
+          schema:
+            type: integer
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPViolationStreamResponse'
+        204:
+          description: No Messages.
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/dlp/violations/signal:
+    get:
       tags:
         - Violations
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/V1DLPViolationStreamResponse'
-        '204':
-          description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-
-  '/v1/dlp/violations/signal':
-    get:
       summary: Get violations as a result of policy enforcement on signals.
-      description: |
-        TBD
-      produces:
-        - application/json
       parameters:
         - name: startTime
+          in: query
           description: |
             Timestamp of the first required violation.
             This is a long integer value representing milliseconds since Jan 1 1970
-          in: query
           required: true
-          type: integer
-          format: int64
+          schema:
+            type: integer
+            format: int64
         - name: endTime
+          in: query
           description: |
             Timestamp of the last required violation.
             This is a long integer value representing milliseconds since Jan 1 1970
             If unspecified, it will default to current time of the request.
-          in: query
-          required: false
-          type: integer
-          format: int64
+          schema:
+            type: integer
+            format: int64
         - name: next
-          description: |
-            Offset of the next chunk of violations. Value is null for the first request.
           in: query
-          type: string
-          required: false
+          description: Offset of the next chunk of violations. Value is null for the first request.
+          schema:
+            type: string
         - name: limit
+          in: query
           description: |
             Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
-          in: query
-          type: integer
-          required: false
+          schema:
+            type: integer
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
-      tags:
-        - Violations
+          schema:
+            type: string
       responses:
-        '200':
+        200:
           description: OK
-          schema:
-            $ref: '#/definitions/V1DLPViolationSignalResponse'
-        '204':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1DLPViolationSignalResponse'
+        204:
           description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-
-  '/v3/dlp/policies':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v3/dlp/policies:
     get:
+      tags:
+        - DLP Policies and Dictionary Management
       summary: Get all policies
       description: Get all policies
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: page
           in: query
-          required: false
-          type: integer
-          format: int32
           description: Optional parameter to specify which page to return (default is 0)
+          schema:
+            type: integer
+            format: int32
         - name: limit
           in: query
-          required: false
-          type: integer
-          format: int32
           description: |
             Optional parameter to specify the number of result to return per page, default is 50. Maximum is 50.
+          schema:
+            type: integer
+            format: int32
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3DLPPoliciesCollectionResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    post:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V3DLPPoliciesCollectionResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-    post:
       summary: Creates a policy
       description: |
         Creates a new policy with dictionary references.
         At the time of policy creation, the caller should only provide - contentTypes, name, scopes and type.
         The rest of the information is populated automatically.
         Note - You need to enable the policy after creation to start enforcing the policy.
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: body
-          in: body
           required: true
           schema:
-            $ref: '#/definitions/V3DLPPolicyRequest'
-          description: Details about the policy that should be created.
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Details about the policy that should be created.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V3DLPPolicyRequest'
+        required: true
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      x-codegen-request-body-name: body
+  /v3/dlp/policies/{policyId}:
+    get:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V3DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v3/dlp/policies/{policyId}':
-    get:
       summary: Get a policy
       description: Get a policy
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: policyId
           in: path
-          required: true
-          type: string
           description: Unique dictionary identifier.
+          required: true
+          schema:
+            type: string
         - name: policyVersion
           in: query
-          required: false
-          type: string
           description: |
-            Optional parameter, if set to be valid policy version number,  will return policy with specified policyVersion. Otherwise, return the latest policy.
+            Optional parameter, if set to be valid policy version number,  will return policy with specified policyVersion. 
+            Otherwise, return the latest policy.
+          schema:
+            type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v3/dlp/policies/{policyId}/update:
+    post:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V3DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v3/dlp/policies/{policyId}/update':
-    post:
       summary: Updates a policy. Cannot be used for creation.
       description: |
         Update the policy (name, type, contentTypes, scopes) and also the dictionaries for a policy.
         Warning: If you send empty list of dictionaries during the update operation, then all the
         dictionaries for this policy are deleted and policy is automatically disabled.
         Note: The policy should already exist.
-      consumes:
-        - application/json
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: policyId
           in: path
-          required: true
-          type: string
           description: Unique dictionary identifier.
-        - name: body
-          in: body
           required: true
           schema:
-            $ref: '#/definitions/V3DLPPolicyRequest'
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V3DLPPolicyRequest'
+        required: true
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      x-codegen-request-body-name: body
+  /v3/dlp/policies/{policyId}/delete:
+    post:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V3DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v3/dlp/policies/{policyId}/delete':
-    post:
       summary: Delete a policy
       description: |
         Delete a policy.
         Note: Only disabled policy can be deleted
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: policyId
           in: path
-          required: true
-          type: string
           description: Unique dictionary identifier.
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v3/dlp/policies/{policyId}/enable:
+    post:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V3DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v3/dlp/policies/{policyId}/enable':
-    post:
       summary: Enables a policy.
       description: Enables a policy.
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: policyId
           in: path
           required: true
-          type: string
+          schema:
+            type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v3/dlp/policies/{policyId}/disable:
+    post:
       tags:
         - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V3DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v3/dlp/policies/{policyId}/disable':
-    post:
       summary: Disables a policy.
       description: Disables a policy.
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: policyId
           in: path
           required: true
-          type: string
-      tags:
-        - DLP Policies and Dictionary Management
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/V3DLPPolicyResponse'
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-  '/v3/dlp/violations/message':
-    get:
-      summary: Get violations as a result of policy enforcement on messages.
-      description: Retrieves DLP v3 message related violations for a given time range
-      produces:
-        - application/json
-      parameters:
-        - name: startTime
-          description: |
-            Timestamp of the first required violation.
-            This is a long integer value representing milliseconds since Jan 1 1970
-          in: query
-          required: true
-          type: integer
-          format: int64
-        - name: endTime
-          description: |
-            Timestamp of the last required violation.
-            This is a long integer value representing milliseconds since Jan 1 1970
-            If unspecified, it will default to current time of the request.
-          in: query
-          required: false
-          type: integer
-          format: int64
-        - name: next
-          description: |
-            Offset of the next chunk of violations. Value is null for the first request.
-          in: query
-          type: string
-          required: false
-        - name: limit
-          description: |
-            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
-          in: query
-          type: integer
-          required: false
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-      tags:
-        - Violations
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/V3DLPViolationMessageResponse'
-        '204':
-          description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-
-  '/v3/dlp/violations/stream':
-    get:
-      summary: Get violations as a result of policy enforcement on streams.
-      description: Retrieves DLP v3 signal related violations for a given time range
-      produces:
-        - application/json
-      parameters:
-        - name: startTime
-          description: |
-            Timestamp of the first required violation.
-            This is a long integer value representing milliseconds since Jan 1 1970
-          in: query
-          required: true
-          type: integer
-          format: int64
-        - name: endTime
-          description: |
-            Timestamp of the last required violation.
-            This is a long integer value representing milliseconds since Jan 1 1970
-            If unspecified, it will default to current time of the request.
-          in: query
-          required: false
-          type: integer
-          format: int64
-        - name: next
-          description: |
-            Offset of the next chunk of violations. Value is null for the first request.
-          in: query
-          type: string
-          required: false
-        - name: limit
-          description: |
-            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
-          in: query
-          type: integer
-          required: false
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-      tags:
-        - Violations
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/V3DLPViolationStreamResponse'
-        '204':
-          description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-
-  '/v3/dlp/violations/signal':
-    get:
-      summary: Get violations as a result of policy enforcement on signals.
-      description: Retrieves DLP v3 signal related violations for a given time range
-      produces:
-        - application/json
-      parameters:
-        - name: startTime
-          description: |
-            Timestamp of the first required violation.
-            This is a long integer value representing milliseconds since Jan 1 1970
-          in: query
-          required: true
-          type: integer
-          format: int64
-        - name: endTime
-          description: |
-            Timestamp of the last required violation.
-            This is a long integer value representing milliseconds since Jan 1 1970
-            If unspecified, it will default to current time of the request.
-          in: query
-          required: false
-          type: integer
-          format: int64
-        - name: next
-          description: |
-            Offset of the next chunk of violations. Value is null for the first request.
-          in: query
-          type: string
-          required: false
-        - name: limit
-          description: |
-            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
-          in: query
-          type: integer
-          required: false
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-      tags:
-        - Violations
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/V3DLPViolationSignalResponse'
-        '204':
-          description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
-          description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
-          description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-
-  '/v3/dlp/violation/attachment':
-    get:
-      summary: Get attachments that were sent as part of messages that were flagged by the DLP System.
-      description: Retrieves attachments from related message violations as a base64 encoded String.
-      produces:
-        - application/octet-stream
-      parameters:
-        - name: fileId
-          description: |
-            ID of attachment that will be downloaded.
-          in: query
-          required: true
-          type: string
-        - name: violationId
-          description: |
-            ID of violation that corresponds to the flagged message that contains the attachment
-          in: query
-          required: true
-          type: string
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-      tags:
-        - Violations
-      responses:
-        '200':
-          description: Attachment body as Base64 encoded string.
           schema:
             type: string
-            format: byte
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3DLPPolicyResponse'
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '404':
-          description: 'Resource not found.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-
-  '/v1/audittrail/privilegeduser':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v3/dlp/violations/message:
     get:
-      summary: Get a list of  actions performed by a privileged account acting as privileged user given a period of time.
-      description: Get a list of actions performed by a privileged account acting as privileged user given a period of time.
-      produces:
-        - application/json
+      tags:
+        - Violations
+      summary: Get violations as a result of policy enforcement on messages.
+      description: Retrieves DLP v3 message related violations for a given time range
+      parameters:
+        - name: startTime
+          in: query
+          description: |
+            Timestamp of the first required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: endTime
+          in: query
+          description: |
+            Timestamp of the last required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+            If unspecified, it will default to current time of the request.
+          schema:
+            type: integer
+            format: int64
+        - name: next
+          in: query
+          description: Offset of the next chunk of violations. Value is null for the first request.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: |
+            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          schema:
+            type: integer
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3DLPViolationMessageResponse'
+        204:
+          description: No Messages.
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v3/dlp/violations/stream:
+    get:
+      tags:
+        - Violations
+      summary: Get violations as a result of policy enforcement on streams.
+      description: Retrieves DLP v3 signal related violations for a given time range
+      parameters:
+        - name: startTime
+          in: query
+          description: |
+            Timestamp of the first required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: endTime
+          in: query
+          description: |
+            Timestamp of the last required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+            If unspecified, it will default to current time of the request.
+          schema:
+            type: integer
+            format: int64
+        - name: next
+          in: query
+          description: Offset of the next chunk of violations. Value is null for the first request.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: |
+            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          schema:
+            type: integer
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3DLPViolationStreamResponse'
+        204:
+          description: No Messages.
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v3/dlp/violations/signal:
+    get:
+      tags:
+        - Violations
+      summary: Get violations as a result of policy enforcement on signals.
+      description: Retrieves DLP v3 signal related violations for a given time range
+      parameters:
+        - name: startTime
+          in: query
+          description: |
+            Timestamp of the first required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: endTime
+          in: query
+          description: |
+            Timestamp of the last required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+            If unspecified, it will default to current time of the request.
+          schema:
+            type: integer
+            format: int64
+        - name: next
+          in: query
+          description: Offset of the next chunk of violations. Value is null for the first request.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: |
+            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          schema:
+            type: integer
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V3DLPViolationSignalResponse'
+        204:
+          description: No Messages.
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v3/dlp/violation/attachment:
+    get:
+      tags:
+        - Violations
+      summary: Get attachments that were sent as part of messages that were flagged by the DLP System.
+      description: Retrieves attachments from related message violations as a base64 encoded String.
+      parameters:
+        - name: fileId
+          in: query
+          description: ID of attachment that will be downloaded.
+          required: true
+          schema:
+            type: string
+        - name: violationId
+          in: query
+          description: ID of violation that corresponds to the flagged message that contains the attachment
+          required: true
+          schema:
+            type: string
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Attachment body as Base64 encoded string.
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: byte
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+        404:
+          description: Resource not found.
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v1/audittrail/privilegeduser:
+    get:
+      tags:
+        - AuditTrail
+      summary: Get a list of  actions performed by a privileged account acting as
+        privileged user given a period of time.
+      description: Get a list of actions performed by a privileged account acting
+        as privileged user given a period of time.
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
         - name: startTimestamp
-          description: |
-            Start timestamp in unix timestamp in millseconds.
           in: query
+          description: Start timestamp in unix timestamp in millseconds.
           required: true
-          type: integer
-          format: int64
+          schema:
+            type: integer
+            format: int64
         - name: endTimestamp
-          description: |
-            End timestamp in unix timestamp in millseconds.
-            If not specified, it assumes to be current time.
           in: query
-          required: false
-          type: integer
-          format: int64
+          description: End timestamp in unix timestamp in millseconds. If not specified, it assumes to be current time.
+          schema:
+            type: integer
+            format: int64
         - name: before
-          description: |
-            Return results from an opaque “before” cursor value as presented via a response cursor.
           in: query
-          type: string
-          required: false
+          description: Return results from an opaque “before” cursor value as presented via a response cursor.
+          schema:
+            type: string
         - name: after
-          description: |
-            Return results from an opaque “after” cursor value as presented via a response cursor.
           in: query
-          type: string
-          required: false
+          description: Return results from an opaque “after” cursor value as presented via a response cursor.
+          schema:
+            type: string
         - name: limit
+          in: query
           description: |
             Max No. of violations to return. If no value is provided, 50 is the default.
             Some maximums for limit may be enforced for performance reasons.
             The maximum supported value is 500.
-          in: query
-          type: integer
-          required: false
+          schema:
+            type: integer
         - name: initiatorId
-          description: |
-            If present, only the initiator with this initiator <user id> will be returned.
           in: query
-          type: integer
-          format: int64
+          description: If present, only the initiator with this initiator <user id> will be returned.
+          schema:
+            type: integer
+            format: int64
         - name: role
+          in: query
           description: |
             If present, only the audit trail initiated by s user with privileged role acting as
             privileged user will be returned.
@@ -2893,36 +3403,108 @@ paths:
             L1 (L1_SUPPORT),
             L2 (L2_SUPPORT),
             Scope Manager (SCOPE_MANAGEMENT)
-          in: query
-          type: string
-          required: false
-      tags:
-        - AuditTrail
+          schema:
+            type: string
       responses:
-        '200':
+        200:
           description: OK
-          schema:
-            $ref: '#/definitions/V1AuditTrailInitiatorList'
-        '204':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1AuditTrailInitiatorList'
+        204:
           description: No Messages.
-        '400':
-          description: 'Client error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
-        '401':
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
           description: 'Unauthorized: Session tokens invalid.'
-          schema:
-            $ref: '#/definitions/Error'
-        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
           description: 'Forbidden: Caller lacks necessary entitlement.'
-          schema:
-            $ref: '#/definitions/Error'
-        '500':
-          description: 'Server error, see response body for further details.'
-          schema:
-            $ref: '#/definitions/Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /v5/datafeeds:
+    get:
+      tags:
+        - Datafeed
+      summary: Read list of real time messages / events stream ("datafeed").
+      description: |
+        _Available on Agent 2.57.0 and above._
 
-  '/v5/datafeeds':
+        The datafeed provides messages and events from all conversations that the user
+        is in. The types of events surfaced in the datafeed can be found in the [Real Time Events](./docs/real-time-events.md) list.
+
+        Returns the list of the datafeeds for the user.
+        Any datafeed ID of the list can then be used as input to the Read Messages/Events Stream v4 endpoint.
+      operationId: listDatafeed
+      parameters:
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+        - name: tag
+          in: query
+          description: A unique identifier to ensure uniqueness of the datafeed. Used
+            to restrict search.
+          schema:
+            maxLength: 100
+            type: string
+      responses:
+        200:
+          description: Datafeed sucessfully created.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/V5Datafeed'
+              example:
+                - id: 8e7c8672-220...
+                  createdAt: 1536346282592
+                - id: 8e7c8672-221...
+                  createdAt: 1536346282500
+        400:
+          description: Bad request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
+          description: Unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
     post:
       tags:
         - Datafeed
@@ -2939,99 +3521,50 @@ paths:
       operationId: createDatafeed
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: body
-          in: body
-          required: false
           schema:
-            $ref: '#/definitions/V5DatafeedCreateBody'
-      produces:
-        - application/json
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V5DatafeedCreateBody'
+        required: false
       responses:
         201:
           description: Datafeed sucessfully created.
-          schema:
-            $ref: '#/definitions/V5Datafeed'
-        400:
-          description: Bad request.
-          schema:
-            $ref: '#/definitions/V2Error'
-        401:
-          description: Unauthorized.
-          schema:
-            $ref: '#/definitions/V2Error'
-        500:
-          description: Internal server error.
-          schema:
-            $ref: '#/definitions/V2Error'
-
-    get:
-      tags:
-        - Datafeed
-      summary: Read list of real time messages / events stream ("datafeed").
-      description: |
-        _Available on Agent 2.57.0 and above._
-
-        The datafeed provides messages and events from all conversations that the user
-        is in. The types of events surfaced in the datafeed can be found in the [Real Time Events](./docs/real-time-events.md) list.
-
-        Returns the list of the datafeeds for the user.
-        Any datafeed ID of the list can then be used as input to the Read Messages/Events Stream v4 endpoint.
-      operationId: listDatafeed
-      produces:
-        - application/json
-      parameters:
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: tag
-          maxLength: 100
-          required: false
-          description: A unique identifier to ensure uniqueness of the datafeed. Used to restrict search.
-          in: query
-          type: string
-      responses:
-        200:
-          description: Datafeed sucessfully created.
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/V5Datafeed'
-          examples:
+          content:
             application/json:
-              - id: '8e7c8672-220...'
-                createdAt: 1536346282592
-              - id: '8e7c8672-221...'
-                createdAt: 1536346282500
-
+              schema:
+                $ref: '#/components/schemas/V5Datafeed'
         400:
           description: Bad request.
-          schema:
-            $ref: '#/definitions/V2Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
         401:
           description: Unauthorized.
-          schema:
-            $ref: '#/definitions/V2Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
         500:
           description: Internal server error.
-          schema:
-            $ref: '#/definitions/V2Error'
-  '/v5/datafeeds/{datafeedId}':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+      x-codegen-request-body-name: body
+  /v5/datafeeds/{datafeedId}:
     delete:
       tags:
         - Datafeed
@@ -3046,40 +3579,50 @@ paths:
         Delete the specified datafeed.
       operationId: deleteDatafeed
       parameters:
-        - in: path
-          name: datafeedId
-          required: true
-          type: string
+        - name: datafeedId
+          in: path
           description: ID of the datafeed
+          required: true
+          schema:
+            type: string
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
           required: true
-          type: string
+          schema:
+            type: string
         - name: keyManagerToken
-          description: Key Manager authentication token.
           in: header
+          description: Key Manager authentication token.
           required: true
-          type: string
+          schema:
+            type: string
       responses:
         204:
           description: Datafeed successfully deleted.
-          schema:
-            $ref: '#/definitions/V2Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
         400:
           description: Bad request.
-          schema:
-            $ref: '#/definitions/V2Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
         401:
           description: Unauthorized.
-          schema:
-            $ref: '#/definitions/V2Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
         500:
           description: Internal server error.
-          schema:
-            $ref: '#/definitions/V2Error'
-
-  '/v5/datafeeds/{datafeedId}/read':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+  /v5/datafeeds/{datafeedId}/read:
     post:
       tags:
         - Datafeed
@@ -3096,2219 +3639,2292 @@ paths:
         The ackId sent as parameter can be empty for the first call. In the response an ackId will be sent back and it can be used for
         the next call: in this way you acknowledge that you have received the events that came with that ackId; datafeed will remove the events
         associated with that ackId from your queue
-      consumes:
-        - application/json
-      produces:
-        - application/json
       operationId: readDatafeed
       parameters:
-        - in: path
-          name: datafeedId
-          required: true
-          type: string
+        - name: datafeedId
+          in: path
           description: ID of the datafeed
-        - name: sessionToken
-          description: Session authentication token.
-          in: header
           required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: ackId
-          description: ackId received from last POST Base64 encoded.
-          in: body
-          required: false
           schema:
-            $ref: '#/definitions/AckId'
+            type: string
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: ackId received from last POST Base64 encoded.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AckId'
+        required: false
       responses:
         200:
           description: Datafeed successfully read.
-          schema:
-            $ref: '#/definitions/V5EventList'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V5EventList'
         400:
           description: Bad request.
-          schema:
-            $ref: '#/definitions/V2Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
         401:
           description: Unauthorized.
-          schema:
-            $ref: '#/definitions/V2Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
         403:
           description: Forbidden.
-          schema:
-            $ref: '#/definitions/V2Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
         500:
           description: Internal server error.
-          schema:
-            $ref: '#/definitions/V2Error'
-
-  '/v5/events/read':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+      x-codegen-request-body-name: ackId
+  /v5/events/read:
     post:
       tags:
         - Datafeed
       summary: Read Real Time Events from an event stream (aka datafeed)
-      x-since: 22.5
       description: |
-        _Available on Agent 22.5 and above._
-
-        This endpoint provides messages and events from all conversations that the user
-        is in or events from the whole pod depending on the "type" field value.
-        When "type": "fanout" is provided in the body, then only events from streams the account belongs to are returned.
-        Otherwise, if "type": "datahose" is provided in the body, then events returned are not limited to the streams user
-        belongs to. In this case, at least one event type must be provided in the "filters" field. 
-        In case you are using a datahose feed and retrieving SOCIALMESSAGE events, ceservice account must be properly
-        configured in the Agent.
-
-        The types of events returned can be found in the Real Time Events list (see definition on top of the file).
-
-        The ackId sent as parameter can be empty for the first call. In the response an ackId will be sent back and it can be used for
-        the next call: in this way you acknowledge that you have received the events that came with that ackId.
-
-        If you have several instances of the same bot, they must share the same feed so that events are spread across
-        all bot instances. To do so, you must:
-        * share the same service account
-        * provide the same "tag" and same "filters" values
-      consumes:
-        - application/json
-      produces:
-        - application/json
+        _Available on Agent 22.5.1 and above.This endpoint provides
+        messages and events from all conversations that the user is in or events
+        from the whole pod depending on the "type" field value.
+        When "type":"fanout" is provided in the body, then only events from streams 
+        the accountbelongs to are returned. Otherwise, if "type": "datahose" is provided
+        in the body, then events returned are not limited to the streams user
+        belongs to. In this case, at least one event type must be provided in the
+        "filters" field. In case you are using a datahose feed and retrieving
+        SOCIALMESSAGE events, ceservice account must be properly configured in
+        the Agent.The types of events returned can be found in the Real Time
+        Events list (see definition on top of the file). The ackId sent as parameter
+        can be empty for the first call. In the response an ackId will be sent back
+        and it can be used for the next call: in this way you acknowledge that
+        you have received the events that came with that ackId.
+        If you have several instances of the same bot, they must share the same feed so 
+        that events are spread across all bot instances. To do so, you must: share the same 
+        service account provide the same "tag" and same "filters" values
       operationId: readEvents
       parameters:
         - name: sessionToken
+          in: header
           description: Session authentication token.
-          in: header
-          required: true
-          type: string
-        - name: keyManagerToken
-          description: Key Manager authentication token.
-          in: header
-          required: true
-          type: string
-        - name: body
-          description: body containing all information of events to be fetched
-          in: body
           required: true
           schema:
-            $ref: '#/definitions/V5EventsReadBody'
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: body containing all information of events to be fetched
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V5EventsReadBody'
+        required: true
       responses:
         200:
           description: Datafeed successfully read.
-          schema:
-            $ref: '#/definitions/V5EventList'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V5EventList'
         400:
           description: Bad request.
-          schema:
-            $ref: '#/definitions/V2Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
         401:
           description: Unauthorized.
-          schema:
-            $ref: '#/definitions/V2Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
         403:
           description: Forbidden.
-          schema:
-            $ref: '#/definitions/V2Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
         500:
           description: Internal server error.
-          schema:
-            $ref: '#/definitions/V2Error'
-definitions:
-  Error:
-    type: object
-    properties:
-      code:
-        type: integer
-        format: int32
-      message:
-        type: string
-  V2Error:
-    type: object
-    properties:
-      code:
-        type: integer
-        format: int32
-      message:
-        type: string
-      details:
-        type: object
-    required:
-    - code
-    - message
-  SuccessResponse:
-    type: object
-    properties:
-      format:
-        type: string
-        enum:
-          - TEXT
-          - XML
-      message:
-        type: string
-  V2BaseMessage:
-    type: object
-    discriminator: v2messageType
-    properties:
-      id:
-        type: string
-        description: The messageId is assigned by the ingestor service when a message is sent.
-      timestamp:
-        type: string
-      v2messageType:
-        type: string
-      streamId:
-        type: string
-    required:
-    - v2messageType
-    - timestamp
-    - streamId
-  V2Message:
-    type: object
-    description: A representation of a message sent by a user of Symphony.
-    allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+      x-codegen-request-body-name: body
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+    V2Error:
+      required:
+        - code
+        - message
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+        details:
+          type: object
+    SuccessResponse:
+      type: object
+      properties:
+        format:
+          type: string
+          enum:
+            - TEXT
+            - XML
+        message:
+          type: string
+    V2BaseMessage:
+      required:
+        - streamId
+        - timestamp
+        - v2messageType
+      type: object
+      properties:
+        id:
+          type: string
+          description: The messageId is assigned by the ingestor service when a message is sent.
+        timestamp:
+          type: string
+        v2messageType:
+          type: string
+        streamId:
+          type: string
+      discriminator:
+        propertyName: v2messageType
+    V2Message:
+      description: A representation of a message sent by a user of Symphony.
+      allOf:
+        - $ref: '#/components/schemas/V2BaseMessage'
+        - required:
+            - fromUserId
+            - message
+            - attachments
+          type: object
+          properties:
+            message:
+              type: string
+              description: Message text in MessageML
+              format: MessageML
+            fromUserId:
+              type: integer
+              description: the Symphony userId of the user who sent the message. This
+                will be populated by the server (and actually ignored if included when
+                sending a message).
+              format: int64
+            attachments:
+              type: array
+              items:
+                $ref: '#/components/schemas/AttachmentInfo'
+    RoomCreatedMessage:
+      description: Generated when a room is created.
+      allOf:
+        - $ref: '#/components/schemas/V2BaseMessage'
+        - type: object
+          required:
+            - keywords
+          properties:
+            creationDate:
+              type: integer
+              format: int64
+            name:
+              type: string
+            keywords:
+              type: array
+              items:
+                $ref: '#/components/schemas/RoomTag'
+            description:
+              type: string
+            createdByUserId:
+              type: integer
+              description: The Symphony userId of the user who created the room.
+              format: int64
+            readOnly:
+              type: boolean
+            discoverable:
+              type: boolean
+            public:
+              type: boolean
+            membersCanInvite:
+              type: boolean
+            copyProtected:
+              type: boolean
+    RoomDeactivatedMessage:
+      description: Generated when a room is deactivated.
+      allOf:
+        - $ref: '#/components/schemas/V2BaseMessage'
+        - type: object
+          properties:
+            deactivatedByUserId:
+              type: integer
+              format: int64
+    RoomReactivatedMessage:
+      description: Generated when a room is reactivated.
+      allOf:
+        - $ref: '#/components/schemas/V2BaseMessage'
+        - type: object
+          properties:
+            reactivatedByUserId:
+              type: integer
+              format: int64
+    RoomUpdatedMessage:
+      description: Generated when a room is updated.
+      allOf:
+        - $ref: '#/components/schemas/V2BaseMessage'
+        - type: object
+          required:
+            - keywords
+          properties:
+            oldName:
+              type: string
+            newName:
+              type: string
+            keywords:
+              type: array
+              items:
+                $ref: '#/components/schemas/RoomTag'
+            oldDescription:
+              type: string
+            newDescription:
+              type: string
+            membersCanInvite:
+              type: boolean
+            discoverable:
+              type: boolean
+            readOnly:
+              type: boolean
+            copyProtected:
+              type: boolean
+    UserJoinedRoomMessage:
+      description: Generated when a user joins a room.
+      allOf:
+        - $ref: '#/components/schemas/V2BaseMessage'
+        - type: object
+          properties:
+            addedByUserId:
+              type: integer
+              format: int64
+            memberAddedUserId:
+              type: integer
+              format: int64
+    UserLeftRoomMessage:
+      description: Generated when a user leaves a room.
+      allOf:
+        - $ref: '#/components/schemas/V2BaseMessage'
+        - type: object
+          properties:
+            removedByUserId:
+              type: integer
+              format: int64
+            memberLeftUserId:
+              type: integer
+              format: int64
+            informationBarrierRemediation:
+              type: boolean
+    RoomMemberPromotedToOwnerMessage:
+      description: Generated when a room member is promoted to owner.
+      allOf:
+        - $ref: '#/components/schemas/V2BaseMessage'
+        - type: object
+          properties:
+            promotedByUserId:
+              type: integer
+              format: int64
+            promotedUserId:
+              type: integer
+              format: int64
+    RoomMemberDemotedFromOwnerMessage:
+      description: Generated when a room member is promoted to owner.
+      allOf:
+        - $ref: '#/components/schemas/V2BaseMessage'
+        - type: object
+          properties:
+            demotedByUserId:
+              type: integer
+              format: int64
+            demotedUserId:
+              type: integer
+              format: int64
+    ConnectionRequestMessage:
+      description: Generated when a connection request is sent.
+      allOf:
+        - $ref: '#/components/schemas/V2BaseMessage'
+        - type: object
+          properties:
+            requestingUserId:
+              type: integer
+              format: int64
+            targetUserId:
+              type: integer
+              format: int64
+            firstRequestedAt:
+              type: integer
+              format: int64
+            updatedAt:
+              type: integer
+              format: int64
+            requestCounter:
+              type: integer
+            status:
+              type: string
+    AttachmentInfo:
+      required:
+        - id
+        - name
+        - size
+      type: object
+      properties:
+        id:
+          type: string
+          description: The attachment ID.
+        name:
+          type: string
+          description: The file name.
+        size:
+          type: integer
+          description: Size in bytes.
+          format: int64
+    V2MessageList:
+      type: array
+      items:
+        $ref: '#/components/schemas/V2BaseMessage'
+    SimpleMessage:
+      type: object
       properties:
         message:
           type: string
-          format: MessageML
-          description: Message text in MessageML
-        fromUserId:
+      description: A string wrapped in a JSON object.
+    RoomTag:
+      required:
+        - key
+        - value
+      type: object
+      properties:
+        key:
+          type: string
+          description: A unique label of the Tag.
+        value:
+          type: string
+          description: The value of this Tag's label.
+      description: Room Tag object. A key:value pair describing additional properties
+        of the room.
+    ShareArticle:
+      required:
+        - appId
+        - author
+        - publisher
+        - title
+      type: object
+      properties:
+        articleId:
+          type: string
+          description: |
+            An ID for this article that should be unique to the calling application. 
+            Either an articleId or an articleUrl is required.
+        title:
+          type: string
+          description: The title of the article
+        subTitle:
+          type: string
+          description: The subtitle of the article
+        message:
+          type: string
+          description: The message text that can be send along with the shared article
+        publisher:
+          type: string
+          description: Publisher of the article
+        publishDate:
           type: integer
+          description: Article publish date in unix timestamp
           format: int64
-          description: the Symphony userId of the user who sent the message. This will be populated by the server (and actually ignored if included when sending a message).
+        thumbnailUrl:
+          type: string
+          description: Url to the thumbnail image
+        author:
+          type: string
+          description: Author of the article
+        articleUrl:
+          type: string
+          description: Url to the article
+        summary:
+          type: string
+          description: Preview summary of the article
+        appId:
+          type: string
+          description: App ID of the calling application
+        appName:
+          type: string
+          description: App name of the calling application
+        appIconUrl:
+          type: string
+          description: App icon url of the calling application
+    ShareContent:
+      type: object
+      properties:
+        type:
+          type: string
+          description: Type of content to be shared.  Currently only support "com.symphony.sharing.article"
+        content:
+          $ref: '#/components/schemas/ShareArticle'
+    V2HealthCheckResponse:
+      type: object
+      properties:
+        podConnectivity:
+          type: boolean
+          description: Indicates whether the Agent server can connect to the Pod
+        podConnectivityError:
+          type: string
+          description: Error details in case of no Pod connectivity
+        keyManagerConnectivity:
+          type: boolean
+          description: Indicates whether the Agent server can connect to the Key Manager
+        keyManagerConnectivityError:
+          type: string
+          description: Error details in case of no Key Manager connectivity
+        firehoseConnectivity:
+          type: boolean
+          description: Indicates whether the Agent server can connect to Firehose Service
+        firehoseConnectivityError:
+          type: string
+          description: Error details in case of no Firehose connectivity
+        datafeedConnectivity:
+          type: boolean
+          description: Indicates whether the Agent server can connect to Datafeed V2 Service
+        datafeedConnectivityError:
+          type: string
+          description: Error details in case of no Datafeed V2 connectivity
+        datafeedVersion:
+          type: string
+          description: Indicates the Datafeed V2 version
+        encryptDecryptSuccess:
+          type: boolean
+          description: Indicates whether the Agent can successfully decrypt and encrypt messages
+        encryptDecryptError:
+          type: string
+          description: Error details in case of the encryption or decryption of the message fails
+        podVersion:
+          type: string
+          description: The version number of the pod
+        agentVersion:
+          type: string
+          description: The version number of the Agent server
+        agentServiceUser:
+          type: boolean
+          description: Indicates whether agent service user is setup correctly.
+        agentServiceUserError:
+          type: string
+          description: Error details in case agent service user is setup incorrectly.
+        ceServiceUser:
+          type: boolean
+          description: Indicates whether CEService user is setup correctly.
+        ceServiceUserError:
+          type: string
+          description: Error details in case CEService user is setup incorrectly.
+    MessageSearchQuery:
+      type: object
+      properties:
+        text:
+          type: string
+          description: Search for messages containing this text. Requires streamId
+            to be specified.
+        streamId:
+          type: string
+          description: Search for messages sent to this stream
+        streamType:
+          type: string
+          description: |
+            Search for messages sent to this type of streams. Accepted values are CHAT, IM, MIM, ROOM, POST.
+        author:
+          type: integer
+          description: Search for messages sent by this user ID
+          format: int64
+        hashtag:
+          type: string
+          description: Search for messages containing this hashtag
+        cashtag:
+          type: string
+          description: Search for messages containing this cashtag
+        mention:
+          type: integer
+          description: Search for messages mentioning this user ID
+          format: int64
+        signal:
+          type: string
+          description: |
+            Search for messages matching this signal. Can only be combined with date filtering and paging parameters.
+        fromDate:
+          type: integer
+          description: Search for messages sent on or after this timestamp
+          format: int64
+        toDate:
+          type: integer
+          description: Search for messages sent before this timestamp
+          format: int64
+    V4MessageImportList:
+      type: array
+      description: |
+        An ordered list of historic messages to be imported.
+        A list of import responses will be returned in the same order.
+      items:
+        $ref: '#/components/schemas/V4ImportedMessage'
+    V4ImportedMessage:
+      required:
+        - intendedMessageFromUserId
+        - intendedMessageTimestamp
+        - message
+        - originatingSystemId
+        - streamId
+      type: object
+      properties:
+        message:
+          type: string
+          description: Message text in MessageMLV2
+          format: MessageML
+        data:
+          type: string
+          description: Entity data in EntityJSON
+          format: JSON
+        intendedMessageTimestamp:
+          type: integer
+          description: |
+            The timestamp representing the time when the message was sent in the original system
+            in milliseconds since Jan 1st 1970.
+          format: int64
+        intendedMessageFromUserId:
+          type: integer
+          description: The long integer userid of the Symphony user who you intend to show sent the message.
+          format: int64
+        originatingSystemId:
+          type: string
+          description: The ID of the system through which the message was originally sent.
+        originalMessageId:
+          type: string
+          description: The ID of the message in the original system.
+        streamId:
+          type: string
         attachments:
           type: array
+          description: List of message attachments. Since Agent 20.14.
           items:
-            $ref: '#/definitions/AttachmentInfo'
-      required:
-      - message
-      - fromUserId
-  RoomCreatedMessage:
-    type: object
-    description: Generated when a room is created.
-    allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
+            $ref: '#/components/schemas/V4ImportedMessageAttachment'
+          x-since: 20.14
+        previews:
+          type: array
+          description: List of attachments previews. Since Agent 20.14.
+          items:
+            $ref: '#/components/schemas/V4ImportedMessageAttachment'
+          x-since: 20.14
+      description: |
+        A historic message to be imported into the system.
+        The importing user must have the Content Management role.
+        Also, the importing user must be a member of the conversation it is importing into.
+        The user that the message is intended to have come from must also be present in the conversation.
+        The intended message timestamp must be a valid time from the past. It cannot be a future timestamp.
+        By design, imported messages do not stream to datafeed or firehose endpoints.
+    V4ImportedMessageAttachment:
+      type: object
       properties:
-        creationDate:
-          type: integer
-          format: int64
+        filename:
+          type: string
+          description: Attachment filename
+          example: car.png
+        content:
+          type: string
+          description: Attachment content as Base64 encoded string
+    V4ImportResponseList:
+      type: array
+      items:
+        $ref: '#/components/schemas/V4ImportResponse'
+    V4ImportResponse:
+      type: object
+      properties:
+        messageId:
+          type: string
+          description: |
+            If the message was successfully imported then the message ID in the system
+            of the newly created message.
+        originatingSystemId:
+          type: string
+          description: The ID of the system through which the message was originally sent.
+        originalMessageId:
+          type: string
+          description: The ID of the message in the original system.
+        diagnostic:
+          type: string
+          description: |
+            A diagnostic message containing an error message in the event that the
+            message import failed. May also be present in the case of a successful
+            call if there is useful narrative to return.
+    V4AttachmentInfo:
+      required:
+        - id
+        - name
+        - size
+        - images
+      type: object
+      properties:
+        id:
+          type: string
+          description: The attachment ID.
         name:
           type: string
-        keywords:
+          description: The file name.
+        size:
+          type: integer
+          description: Size in bytes.
+          format: int64
+        images:
           type: array
           items:
-            $ref: '#/definitions/RoomTag'
+            $ref: '#/components/schemas/V4ThumbnailInfo'
+    V4ThumbnailInfo:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The thumbnail ID.
+        dimension:
+          type: string
+          description: The thumbnail pixel size.
+    V4MessageList:
+      type: array
+      items:
+        $ref: '#/components/schemas/V4Message'
+    V4Message:
+      type: object
+      required:
+        - attachments
+      properties:
+        messageId:
+          type: string
+          description: Id of the message
+        parentMessageId:
+          type: string
+          description: Id of the parent message, set when the message is a reply to
+            another message or a forwarded message. Since Agent 20.14.
+          x-since: 20.14
+        timestamp:
+          type: integer
+          description: Timestamp of the message in milliseconds since Jan 1 1970
+          format: int64
+        message:
+          type: string
+          description: Message content in MessageMLV2
+          format: MessageMLV2
+        sharedMessage:
+          $ref: '#/components/schemas/V4Message'
+        data:
+          type: string
+          description: Message data in EntityJSON
+          format: JSON
+        attachments:
+          type: array
+          description: Message attachments
+          items:
+            $ref: '#/components/schemas/V4AttachmentInfo'
+        user:
+          $ref: '#/components/schemas/V4User'
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+        externalRecipients:
+          type: boolean
+          description: Indicates if the message have external recipients. Only present
+            on real time messaging.
+        diagnostic:
+          type: string
+          description: |
+            Details if event failed to parse for any reason.  The contents of this field may not be useful,
+            depending on the nature of the error. Only present when error occurs.
+        userAgent:
+          type: string
+          description: |
+            User agent string for client that sent the message.  Allows callers to identify which client sent the
+            origin message (e.g. API Agent, SFE Client, mobile, etc)
+        originalFormat:
+          type: string
+          description: |
+            Indicates the format in which the message was originally sent.  This could have been either:
+            - com.symphony.markdown - Markdown OR Message ML V1
+            - com.symphony.messageml.v2 - Message ML V2
+        disclaimer:
+          type: string
+          description: |
+            Message that may be sent along with a regular message if configured for the POD,
+            usually the first message sent in a room that day.
+        sid:
+          type: string
+          description: |
+            Unique session identifier from where the message was created.
+          example: fa691cd3-484a-4109-aeb2-57c05b78c95b
+        replacing:
+          type: string
+          description: Id of the message that the current message is replacing (present only if set)
+        replacedBy:
+          type: string
+          description: Id of the message that the current message is being replaced with (present only if set)
+        initialTimestamp:
+          type: integer
+          description: |
+            Timestamp of when the initial message has been created in milliseconds since 
+            Jan 1 1970 (present only if set)
+          format: int64
+        initialMessageId:
+          type: string
+          description: Id the the initial message that has been updated (present only if set)
+        silent:
+          type: boolean
+          description: When false the user/s will receive the message update as unread (true by default)
+          x-since: 20.14
+      description: A representation of a message sent by a user of Symphony
+    V4MessageBlastResponse:
+      type: object
+      required:
+        - messages
+        - errors
+      properties:
+        messages:
+          type: array
+          description: List of messages successfully sent
+          items:
+            $ref: '#/components/schemas/V4Message'
+        errors:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/Error'
+          description: List of streams where the messages ingestion has failed
+      description: Wrapper response for a single message sent to multiple streams
+    V4User:
+      type: object
+      properties:
+        userId:
+          type: integer
+          description: Id of user
+          format: int64
+        firstName:
+          type: string
+          description: First name of user
+        lastName:
+          type: string
+          description: Last name of user
+        displayName:
+          type: string
+          description: User display name
+        email:
+          type: string
+          description: Email of user
+        username:
+          type: string
+          description: Applicable only to internal users
+    V4Stream:
+      type: object
+      properties:
+        streamId:
+          type: string
+          description: Id of stream
+        streamType:
+          type: string
+          description: |
+            Stream type, possible values are:
+              - IM
+              - MIM
+              - ROOM
+              - POST
+        roomName:
+          type: string
+          description: Applicable only to rooms
+        members:
+          type: array
+          description: Applicable only to IM Created
+          items:
+            $ref: '#/components/schemas/V4User'
+        external:
+          type: boolean
+        crossPod:
+          type: boolean
+    V4RoomProperties:
+      type: object
+      required:
+        - keywords
+      properties:
+        name:
+          type: string
         description:
           type: string
-        createdByUserId:
+        creatorUser:
+          $ref: '#/components/schemas/V4User'
+        createdDate:
           type: integer
+          description: Timestamp
           format: int64
-          description: The Symphony userId of the user who created the room.
-        readOnly:
+        external:
           type: boolean
-        discoverable:
+        crossPod:
           type: boolean
         public:
           type: boolean
-        membersCanInvite:
-          type: boolean
         copyProtected:
           type: boolean
-  RoomDeactivatedMessage:
-    type: object
-    description: Generated when a room is deactivated.
-    allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        deactivatedByUserId:
-          type: integer
-          format: int64
-  RoomReactivatedMessage:
-    type: object
-    description: Generated when a room is reactivated.
-    allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        reactivatedByUserId:
-          type: integer
-          format: int64
-  RoomUpdatedMessage:
-    type: object
-    description: Generated when a room is updated.
-    allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
-      properties:
-        oldName:
-          type: string
-        newName:
-          type: string
+        readOnly:
+          type: boolean
+        discoverable:
+          type: boolean
+        membersCanInvite:
+          type: boolean
         keywords:
           type: array
           items:
-            $ref: '#/definitions/RoomTag'
-        oldDescription:
-          type: string
-        newDescription:
-          type: string
-        membersCanInvite:
+            $ref: '#/components/schemas/V4KeyValuePair'
+        canViewHistory:
           type: boolean
-        discoverable:
-          type: boolean
-        readOnly:
-          type: boolean
-        copyProtected:
-          type: boolean
-  UserJoinedRoomMessage:
-    type: object
-    description: Generated when a user joins a room.
-    allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
+    V4KeyValuePair:
+      type: object
       properties:
-        addedByUserId:
-          type: integer
-          format: int64
-        memberAddedUserId:
-          type: integer
-          format: int64
-  UserLeftRoomMessage:
-    type: object
-    description: Generated when a user leaves a room.
-    allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
+        key:
+          type: string
+        value:
+          type: string
+    V4MessageSent:
+      type: object
       properties:
-        removedByUserId:
-          type: integer
-          format: int64
-        memberLeftUserId:
-          type: integer
-          format: int64
-        informationBarrierRemediation:
-          type: boolean
-  RoomMemberPromotedToOwnerMessage:
-    type: object
-    description: Generated when a room member is promoted to owner.
-    allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
+        message:
+          $ref: '#/components/schemas/V4Message'
+    V4Initiator:
+      type: object
       properties:
-        promotedByUserId:
-          type: integer
-          format: int64
-        promotedUserId:
-          type: integer
-          format: int64
-  RoomMemberDemotedFromOwnerMessage:
-    type: object
-    description: Generated when a room member is promoted to owner.
-    allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
+        user:
+          $ref: '#/components/schemas/V4User'
+    V4SharedPost:
+      type: object
       properties:
-        demotedByUserId:
-          type: integer
-          format: int64
-        demotedUserId:
-          type: integer
-          format: int64
-  ConnectionRequestMessage:
-    type: object
-    description: Generated when a connection request is sent.
-    allOf:
-    - $ref: '#/definitions/V2BaseMessage'
-    - type: object
+        message:
+          $ref: '#/components/schemas/V4Message'
+        sharedMessage:
+          $ref: '#/components/schemas/V4Message'
+    V4InstantMessageCreated:
+      type: object
       properties:
-        requestingUserId:
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+    V4RoomCreated:
+      type: object
+      properties:
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+        roomProperties:
+          $ref: '#/components/schemas/V4RoomProperties'
+    V4RoomUpdated:
+      type: object
+      properties:
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+        newRoomProperties:
+          $ref: '#/components/schemas/V4RoomProperties'
+    V4RoomDeactivated:
+      type: object
+      properties:
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+    V4RoomReactivated:
+      type: object
+      properties:
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+    V4UserJoinedRoom:
+      type: object
+      properties:
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+        affectedUser:
+          $ref: '#/components/schemas/V4User'
+    V4UserLeftRoom:
+      type: object
+      properties:
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+        affectedUser:
+          $ref: '#/components/schemas/V4User'
+    V4RoomMemberPromotedToOwner:
+      type: object
+      properties:
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+        affectedUser:
+          $ref: '#/components/schemas/V4User'
+    V4RoomMemberDemotedFromOwner:
+      type: object
+      properties:
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+        affectedUser:
+          $ref: '#/components/schemas/V4User'
+    V4ConnectionRequested:
+      type: object
+      properties:
+        toUser:
+          $ref: '#/components/schemas/V4User'
+    V4ConnectionAccepted:
+      type: object
+      properties:
+        fromUser:
+          $ref: '#/components/schemas/V4User'
+    V4MessageSuppressed:
+      type: object
+      properties:
+        messageId:
+          type: string
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+    V4SymphonyElementsAction:
+      type: object
+      properties:
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+        formMessageId:
+          type: string
+          description: The id of the message that contains the Form
+        formId:
+          type: string
+          description: The id of the Form element
+        formValues:
+          type: object
+          description: The values (in JSON format) answered on the Form
+    V4UserRequestedToJoinRoom:
+      type: object
+      properties:
+        stream:
+          $ref: '#/components/schemas/V4Stream'
+        affectedUsers:
+          type: array
+          description: List of affected users by the action (i.e. owners of the room)
+          items:
+            $ref: '#/components/schemas/V4User'
+    V4Payload:
+      type: object
+      properties:
+        messageSent:
+          $ref: '#/components/schemas/V4MessageSent'
+        sharedPost:
+          $ref: '#/components/schemas/V4SharedPost'
+        instantMessageCreated:
+          $ref: '#/components/schemas/V4InstantMessageCreated'
+        roomCreated:
+          $ref: '#/components/schemas/V4RoomCreated'
+        roomUpdated:
+          $ref: '#/components/schemas/V4RoomUpdated'
+        roomDeactivated:
+          $ref: '#/components/schemas/V4RoomDeactivated'
+        roomReactivated:
+          $ref: '#/components/schemas/V4RoomReactivated'
+        userJoinedRoom:
+          $ref: '#/components/schemas/V4UserJoinedRoom'
+        userLeftRoom:
+          $ref: '#/components/schemas/V4UserLeftRoom'
+        roomMemberPromotedToOwner:
+          $ref: '#/components/schemas/V4RoomMemberPromotedToOwner'
+        roomMemberDemotedFromOwner:
+          $ref: '#/components/schemas/V4RoomMemberDemotedFromOwner'
+        connectionRequested:
+          $ref: '#/components/schemas/V4ConnectionRequested'
+        connectionAccepted:
+          $ref: '#/components/schemas/V4ConnectionAccepted'
+        messageSuppressed:
+          $ref: '#/components/schemas/V4MessageSuppressed'
+        symphonyElementsAction:
+          $ref: '#/components/schemas/V4SymphonyElementsAction'
+        userRequestedToJoinRoom:
+          $ref: '#/components/schemas/V4UserRequestedToJoinRoom'
+    V4Event:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Event ID
+        messageId:
+          type: string
+          description: Message ID
+        timestamp:
           type: integer
+          description: Timestamp of event
           format: int64
-        targetUserId:
-          type: integer
-          format: int64
-        firstRequestedAt:
-          type: integer
-          format: int64
-        updatedAt:
-          type: integer
-          format: int64
-        requestCounter:
-          type: integer
-        status:
+        type:
           type: string
-  AttachmentInfo:
-    type: object
-    properties:
-      id:
-        type: string
-        description: The attachment ID.
-      name:
-        type: string
-        description: The file name.
-      size:
-        type: integer
-        format: int64
-        description: Size in bytes.
-    required:
-    - id
-    - name
-    - size
-  V2MessageList:
-    type: array
-    items:
-      $ref: '#/definitions/V2BaseMessage'
-  SimpleMessage:
-    description: A string wrapped in a JSON object.
-    type: object
-    properties:
-      message:
-        type: string
-
-  RoomTag:
-    description: Room Tag object. A key:value pair describing additional properties of the room.
-    properties:
-      key:
-        description: A unique label of the Tag.
-        type: string
-      value:
-        description: The value of this Tag's label.
-        type: string
-    required:
-    - key
-    - value
-  ShareArticle:
-    type: object
-    properties:
-      articleId:
-        type: string
-        description: An ID for this article that should be unique to the calling application. Either an articleId or an articleUrl is required.
-      title:
-        type: string
-        description: The title of the article
-      subTitle:
-        type: string
-        description: The subtitle of the article
-      message:
-        type: string
-        description: The message text that can be send along with the shared article
-      publisher:
-        type: string
-        description: Publisher of the article
-      publishDate:
-        type: integer
-        format: int64
-        description: Article publish date in unix timestamp
-      thumbnailUrl:
-        type: string
-        description: Url to the thumbnail image
-      author:
-        type: string
-        description: Author of the article
-      articleUrl:
-        type: string
-        description: Url to the article
-      summary:
-        type: string
-        description: Preview summary of the article
-      appId:
-        type: string
-        description: App ID of the calling application
-      appName:
-        type: string
-        description: App name of the calling application
-      appIconUrl:
-        type: string
-        description: App icon url of the calling application
-    required:
-    - title
-    - publisher
-    - author
-    - appId
-  ShareContent:
-    type: object
-    properties:
-      type:
-        type: string
-        description: Type of content to be shared.  Currently only support "com.symphony.sharing.article"
-      content:
-        $ref: '#/definitions/ShareArticle'
-  V2HealthCheckResponse:
-     type: object
-     properties:
-       podConnectivity:
-         type: boolean
-         description: Indicates whether the Agent server can connect to the Pod
-       podConnectivityError:
-         type: string
-         description: Error details in case of no Pod connectivity
-       keyManagerConnectivity:
-         type: boolean
-         description: Indicates whether the Agent server can connect to the Key Manager
-       keyManagerConnectivityError:
-         type: string
-         description: Error details in case of no Key Manager connectivity
-       firehoseConnectivity:
-         type: boolean
-         description: Indicates whether the Agent server can connect to Firehose Service
-       firehoseConnectivityError:
-         type: string
-         description: Error details in case of no Firehose connectivity
-       encryptDecryptSuccess:
-         type: boolean
-         description: Indicates whether the Agent can successfully decrypt and encrypt messages
-       encryptDecryptError:
-         type: string
-         description: Error details in case of the encryption or decryption of the message fails
-       podVersion:
-         type: string
-         description: The version number of the pod
-       agentVersion:
-         type: string
-         description: The version number of the Agent server
-       agentServiceUser:
-         type: boolean
-         description: Indicates whether agent service user is setup correctly.
-       agentServiceUserError:
-         type: string
-         description: Error details in case agent service user is setup incorrectly.
-       ceServiceUser:
-         type: boolean
-         description: Indicates whether CEService user is setup correctly.
-       ceServiceUserError:
-         type: string
-         description: Error details in case CEService user is setup incorrectly.
-  MessageSearchQuery:
-    type: object
-    properties:
-      text:
-        type: string
-        description: Search for messages containing this text. Requires streamId to be specified.
-      streamId:
-        type: string
-        description: Search for messages sent to this stream
-      streamType:
-        type: string
-        description: |
-          Search for messages sent to this type of streams. Accepted values are CHAT, IM, MIM, ROOM, POST.
-      author:
-        type: integer
-        format: int64
-        description: Search for messages sent by this user ID
-      hashtag:
-        type: string
-        description: Search for messages containing this hashtag
-      cashtag:
-        type: string
-        description: Search for messages containing this cashtag
-      mention:
-        type: integer
-        format: int64
-        description: Search for messages mentioning this user ID
-      signal:
-        type: string
-        description: |
-          Search for messages matching this signal. Can only be combined with date filtering and paging parameters.
-      fromDate:
-        type: integer
-        format: int64
-        description: Search for messages sent on or after this timestamp
-      toDate:
-        type: integer
-        format: int64
-        description: Search for messages sent before this timestamp
-  V4MessageImportList:
-    description: |
-      An ordered list of historic messages to be imported.
-      A list of import responsees will be returned in the same order.
-    type: array
-    items:
-      $ref: '#/definitions/V4ImportedMessage'
-  V4ImportedMessage:
-    description: |
-      A historic message to be imported into the system.
-      The importing user must have the Content Management role.
-      Also, the importing user must be a member of the conversation it is importing into.
-      The user that the message is intended to have come from must also be present in the conversation.
-      The intended message timestamp must be a valid time from the past. It cannot be a future timestamp.
-      By design, imported messages do not stream to datafeed or firehose endpoints.
-    type: object
-    properties:
-      message:
-        type: string
-        format: MessageML
-        description: Message text in MessageMLV2
-      data:
-        type: string
-        format: JSON
-        description: Entity data in EntityJSON
-      intendedMessageTimestamp:
-        description: |
-          The timestamp representing the time when the message was sent in the original system
-          in milliseconds since Jan 1st 1970.
-        type: integer
-        format: int64
-      intendedMessageFromUserId:
-        description: |
-          The long integer userid of the Symphony user who you intend to show sent the message.
-        type: integer
-        format: int64
-      originatingSystemId:
-        description: |
-          The ID of the system through which the message was originally sent.
-        type: string
-      originalMessageId:
-        description: |
-          The ID of the message in the original system.
-        type: string
-      streamId:
-        type: string
-      attachments:
-        description: List of message attachments. Since Agent 20.14.
-        type: array
-        items:
-          $ref: '#/definitions/V4ImportedMessageAttachment'
-        x-since: 20.14
-      previews:
-        description: List of attachments previews. Since Agent 20.14.
-        type: array
-        items:
-          $ref: '#/definitions/V4ImportedMessageAttachment'
-        x-since: 20.14
-    required:
-    - message
-    - intendedMessageTimestamp
-    - intendedMessageFromUserId
-    - originatingSystemId
-    - streamId
-  V4ImportedMessageAttachment:
-    type: object
-    properties:
-      filename:
-        description: Attachment filename
-        type: string
-        example: 'car.png'
-      content:
-        description: Attachment content as Base64 encoded string
-        type: string
-  V4ImportResponseList:
-    type: array
-    items:
-      $ref: '#/definitions/V4ImportResponse'
-  V4ImportResponse:
-    type: object
-    properties:
-      messageId:
-        description: |
-          If the message was successfully imported then the message ID in the system
-          of the newly created message.
-        type: string
-      originatingSystemId:
-        description: |
-          The ID of the system through which the message was originally sent.
-        type: string
-      originalMessageId:
-        description: |
-          The ID of the message in the original system.
-        type: string
-      diagnostic:
-        description: |
-          A diagnostic message containing an error message in the event that the
-          message import failed. May also be present in the case of a successful
-          call if there is useful narrative to return.
-        type: string
-  V4AttachmentInfo:
-    type: object
-    properties:
-      id:
-        type: string
-        description: The attachment ID.
-      name:
-        type: string
-        description: The file name.
-      size:
-        type: integer
-        format: int64
-        description: Size in bytes.
-      images:
-        type: array
-        items:
-          $ref: '#/definitions/V4ThumbnailInfo'
-    required:
-    - id
-    - name
-    - size
-  V4ThumbnailInfo:
-    type: object
-    properties:
-      id:
-        type: string
-        description: The thumbnail ID.
-      dimension:
-        type: string
-        description: The thumbnail pixel size.
-  V4MessageList:
-    type: array
-    items:
-      $ref: '#/definitions/V4Message'
-  V4Message:
-    type: object
-    description: A representation of a message sent by a user of Symphony
-    properties:
-      messageId:
-        type: string
-        description: Id of the message
-      parentMessageId:
-        type: string
-        description: Id of the parent message, set when the message is a reply to another message or a forwarded message. Since Agent 20.14.
-        x-since: 20.14
-      timestamp:
-        type: integer
-        format: int64
-        description: Timestamp of the message in milliseconds since Jan 1 1970
-      message:
-        type: string
-        format: MessageMLV2
-        description: Message content in MessageMLV2
-      sharedMessage:
-        description: Only present when the message represented by this class is a wall post sharing another message.
-        $ref: '#/definitions/V4Message'
-      data:
-        type: string
-        format: JSON
-        description: Message data in EntityJSON
-      attachments:
-        description: Message attachments
-        type: array
-        items:
-          $ref: '#/definitions/V4AttachmentInfo'
-      user:
-        $ref: '#/definitions/V4User'
-      stream:
-        $ref: '#/definitions/V4Stream'
-      externalRecipients:
-        description: Indicates if the message have external recipients. Only present on real time messaging.
-        type: boolean
-      diagnostic:
-        type: string
-        description: |
-          Details if event failed to parse for any reason.  The contents of this field may not be useful,
-          depending on the nature of the error. Only present when error occurs.
-      userAgent:
-        type: string
-        description: |
-          User agent string for client that sent the message.  Allows callers to identify which client sent the
-          origin message (e.g. API Agent, SFE Client, mobile, etc)
-      originalFormat:
-        type: string
-        description: |
-          Indicates the format in which the message was originally sent.  This could have been either:
-          - com.symphony.markdown - Markdown OR Message ML V1
-          - com.symphony.messageml.v2 - Message ML V2
-      disclaimer:
-        type: string
-        description: |
-          Message that may be sent along with a regular message if configured for the POD,
-          usually the first message sent in a room that day.
-      sid:
-        type: string
-        description: |
-          Unique session identifier from where the message was created.
-        example: 'fa691cd3-484a-4109-aeb2-57c05b78c95b'
-      replacing:
-        type: string
-        description: Id of the message that the current message is replacing (present only if set)
-      replacedBy:
-        type: string
-        description: Id of the message that the current message is being replaced with (present only if set)
-      initialTimestamp:
-        type: integer
-        format: int64
-        description: Timestamp of when the initial message has been created in milliseconds since Jan 1 1970 (present only if set)
-      initialMessageId:
-        type: string
-        description: Id the the initial message that has been updated (present only if set)
-      silent:
-        type: boolean
-        description: When false the user/s will receive the message update as unread (true by default). Since Agent 20.14.
-        x-since: 20.14
-  V4MessageBlastResponse:
-    type: object
-    description: Wrapper response for a single message sent to multiple streams
-    properties:
-      messages:
-        type: array
-        description: List of messages successfully sent
-        items:
-          $ref: '#/definitions/V4Message'
-      errors:
-        type: object
-        description: List of streams where the messages ingestion has failed
-        additionalProperties:
-          $ref: '#/definitions/Error'
-  V4User:
-    type: object
-    properties:
-      userId:
-        type: integer
-        format: int64
-        description: Id of user
-      firstName:
-        type: string
-        description: First name of user
-      lastName:
-        type: string
-        description: Last name of user
-      displayName:
-        type: string
-        description: User display name
-      email:
-        type: string
-        description: Email of user
-      username:
-        type: string
-        description: Applicable only to internal users
-  V4Stream:
-    type: object
-    properties:
-      streamId:
-        type: string
-        description: Id of stream
-      streamType:
-        type: string
-        description: |
-          Stream type, possible values are:
-            - IM
-            - MIM
-            - ROOM
-            - POST
-      roomName:
-        type: string
-        description: Applicable only to rooms
-      members:
-        description: Applicable only to IM Created
-        type: array
-        items:
-          $ref: '#/definitions/V4User'
-      external:
-        type: boolean
-      crossPod:
-        type: boolean
-  V4RoomProperties:
-    type: object
-    properties:
-      name:
-        type: string
-      description:
-        type: string
-      creatorUser:
-        $ref: '#/definitions/V4User'
-      createdDate:
-        type: integer
-        format: int64
-        description: Timestamp
-      external:
-        type: boolean
-      crossPod:
-        type: boolean
-      public:
-        type: boolean
-      copyProtected:
-        type: boolean
-      readOnly:
-        type: boolean
-      discoverable:
-        type: boolean
-      membersCanInvite:
-        type: boolean
-      keywords:
-        type: array
-        items:
-          $ref: '#/definitions/V4KeyValuePair'
-      canViewHistory:
-        type: boolean
-  V4KeyValuePair:
-    type: object
-    properties:
-      key:
-        type: string
-      value:
-        type: string
-  V4MessageSent:
-    type: object
-    properties:
-      message:
-        $ref: '#/definitions/V4Message'
-  V4Initiator:
-    type: object
-    properties:
-      user:
-        $ref: '#/definitions/V4User'
-  V4SharedPost:
-    type: object
-    properties:
-      message:
-        $ref: '#/definitions/V4Message'
-      sharedMessage:
-        $ref: '#/definitions/V4Message'
-  V4InstantMessageCreated:
-    type: object
-    properties:
-      stream:
-        $ref: '#/definitions/V4Stream'
-  V4RoomCreated:
-    type: object
-    properties:
-      stream:
-        $ref: '#/definitions/V4Stream'
-      roomProperties:
-        $ref: '#/definitions/V4RoomProperties'
-  V4RoomUpdated:
-    type: object
-    properties:
-      stream:
-        $ref: '#/definitions/V4Stream'
-      newRoomProperties:
-        $ref: '#/definitions/V4RoomProperties'
-  V4RoomDeactivated:
-    type: object
-    properties:
-      stream:
-        $ref: '#/definitions/V4Stream'
-  V4RoomReactivated:
-    type: object
-    properties:
-      stream:
-        $ref: '#/definitions/V4Stream'
-  V4UserJoinedRoom:
-    type: object
-    properties:
-      stream:
-        $ref: '#/definitions/V4Stream'
-      affectedUser:
-        # User who was affected by the action (i.e. added to the room)
-        $ref: '#/definitions/V4User'
-  V4UserLeftRoom:
-    type: object
-    properties:
-      stream:
-        $ref: '#/definitions/V4Stream'
-      affectedUser:
-        # User who was affected by the action (i.e. left the room)
-        $ref: '#/definitions/V4User'
-  V4RoomMemberPromotedToOwner:
-    type: object
-    properties:
-      stream:
-        $ref: '#/definitions/V4Stream'
-      affectedUser:
-        # User who was affected by the action (i.e. promoted to owner)
-        $ref: '#/definitions/V4User'
-  V4RoomMemberDemotedFromOwner:
-    type: object
-    properties:
-      stream:
-        $ref: '#/definitions/V4Stream'
-      affectedUser:
-        # User who was affected by the action (i.e. demoted from owner)
-        $ref: '#/definitions/V4User'
-  V4ConnectionRequested:
-    type: object
-    properties:
-      toUser:
-        # User who received the connection request
-        $ref: '#/definitions/V4User'
-  V4ConnectionAccepted:
-    type: object
-    properties:
-      fromUser:
-        # User who sent the connection request
-        $ref: '#/definitions/V4User'
-  V4MessageSuppressed:
-    type: object
-    properties:
-      messageId:
-        type: string
-      stream:
-        # the stream holding the suppressed message
-        $ref: '#/definitions/V4Stream'
-  V4SymphonyElementsAction:
-    type: object
-    properties:
-      stream:
-        description: "The stream where the Form message was posted"
-        $ref: '#/definitions/V4Stream'
-      formMessageId:
-        description: "The id of the message that contains the Form"
-        type: string
-      formId:
-        description: "The id of the Form element"
-        type: string
-      formValues:
-        description: "The values (in JSON format) answered on the Form"
-        type: object
-  V4UserRequestedToJoinRoom:
-    type: object
-    properties:
-      stream:
-        description: "The stream that the user requested to join"
-        $ref: '#/definitions/V4Stream'
-      affectedUsers:
-        type: array
-        description: "List of affected users by the action (i.e. owners of the room)"
-        items:
-          $ref: '#/definitions/V4User'
-  V4Payload:
-    type: object
-    properties:
-      messageSent:
-        $ref: '#/definitions/V4MessageSent'
-      sharedPost:
-        $ref: '#/definitions/V4SharedPost'
-      instantMessageCreated:
-        $ref: '#/definitions/V4InstantMessageCreated'
-      roomCreated:
-        $ref: '#/definitions/V4RoomCreated'
-      roomUpdated:
-        $ref: '#/definitions/V4RoomUpdated'
-      roomDeactivated:
-        $ref: '#/definitions/V4RoomDeactivated'
-      roomReactivated:
-        $ref: '#/definitions/V4RoomReactivated'
-      userJoinedRoom:
-        $ref: '#/definitions/V4UserJoinedRoom'
-      userLeftRoom:
-        $ref: '#/definitions/V4UserLeftRoom'
-      roomMemberPromotedToOwner:
-        $ref: '#/definitions/V4RoomMemberPromotedToOwner'
-      roomMemberDemotedFromOwner:
-        $ref: '#/definitions/V4RoomMemberDemotedFromOwner'
-      connectionRequested:
-        $ref: '#/definitions/V4ConnectionRequested'
-      connectionAccepted:
-        $ref: '#/definitions/V4ConnectionAccepted'
-      messageSuppressed:
-        $ref: '#/definitions/V4MessageSuppressed'
-      symphonyElementsAction:
-        $ref: '#/definitions/V4SymphonyElementsAction'
-      userRequestedToJoinRoom:
-        $ref: '#/definitions/V4UserRequestedToJoinRoom'
-  V4Event:
-    type: object
-    properties:
-      id:
-        type: string
-        description: Event ID
-      messageId:
-        type: string
-        description: Message ID
-      timestamp:
-        type: integer
-        format: int64
-        description: Timestamp of event
-      type:
-        type: string
-        description: |
-          Event type, possible events are:
-            - MESSAGESENT
-            - SHAREDPOST
-            - INSTANTMESSAGECREATED
-            - ROOMCREATED
-            - ROOMUPDATED
-            - ROOMDEACTIVATED
-            - ROOMREACTIVATED
-            - USERJOINEDROOM
-            - USERLEFTROOM
-            - ROOMMEMBERPROMOTEDTOOWNER
-            - ROOMMEMBERDEMOTEDFROMOWNER
-            - CONNECTIONREQUESTED
-            - CONNECTIONACCEPTED
-            - MESSAGESUPPRESSED
-            - SYMPHONYELEMENTSACTION
-            - USERREQUESTEDTOJOINROOM
-      diagnostic:
-        type: string
-        description: |
-          Details if event failed to parse for any reason.  The contents of this field may not be useful,
-          depending on the nature of the error. Only present when error occurs.
-      initiator:
-        # Actor who initiated the event
-        $ref: '#/definitions/V4Initiator'
-      payload:
-        # Holds payload for all event types
-        $ref: '#/definitions/V4Payload'
-  V4EventList:
-    type: array
-    items:
-      $ref: '#/definitions/V4Event'
-  BaseSignal:
-    type: object
-    properties:
-      name:
-        type: string
-        description: Signal name
-      query:
-        type: string
-        description: |
-          The query used to define this signal. The query is defined as "field:value" pairs combined by the operators
-          "AND" or "OR". Supported fields are (case-insensitive): "author", "hashtag" and "cashtag".
-          MUST contain at least one "hashtag" or "cashtag" definition.
-      visibleOnProfile:
-        type: boolean
-        description: Whether the signal is visible on its creator's profile
-      companyWide:
-        type: boolean
-        description: Whether the signal is a push signal
-  Signal:
-    allOf:
-      - $ref: '#/definitions/BaseSignal'
-      - type: object
-        properties:
-          id:
-            type: string
-            description: Signal ID
-          timestamp:
-            type: integer
-            format: int64
-            description: Timestamp when the signal was created, in milliseconds since Jan 1 1970
-          companyWide:
-            type: boolean
-            description: Whether the signal is a push signal
-  SignalList:
-    type: array
-    items:
-      $ref: '#/definitions/Signal'
-  ChannelSubscriptionResponse:
-    type: object
-    properties:
-      requestedSubscription:
-        type: integer
-        format: int64
-        description: The number of requested userIds to subscribe
-      successfulSubscription:
-        type: integer
-        format: int64
-        description: The number of successful subscriptions done
-      failedSubscription:
-        type: integer
-        format: int64
-        description: The number of subscription failures
-      subscriptionErrors:
-        type: array
-        items:
-          $ref: '#/definitions/ChannelSubscriptionError'
-  ChannelSubscriptionError:
-    type: object
-    properties:
-      userId:
-        type: integer
-        format: int64
-        description: The userId on which failure happened
-      code:
-        type: string
-        description: subscription failure code
-      message:
-        type: string
-        description: subscription failure message
-  ChannelSubscriberResponse:
-    type: object
-    properties:
-      offset:
-        type: integer
-        format: int64
-        description: The number of subscribers skipped
-      hasMore:
-        type: boolean
-        description: True if there are more subscribers
-      total:
-        type: integer
-        description: The total number of subscribers
-      data:
-        type: array
-        items:
-          $ref: '#/definitions/ChannelSubscriber'
-  ChannelSubscriber:
-    type: object
-    properties:
-      subscriptionId:
-        type: string
-      pushed:
-        type: boolean
-        description: True if the subscriber is allowed to unsubscribe
-      owner:
-        type: boolean
-        description: True if the subscriber is the creator
-      subscriberName:
-        type: string
-        description: User display name
-      userId:
-        type: integer
-        format: int64
-        description: The user ID of the subscriber
-      timestamp:
-        type: integer
-        format: int64
-        description: Timestamp when the signal was subscribed, in milliseconds since Jan 1 1970
-  AgentInfo:
-    type: object
-    properties:
-      ipAddress:
-        type: string
-        description: The IP address of the Agent server.
-      hostname:
-        type: string
-        description: The hostname of the Agent server.
-      serverFqdn:
-        type: string
-        description: The fully-qualified domain name of the Agent server. Must be set by the user at startup.
-      version:
-        type: string
-        description: The version of the Agent.
-      url:
-        type: string
-        description: The URL under which the Agent is available.
-      onPrem:
-        type: boolean
-        description: Whether this is an on-prem or cloud installation.
-      commitId:
-        type: string
-        description: The Git commit ID of the running revision.
-  V1DLPPoliciesCollectionResponse:
-    type: object
-    properties:
-      policies:
-        type: array
-        description: List of policies
-        items:
-          $ref: '#/definitions/V1DLPPolicy'
-      page:
-        type: integer
-        format: int32
-        description: Page number of current page
-      pageCount:
-        type: integer
-        format: int32
-        description: Total number of pages available
-    description: List of policies
-  V1DLPPolicy:
-    type: object
-    required:
-    - "contentTypes"
-    - "name"
-    - "scopes"
-    - "type"
-    properties:
-      active:
-        type: boolean
-        description: Indicate whether the policy is active or not
-      contentTypes:
-        type: array
-        description: |
-          The list of content types that policy should apply to. Cannot be empty. Policy content types could be either of "Messages", "RoomMeta", "SignalMeta".
-          Default is set to ["Messages"] if not specified.
-        items:
+          description: |
+            Event type, possible events are:
+              - MESSAGESENT
+              - SHAREDPOST
+              - INSTANTMESSAGECREATED
+              - ROOMCREATED
+              - ROOMUPDATED
+              - ROOMDEACTIVATED
+              - ROOMREACTIVATED
+              - USERJOINEDROOM
+              - USERLEFTROOM
+              - ROOMMEMBERPROMOTEDTOOWNER
+              - ROOMMEMBERDEMOTEDFROMOWNER
+              - CONNECTIONREQUESTED
+              - CONNECTIONACCEPTED
+              - MESSAGESUPPRESSED
+              - SYMPHONYELEMENTSACTION
+              - USERREQUESTEDTOJOINROOM
+        diagnostic:
           type: string
-      creationDate:
-        type: integer
-        format: int64
-        description: |
-          Creation time of the policy in milliseconds elapsed as of epoch time.
-      creatorId:
-        type: string
-        description: Numeric userId of the creator
-      dictionaryRefs:
-        type: array
-        description: List of dictionaries.
-        items:
-          $ref: '#/definitions/V1DLPDictionaryRef'
-      lastDisabledDate:
-        type: integer
-        format: int64
-        description: |
-          Recent disable time of the policy in milliseconds elapsed as of epoch time.
-      lastUpdatedDate:
-        type: integer
-        format: int64
-        description: Recent update time of the policy in milliseconds elapsed as of epoch time.
-      name:
-        type: string
-        description: Unique name of a policy, max 30 characters. Cannot be empty. All the leading and trailing blank spaces are trimmed.
-      policyId:
-        type: string
-        description: Policy Id
-      scopes:
-        type: array
-        description: |
-          List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
-          You can apply both scopes if you set it to ["Internal", "External"].
-        items:
-          type: string
-      type:
-        type: string
-        description: Type of policy. Possible values "Block" or "Warn".
-      version:
-        type: string
-        description: |
-          The version of a dictionary, in format "major.minor". Initial value will set by backend as "1.0" when created.
-          Whenever the dictionary version needs to be changed, the minor version by 1 unless minor == 999, then the major version is increased by 1 until it reaches 999.
-    description: The policy object for expression filter, one policy can have multiple dictionaries
-  V1DLPPolicyRequest:
-    type: object
-    required:
-    - "contentTypes"
-    - "name"
-    - "scopes"
-    - "type"
-    properties:
-      contentTypes:
-        type: array
-        description: |
-          The list of content types that policy should apply to. Cannot be empty. Policy content types could be either of "Messages", "RoomMeta", "SignalMeta".
-          Default is set to ["Messages"] if not specified.
-        items:
-          type: string
-      dictionaryIds:
-        type: array
-        description: List of dictionaries Ids for the policy.
-        items:
-          type: string
-      name:
-        type: string
-        description: Unique name of a policy, max 30 characters. Cannot be empty. All the leading and trailing blank spaces are trimmed.
-      scopes:
-        type: array
-        description: |
-          List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
-          You can apply both scopes if you set it to ["Internal", "External"].
-        items:
-          type: string
-      type:
-        type: string
-        description: Type of policy. Possible values "Block" or "Warn".
-    description: The policy object to use for creating/updating a policy.
-  V1DLPPolicyResponse:
-    type: object
-    properties:
-      data:
-        $ref: '#/definitions/V1DLPPolicy'
-    description: Policy Response
-  V1DLPDictionary:
-    type: object
-    required:
-    - dictionaryMetadata
-    properties:
-      content:
-        $ref: '#/definitions/V1DLPDictionaryContent'
-      dictionaryMetadata:
-        $ref: '#/definitions/V1DLPDictionaryMetadata'
-    description: Dictionary object
-  V1DLPDictionaryContent:
-    type: object
-    properties:
-      data:
-        type: string
-        description: |
-          A comma separated string which contains a lot of keywords/regexes.
-      numKeywords:
-        type: integer
-        format: int32
-        description: Number of Keywords in dictionary
-      md5:
-        type: string
-        description: MD5 value of the content
-    description: Content of a dictionary
-  V1DLPDictionaryMetadataCollectionResponse:
-    type: object
-    properties:
+          description: |
+            Details if event failed to parse for any reason.  The contents of this field may not be useful,
+            depending on the nature of the error. Only present when error occurs.
+        initiator:
+          $ref: '#/components/schemas/V4Initiator'
+        payload:
+          $ref: '#/components/schemas/V4Payload'
+    V4EventList:
+      type: array
       items:
-        type: array
-        description: List of dictionary metadata
+        $ref: '#/components/schemas/V4Event'
+    BaseSignal:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Signal name
+        query:
+          type: string
+          description: |
+            The query used to define this signal. The query is defined as "field:value" pairs combined by the operators
+            "AND" or "OR". Supported fields are (case-insensitive): "author", "hashtag" and "cashtag".
+            MUST contain at least one "hashtag" or "cashtag" definition.
+        visibleOnProfile:
+          type: boolean
+          description: Whether the signal is visible on its creator's profile
+        companyWide:
+          type: boolean
+          description: Whether the signal is a push signal
+    Signal:
+      allOf:
+        - $ref: '#/components/schemas/BaseSignal'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: Signal ID
+            timestamp:
+              type: integer
+              description: Timestamp when the signal was created, in milliseconds since
+                Jan 1 1970
+              format: int64
+            companyWide:
+              type: boolean
+              description: Whether the signal is a push signal
+    SignalList:
+      type: array
+      items:
+        $ref: '#/components/schemas/Signal'
+    ChannelSubscriptionResponse:
+      type: object
+      properties:
+        requestedSubscription:
+          type: integer
+          description: The number of requested userIds to subscribe
+          format: int64
+        successfulSubscription:
+          type: integer
+          description: The number of successful subscriptions done
+          format: int64
+        failedSubscription:
+          type: integer
+          description: The number of subscription failures
+          format: int64
+        subscriptionErrors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChannelSubscriptionError'
+    ChannelSubscriptionError:
+      type: object
+      properties:
+        userId:
+          type: integer
+          description: The userId on which failure happened
+          format: int64
+        code:
+          type: string
+          description: subscription failure code
+        message:
+          type: string
+          description: subscription failure message
+    ChannelSubscriberResponse:
+      type: object
+      properties:
+        offset:
+          type: integer
+          description: The number of subscribers skipped
+          format: int64
+        hasMore:
+          type: boolean
+          description: True if there are more subscribers
+        total:
+          type: integer
+          description: The total number of subscribers
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChannelSubscriber'
+    ChannelSubscriber:
+      type: object
+      properties:
+        subscriptionId:
+          type: string
+        pushed:
+          type: boolean
+          description: True if the subscriber is allowed to unsubscribe
+          default: false
+        owner:
+          type: boolean
+          description: True if the subscriber is the creator
+          default: false
+        subscriberName:
+          type: string
+          description: User display name
+        userId:
+          type: integer
+          description: The user ID of the subscriber
+          format: int64
+        timestamp:
+          type: integer
+          description: Timestamp when the signal was subscribed, in milliseconds since
+            Jan 1 1970
+          format: int64
+    AgentInfo:
+      type: object
+      properties:
+        ipAddress:
+          type: string
+          description: The IP address of the Agent server.
+        hostname:
+          type: string
+          description: The hostname of the Agent server.
+        serverFqdn:
+          type: string
+          description: The fully-qualified domain name of the Agent server. Must be
+            set by the user at startup.
+        version:
+          type: string
+          description: The version of the Agent.
+        url:
+          type: string
+          description: The URL under which the Agent is available.
+        onPrem:
+          type: boolean
+          description: Whether this is an on-prem or cloud installation.
+        mt:
+          type: boolean
+          description: Whether this is a multi tenant instance.
+        commitId:
+          type: string
+          description: The Git commit ID of the running revision.
+    V1DLPPoliciesCollectionResponse:
+      type: object
+      required:
+        - policies
+      properties:
+        policies:
+          type: array
+          description: List of policies
+          items:
+            $ref: '#/components/schemas/V1DLPPolicy'
+        page:
+          type: integer
+          description: Page number of current page
+          format: int32
+        pageCount:
+          type: integer
+          description: Total number of pages available
+          format: int32
+      description: List of policies
+    V1DLPPolicy:
+      required:
+        - contentTypes
+        - name
+        - scopes
+        - dictionaryRefs
+        - type
+      type: object
+      properties:
+        active:
+          type: boolean
+          description: Indicate whether the policy is active or not
+        contentTypes:
+          type: array
+          description: |
+            The list of content types that policy should apply to. Cannot be empty. Policy content types could be either of "Messages", "RoomMeta", "SignalMeta".
+            Default is set to ["Messages"] if not specified.
+          items:
+            type: string
+        creationDate:
+          type: integer
+          description: Creation time of the policy in milliseconds elapsed as of epoch time.
+          format: int64
+        creatorId:
+          type: string
+          description: Numeric userId of the creator
+        dictionaryRefs:
+          type: array
+          description: List of dictionaries.
+          items:
+            $ref: '#/components/schemas/V1DLPDictionaryRef'
+        lastDisabledDate:
+          type: integer
+          description: Recent disable time of the policy in milliseconds elapsed as of epoch time.
+          format: int64
+        lastUpdatedDate:
+          type: integer
+          description: Recent update time of the policy in milliseconds elapsed as of epoch time.
+          format: int64
+        name:
+          type: string
+          description: Unique name of a policy, max 30 characters. Cannot be empty.
+            All the leading and trailing blank spaces are trimmed.
+        policyId:
+          type: string
+          description: Policy Id
+        scopes:
+          type: array
+          description: |
+            List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
+            You can apply both scopes if you set it to ["Internal", "External"].
+          items:
+            type: string
+        type:
+          type: string
+          description: Type of policy. Possible values "Block" or "Warn".
+        version:
+          type: string
+          description: |
+            The version of a dictionary, in format "major.minor". Initial value will set by backend as "1.0" when created.
+            Whenever the dictionary version needs to be changed, the minor version by 1 unless minor == 999, then the major version is increased by 1 until it reaches 999.
+      description: The policy object for expression filter, one policy can have multiple
+        dictionaries
+    V1DLPPolicyRequest:
+      required:
+        - contentTypes
+        - name
+        - scopes
+        - type
+      type: object
+      properties:
+        contentTypes:
+          type: array
+          description: |
+            The list of content types that policy should apply to. Cannot be empty. Policy content types could be either of "Messages", "RoomMeta", "SignalMeta".
+            Default is set to ["Messages"] if not specified.
+          items:
+            type: string
+        dictionaryIds:
+          type: array
+          description: List of dictionaries Ids for the policy.
+          items:
+            type: string
+        name:
+          type: string
+          description: Unique name of a policy, max 30 characters. Cannot be empty.
+            All the leading and trailing blank spaces are trimmed.
+        scopes:
+          type: array
+          description: |
+            List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
+            You can apply both scopes if you set it to ["Internal", "External"].
+          items:
+            type: string
+        type:
+          type: string
+          description: Type of policy. Possible values "Block" or "Warn".
+      description: The policy object to use for creating/updating a policy.
+    V1DLPPolicyResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/V1DLPPolicy'
+      description: Policy Response
+    V1DLPDictionary:
+      required:
+        - dictionaryMetadata
+      type: object
+      properties:
+        content:
+          $ref: '#/components/schemas/V1DLPDictionaryContent'
+        dictionaryMetadata:
+          $ref: '#/components/schemas/V1DLPDictionaryMetadata'
+      description: Dictionary object
+    V1DLPDictionaryContent:
+      type: object
+      properties:
+        data:
+          type: string
+          description: A comma separated string which contains a lot of keywords/regexes.
+        numKeywords:
+          type: integer
+          description: Number of Keywords in dictionary
+          format: int32
+        md5:
+          type: string
+          description: MD5 value of the content
+      description: Content of a dictionary
+    V1DLPDictionaryMetadataCollectionResponse:
+      type: object
+      required:
+        - items
+      properties:
         items:
-          $ref: '#/definitions/V1DLPDictionaryMetadata'
-      page:
-        type: integer
-        format: int32
-        description: Page number of current page
-      pageCount:
-        type: integer
-        format: int32
-        description: Total number of pages available
-    description: List of dictionary metadata.
-  V1DLPDictionaryMetadataResponse:
-    type: object
-    required:
-    - data
-    properties:
-      data:
-        $ref: '#/definitions/V1DLPDictionaryMetadata'
-    description: Dictionary response containing dictionary metadata.
-  V1DLPDictionaryMetadataCreateRequest:
-    type: object
-    required:
-    - name
-    - type
-    properties:
-      name:
-        type: string
-        description: |
-          The name of dictionary
-      type:
-        type: string
-        description: |
-          The type of dictionary, which specify the content is a list of words or a list of regexes.
-          By default set to "Word" if not specified. Possible values - Word, Regex
-    description: Dictionary's metadata (excluding content) to use for dictionary create operations.
-  V1DLPDictionaryMetadataUpdateRequest:
-    type: object
-    required:
-    - name
-    properties:
-      name:
-        type: string
-        description: |
-          The name of dictionary
-    description: Dictionary's metadata (excluding content) to use for dictionary update operations.
-  V1DLPDictionaryMetadata:
-    type: object
-    required:
-    - dictRef
-    - type
-    properties:
-      creationDate:
-        type: integer
-        format: int64
-        description: Creation time of the dictionary in milliseconds elapsed as of epoch time.
-      creatorId:
-        type: string
-        description: Numeric userId of the creator
-      dictRef:
-        $ref: '#/definitions/V1DLPDictionaryRef'
-      lastUpdatedDate:
-        type: integer
-        format: int64
-        description: The recent update time of the dictionary in milliseconds
-      type:
-        type: string
-        description: |
-          The type of dictionary, which specify the content is a list of words or a list of regexes.
-          By default set to "Word" if not specified. Possible values - Word, Regex
-    description: Dictionary's metadata (excluding content)
-  V1DLPDictionaryRef:
-    type: object
-    required:
-    - name
-    properties:
-      dictId:
-        type: string
-        description: Unique dictionary id
-      name:
-        type: string
-        description: Unique name of a dictionary, max 30 characters, with trimmed leading and trailing blank spaces.
-      version:
-        type: string
-        description: |
-          The version of a dictionary, in format "major.minor".
-          Initial value will set by backend as "1.0" when created.
-          Whenever the dictionary version needs to be changed, the minor version by 1 unless minor == 999, then the major version is increased by 1 until it reaches 999.
-    description: Basic information needed to identify a dictionary
-  V1DLPViolationMessageResponse:
-    type: object
-    properties:
-      violations:
-        type: array
-        description: A representation of list of violations due to messages sent by a user of Symphony
-        items:
-          $ref: '#/definitions/V1DLPViolationMessage'
-      nextOffset:
-        type: string
-        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
-  V1DLPViolationStreamResponse:
-    type: object
-    properties:
-      violations:
-        type: array
-        items:
-          # A representation of list of violations due to rooms creation/update sent by a user of Symphony
-          $ref: '#/definitions/V1DLPViolationStream'
-      nextOffset:
-        type: string
-        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
-  V1DLPViolationSignalResponse:
-    type: object
-    properties:
-      violations:
-        type: array
-        description: A representation of list of violations due to signal creation/update sent by a user of Symphony
-        items:
-          $ref: '#/definitions/V1DLPViolationSignal'
-      nextOffset:
-        type: string
-        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
-  V1DLPViolationMessage:
-    type: object
-    properties:
-      violation:
-        # A representation of a violation due to a message sent by a user of Symphony
-        $ref: '#/definitions/V1DLPViolation'
-      message:
-        # Message details when DLP was enforced
-        $ref: '#/definitions/V4Message'
-      diagnostic:
-        type: string
-        description: |
+          type: array
+          description: List of dictionary metadata
+          items:
+            $ref: '#/components/schemas/V1DLPDictionaryMetadata'
+        page:
+          type: integer
+          description: Page number of current page
+          format: int32
+        pageCount:
+          type: integer
+          description: Total number of pages available
+          format: int32
+      description: List of dictionary metadata.
+    V1DLPDictionaryMetadataResponse:
+      required:
+        - data
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/V1DLPDictionaryMetadata'
+      description: Dictionary response containing dictionary metadata.
+    V1DLPDictionaryMetadataCreateRequest:
+      required:
+        - name
+        - type
+      type: object
+      properties:
+        name:
+          type: string
+          description: |
+            The name of dictionary
+        type:
+          type: string
+          description: |
+            The type of dictionary, which specify the content is a list of words or a list of regexes.
+            By default set to "Word" if not specified. Possible values - Word, Regex
+      description: Dictionary's metadata (excluding content) to use for dictionary
+        create operations.
+    V1DLPDictionaryMetadataUpdateRequest:
+      required:
+        - name
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of dictionary
+      description: Dictionary's metadata (excluding content) to use for dictionary
+        update operations.
+    V1DLPDictionaryMetadata:
+      required:
+        - dictRef
+        - type
+      type: object
+      properties:
+        creationDate:
+          type: integer
+          description: Creation time of the dictionary in milliseconds elapsed as
+            of epoch time.
+          format: int64
+        creatorId:
+          type: string
+          description: Numeric userId of the creator
+        dictRef:
+          $ref: '#/components/schemas/V1DLPDictionaryRef'
+        lastUpdatedDate:
+          type: integer
+          description: The recent update time of the dictionary in milliseconds
+          format: int64
+        type:
+          type: string
+          description: |
+            The type of dictionary, which specify the content is a list of words or a list of regexes.
+            By default set to "Word" if not specified. Possible values - Word, Regex
+      description: Dictionary's metadata (excluding content)
+    V1DLPDictionaryRef:
+      required:
+        - name
+      type: object
+      properties:
+        dictId:
+          type: string
+          description: Unique dictionary id
+        name:
+          type: string
+          description: Unique name of a dictionary, max 30 characters, with trimmed
+            leading and trailing blank spaces.
+        version:
+          type: string
+          description: |
+            The version of a dictionary, in format "major.minor".
+            Initial value will set by backend as "1.0" when created.
+            Whenever the dictionary version needs to be changed, the minor version by 1 unless minor == 999, then the major version is increased by 1 until it reaches 999.
+      description: Basic information needed to identify a dictionary
+    V1DLPViolationMessageResponse:
+      type: object
+      required:
+        - violations
+      properties:
+        violations:
+          type: array
+          description: A representation of list of violations due to messages sent
+            by a user of Symphony
+          items:
+            $ref: '#/components/schemas/V1DLPViolationMessage'
+        nextOffset:
+          type: string
+          description: Offset for the next chunk of violations to be submitted in
+            the next request.  Value is null if there are no further violations.
+    V1DLPViolationStreamResponse:
+      type: object
+      required:
+        - violations
+      properties:
+        violations:
+          type: array
+          items:
+            $ref: '#/components/schemas/V1DLPViolationStream'
+        nextOffset:
+          type: string
+          description: Offset for the next chunk of violations to be submitted in
+            the next request.  Value is null if there are no further violations.
+    V1DLPViolationSignalResponse:
+      type: object
+      required:
+        - violations
+      properties:
+        violations:
+          type: array
+          description: A representation of list of violations due to signal creation/update
+            sent by a user of Symphony
+          items:
+            $ref: '#/components/schemas/V1DLPViolationSignal'
+        nextOffset:
+          type: string
+          description: Offset for the next chunk of violations to be submitted in
+            the next request.  Value is null if there are no further violations.
+    V1DLPViolationMessage:
+      type: object
+      properties:
+        violation:
+          $ref: '#/components/schemas/V1DLPViolation'
+        message:
+          $ref: '#/components/schemas/V4Message'
+        diagnostic:
+          type: string
+          description: |
             A diagnostic message containing an error message in the event there are parsing errors.
             May also be present in the case of a successful call if there is useful narrative to return.
-  V1DLPViolationStream:
-    type: object
-    properties:
-      violation:
-        # A representation of a violation due to rooms creation/update sent by a user of Symphony
-        $ref: '#/definitions/V1DLPViolation'
-      stream:
-        # Room details when DLP was enforced
-        $ref: '#/definitions/V1DLPStream'
-  V1DLPViolationSignal:
-    type: object
-    properties:
-      violation:
-        # A representation of a violation due to signal creation/update sent by a user of Symphony
-        $ref: '#/definitions/V1DLPViolation'
-      signal:
-        # Signal details when DLP was enforced
-        $ref: '#/definitions/V1DLPSignal'
-  V1DLPViolation:
-    type: object
-    description: A representation of a violation due to a message sent by a user of Symphony
-    properties:
-      enforcementEventID:
-        type: string
-        description: Enforcement event ID. Unique ID that identifies this enforcement.
-      entityID:
-        type: string
-        description: Entity ID is the content Id of the violation, for example, for messages, its the Id of the message
-      createTime:
-        type: integer
-        format: int64
-        description: Timestamp of the violation in milliseconds since Jan 1 1970
-      lastModified:
-        type: integer
-        format: int64
-        description: Timestamp of the last modification of violation in milliseconds since Jan 1 1970
-      requesterId:
-        type: integer
-        format: int64
-        description: Id of the requester responsible for the message/stream/signal
-      matchedPolicies:
-        # Policies that matched when DLP was enforced and the list of matched terms decrypted.
-        $ref: '#/definitions/V1DLPMatchedPolicyList'
-      action:
-        type: string
-        description: action taken such as BLOCK or WARN.  See outcome for a more detailed description of the outcome this action.
-      outcome:
-        # Detailed outcome of the DLP enforcement such as REJECTED_VIOLATION, ACCEPTED_WARNING, ACCEPTED_LEGACY_CLIENT etc.
-        $ref: '#/definitions/V1DLPOutcome'
-      version:
-        type: string
-        description: Version of application which processed the message and produced this violation.
-      ignoreDLPwarning:
+    V1DLPViolationStream:
+      type: object
+      properties:
+        violation:
+          $ref: '#/components/schemas/V1DLPViolation'
+        stream:
+          $ref: '#/components/schemas/V1DLPStream'
+    V1DLPViolationSignal:
+      type: object
+      properties:
+        violation:
+          $ref: '#/components/schemas/V1DLPViolation'
+        signal:
+          $ref: '#/components/schemas/V1DLPSignal'
+    V1DLPViolation:
+      type: object
+      properties:
+        enforcementEventID:
+          type: string
+          description: Enforcement event ID. Unique ID that identifies this enforcement.
+        entityID:
+          type: string
+          description: Entity ID is the content Id of the violation, for example,
+            for messages, its the Id of the message
+        createTime:
+          type: integer
+          description: Timestamp of the violation in milliseconds since Jan 1 1970
+          format: int64
+        lastModified:
+          type: integer
+          description: Timestamp of the last modification of violation in milliseconds
+            since Jan 1 1970
+          format: int64
+        requesterId:
+          type: integer
+          description: Id of the requester responsible for the message/stream/signal
+          format: int64
+        matchedPolicies:
+          $ref: '#/components/schemas/V1DLPMatchedPolicyList'
+        action:
+          type: string
+          description: action taken such as BLOCK or WARN.  See outcome for a more
+            detailed description of the outcome this action.
+        outcome:
+          $ref: '#/components/schemas/V1DLPOutcome'
+        contentType:
+          $ref: '#/components/schemas/V1DLPContentType'
+        version:
+          type: string
+          description: Version of application which processed the message and produced
+            this violation.
+        ignoreDLPwarning:
           type: boolean
           description: Did the user chose to ignore DLP warning that was presented?
-  V1DLPMatchedPolicyList:
-    type: array
-    items:
-      $ref: '#/definitions/V1DLPMatchedPolicy'
-    description: List of policies that matched the violation.
-  V1DLPMatchedPolicy:
-    type: object
-    description: A representation of policy that matched the violation with a list of matched keywords in the policy
-    properties:
-      id:
-        type: string
-        description: Id of the policy
-      version:
-        type: string
-        description: Version of the policy
-      policyName:
-        type: string
-        description: Name of the policy
-      type:
-        type: string
-        description: Whether BLOCK or WARN
-      terms:
-        type: string
-        description: List of decrypted matched keywords in the policy
-      diagnostic:
-        type: string
-        description: |
+      description: A representation of a violation due to a message sent by a user
+        of Symphony
+    V1DLPMatchedPolicyList:
+      type: array
+      description: List of policies that matched the violation.
+      items:
+        $ref: '#/components/schemas/V1DLPMatchedPolicy'
+    V1DLPMatchedPolicy:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Id of the policy
+        version:
+          type: string
+          description: Version of the policy
+        policyName:
+          type: string
+          description: Name of the policy
+        type:
+          type: string
+          description: Whether BLOCK or WARN
+        terms:
+          type: string
+          description: List of decrypted matched keywords in the policy
+        diagnostic:
+          type: string
+          description: |
             A diagnostic message containing an error message in the event that the
             decryption of terms failed. May also be present in the case of a successful
             call if there is useful narrative to return.
-  V1DLPOutcome:
-    type: object
-    description: A representation of outcome of DLP message/stream/signal sent by a user of Symphony
-    properties:
-      type:
-        type: string
-        description: Outcome of DLP enforcement
-  V1DLPContentType:
-    type: object
-    description: A representation of content type of message sent by a user of Symphony (message/stream/signal)
-    properties:
-      type:
-        type: string
-        description: content type
-  V1DLPStream:
-    type: object
-    description: Room details in the context of violation.
-    properties:
-        name:
-          type: string
-          description:  Name of the Stream/Room.
-        creatorPrettyName:
-          type: string
-          description:  Name of the creator of the Room.
-        publicRoom:
-          type: boolean
-          description:  Is this a public room?
-        crossPod:
-          type: boolean
-          description:  Is this a cross pod scenario?
-        allowExternal:
-          type: boolean
-          description:  Is external messaging allowed
-        creatorId:
-          type: string
-          description:  Id of the creator of the Room.
-        roomDescription:
-          type: string
-          description:  Description of the Room.
-        streamId:
-          type: string
-          description:  ThreadId of the Room.
-        state:
-          type: string
-          description:  State of the Room (example CREATED etc)
+      description: A representation of policy that matched the violation with a list
+        of matched keywords in the policy
+    V1DLPOutcome:
+      type: object
+      properties:
         type:
           type: string
-          description:  Type of the Room (example ROOM (or IM or Wall))
-        lastDisabled:
-          type: integer
-          format: int64
-          description: Timestamp of last time the room is Disabled
-        memberAddUserEnabled:
-          type: boolean
-          description:  Is memberAddUserEnabled
-        active:
-          type: boolean
-          description:  Is Room Active
-        discoverable:
-          type: boolean
-          description:  Is Room discoverable
-        readOnly:
-          type: boolean
-          description:  Is Room read-only
-        copyDisabled:
-          type: boolean
-          description:  Is Room copyDisabled
-        externalOwned:
-          type: boolean
-          description:  Is Room externalOwned
-        sendMessageDisabled:
-          type: boolean
-          description:  Is sendMessage Disabled for this Room
-        moderated:
-          type: boolean
-          description:  Is room moderated
-        shareHistoryEnabled:
-          type: boolean
-          description:  Is room shareHistoryEnabled
-        diagnostic:
+          description: Outcome of DLP enforcement
+      description: A representation of outcome of DLP message/stream/signal sent by
+        a user of Symphony
+    V1DLPContentType:
+      type: object
+      properties:
+        type:
           type: string
-          description: |
-              A diagnostic message containing an error message in the event that the
-              stream retrieval failed. May also be present in the case of a successful
-              call if there is useful narrative to return.
-  V1DLPSignal:
-    type: object
-    description: Signal details
-    properties:
+          description: content type
+      description: A representation of content type of message sent by a user of Symphony
+        (message/stream/signal)
+    V1DLPStream:
+      type: object
+      properties:
         name:
           type: string
-          description:  Name of the Signal
-        rules:
+          description: Name of the Stream/Room.
+        creatorPrettyName:
           type: string
-          description:  Signal rules decrypted.
+          description: Name of the creator of the Room.
+        publicRoom:
+          type: boolean
+          description: Is this a public room?
+        crossPod:
+          type: boolean
+          description: Is this a cross pod scenario?
+        allowExternal:
+          type: boolean
+          description: Is external messaging allowed
+        creatorId:
+          type: string
+          description: Id of the creator of the Room.
+        roomDescription:
+          type: string
+          description: Description of the Room.
+        streamId:
+          type: string
+          description: ThreadId of the Room.
+        state:
+          type: string
+          description: State of the Room (example CREATED etc)
+        type:
+          type: string
+          description: Type of the Room (example ROOM (or IM or Wall))
+        lastDisabled:
+          type: integer
+          description: Timestamp of last time the room is Disabled
+          format: int64
+        memberAddUserEnabled:
+          type: boolean
+          description: Is memberAddUserEnabled
+        active:
+          type: boolean
+          description: Is Room Active
+        discoverable:
+          type: boolean
+          description: Is Room discoverable
+        readOnly:
+          type: boolean
+          description: Is Room read-only
+        copyDisabled:
+          type: boolean
+          description: Is Room copyDisabled
+        externalOwned:
+          type: boolean
+          description: Is Room externalOwned
+        sendMessageDisabled:
+          type: boolean
+          description: Is sendMessage Disabled for this Room
+        moderated:
+          type: boolean
+          description: Is room moderated
+        shareHistoryEnabled:
+          type: boolean
+          description: Is room shareHistoryEnabled
         diagnostic:
           type: string
           description: |
-              A diagnostic message containing an error message in the event that the
-              signal decryption failed. May also be present in the case of a successful
-              call if there is useful narrative to return.
-
-#
-# V3 Policies definitions
-#
-  V3DLPPolicyRequest:
-    type: object
-    required:
-      - "name"
-      - "scopes"
-      - "appliesTo"
-    properties:
-      name:
-        type: string
-        description: |
-          Unique name of a policy, max 30 characters. Cannot be empty. All the leading and trailing blank spaces are trimmed.
-      scopes:
-        type: array
-        description: |
-          List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
-          You can apply both scopes if you set it to ["Internal", "External"].
-        items:
+            A diagnostic message containing an error message in the event that the
+            stream retrieval failed. May also be present in the case of a successful
+            call if there is useful narrative to return.
+      description: Room details in the context of violation.
+    V1DLPSignal:
+      type: object
+      properties:
+        name:
           type: string
-      appliesTo:
-        type: array
-        items:
-          $ref: '#/definitions/V3DLPPolicyAppliesTo'
-    description: Request to be used to get policies.
-  V3DLPPolicy:
-    type: object
-    properties:
-      id:
-        type: string
-        description: Unique identifier for policy.
-      policyId:
-        type: string
-        description: Policy Id.
-      version:
-        type: string
-        description: |
-          The version of the policy, in format "major.minor". Initial value will set by backend as "3.0" when created.
-          Whenever the policy version needs to be changed, the minor version by 1 unless minor == 999,
-          then the major version is increased by 1 until it reaches 999.
-      name:
-        type: string
-        description: |
-          Unique name of policy, max 30 characters. Cannot be empty. All the leading and trailing blank spaces are trimmed.
-      creatorId:
-        type: integer
-        format: int64
-        description: Numeric userId of the creator.
-      scopes:
-        type: array
-        description: |
-          List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
-          You can apply both scopes if you set it to ["Internal", "External"].
-        items:
+          description: Name of the Signal
+        rules:
           type: string
-      appliesTo:
-        type: array
-        items:
-          $ref: '#/definitions/V3DLPPolicyAppliesTo'
-      active:
-        type: boolean
-        description: Indicate whether the policy is active or not.
-      deleted:
-        type: boolean
-        description: Indicate whether the policy is deleted or not.
-      creationDate:
-        type: integer
-        format: int64
-        description: |
-          Creation time of the policy in milliseconds elapsed as of epoch time.
-      lastUpdatedDate:
-        type: integer
-        format: int64
-        description: |
-          Recent update time of the policy in milliseconds elapsed as of epoch.
-          time.
-      lastDisabledDate:
-        type: integer
-        format: int64
-        description: |
-          Recent disable time of the policy in milliseconds elapsed as of epoch.
-          time.
-      systemPolicy:
-        type: boolean
-    description : |
-      A policy is the main entity of V3 policy/rule system. It is responsible to define rules and add scope constraints to the engine.
-  V3DLPRule:
-    type: object
-    required:
-     - "type"
-     - "name"
-    properties:
-      id:
-        type: string
-      type:
-        type: string
-        description: Type of a rule used by policy. Can be ["UNKNOWN", "TEXT_MATCH", "FILE_EXTENSION", "FILE_SIZE", "FILE_PASSWORD", "FILE_CLASSIFIER"].
-      name:
-        type: string
-        description: Name for rule.
-      textMatchConfig:
-        $ref: '#/definitions/V3DLPTextMatchConfig'
-      fileSizeConfig:
-        $ref: '#/definitions/V3DLPFileSizeConfig'
-      fileExtensionConfig:
-        $ref: '#/definitions/V3DLPFileExtensionConfig'
-      filePasswordConfig:
-        $ref: '#/definitions/V3DLPFilePasswordConfig'
-      fileClassifierConfig:
-        $ref: '#/definitions/V3DLPFileClassifierConfig'
-    description: |
-     A Rule defines the actual matching specification for policies. It holds a type and a configuration
-     for the rule, these properties should be used to build the corresponding matching implementation.
-     Only one of the configuration property should be set [textMatchConfig, fileSizeConfig, fileExtensionConfig, filePasswordConfig, fileClassifierConfig].
-  V3DLPFilePasswordConfig:
-    type: object
-    required:
-      - "applicableFileTypes"
-      - "matchCriteria"
-    properties:
-        applicableFileTypes:
+          description: Signal rules decrypted.
+        diagnostic:
+          type: string
+          description: |
+            A diagnostic message containing an error message in the event that the
+            signal decryption failed. May also be present in the case of a successful
+            call if there is useful narrative to return.
+      description: Signal details
+    V3DLPPolicyRequest:
+      required:
+        - appliesTo
+        - name
+        - scopes
+      type: object
+      properties:
+        name:
+          type: string
+          description: |
+            Unique name of a policy, max 30 characters. Cannot be empty. All the leading and trailing blank spaces are trimmed.
+        scopes:
           type: array
+          description: |
+            List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
+            You can apply both scopes if you set it to ["Internal", "External"].
           items:
             type: string
-          description: File types that can be applied. Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
+        appliesTo:
+          type: array
+          items:
+            $ref: '#/components/schemas/V3DLPPolicyAppliesTo'
+      description: Request to be used to get policies.
+    V3DLPPolicy:
+      type: object
+      required:
+        - appliesTo
+      properties:
+        id:
+          type: string
+          description: Unique identifier for policy.
+        policyId:
+          type: string
+          description: Policy Id.
+        version:
+          type: string
+          description: |
+            The version of the policy, in format "major.minor". Initial value will set by backend as "3.0" when created.
+            Whenever the policy version needs to be changed, the minor version by 1 unless minor == 999,
+            then the major version is increased by 1 until it reaches 999.
+        name:
+          type: string
+          description: |
+            Unique name of policy, max 30 characters. Cannot be empty. All the leading and trailing blank spaces are trimmed.
+        creatorId:
+          type: integer
+          description: Numeric userId of the creator.
+          format: int64
+        scopes:
+          type: array
+          description: |
+            List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
+            You can apply both scopes if you set it to ["Internal", "External"].
+          items:
+            type: string
+        appliesTo:
+          type: array
+          items:
+            $ref: '#/components/schemas/V3DLPPolicyAppliesTo'
+        active:
+          type: boolean
+          description: Indicate whether the policy is active or not.
+        deleted:
+          type: boolean
+          description: Indicate whether the policy is deleted or not.
+        creationDate:
+          type: integer
+          description: Creation time of the policy in milliseconds elapsed as of epoch time.
+          format: int64
+        lastUpdatedDate:
+          type: integer
+          description: Recent update time of the policy in milliseconds elapsed as of epoch time.
+          format: int64
+        lastDisabledDate:
+          type: integer
+          description: Recent disable time of the policy in milliseconds elapsed as of epoch time.
+          format: int64
+        systemPolicy:
+          type: boolean
+      description: |
+        A policy is the main entity of V3 policy/rule system. It is responsible to define rules and add scope constraints to the engine.
+    V3DLPRule:
+      required:
+        - name
+        - type
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          description: Type of a rule used by policy. Can be ["UNKNOWN", "TEXT_MATCH",
+            "FILE_EXTENSION", "FILE_SIZE", "FILE_PASSWORD", "FILE_CLASSIFIER"].
+        name:
+          type: string
+          description: Name for rule.
+        textMatchConfig:
+          $ref: '#/components/schemas/V3DLPTextMatchConfig'
+        fileSizeConfig:
+          $ref: '#/components/schemas/V3DLPFileSizeConfig'
+        fileExtensionConfig:
+          $ref: '#/components/schemas/V3DLPFileExtensionConfig'
+        filePasswordConfig:
+          $ref: '#/components/schemas/V3DLPFilePasswordConfig'
+        fileClassifierConfig:
+          $ref: '#/components/schemas/V3DLPFileClassifierConfig'
+      description: |
+        A Rule defines the actual matching specification for policies. It holds a type and a configuration
+        for the rule, these properties should be used to build the corresponding matching implementation.
+        Only one of the configuration property should be set [textMatchConfig, fileSizeConfig, fileExtensionConfig, filePasswordConfig, fileClassifierConfig].
+    V3DLPFilePasswordConfig:
+      required:
+        - applicableFileTypes
+        - matchCriteria
+      type: object
+      properties:
+        applicableFileTypes:
+          type: array
+          description: File types that can be applied. Can be ["PDF", "WORD", "EXCEL",
+            "POWERPOINT", "ZIP", "CSV", "TXT"].
+          items:
+            type: string
         matchCriteria:
           type: string
           description: |
-           Based on the criteria, whether a file is password protected or not means a match.
-           Can be ["PASSWORD_PROTECTED", "NOT_PASSWORD_PROTECTED"]. The default is "NOT_PASSWORD_PROTECTED".
-    description: Password protected detection config for files that are password protected or not.
-  V3DLPFileExtensionConfig:
-    type: object
-    required:
-      - "allowLists"
-    properties:
-      allowLists:
-        type: array
-        items:
+            Based on the criteria, whether a file is password protected or not means a match.
+            Can be ["PASSWORD_PROTECTED", "NOT_PASSWORD_PROTECTED"]. The default is "NOT_PASSWORD_PROTECTED".
+      description: Password protected detection config for files that are password
+        protected or not.
+    V3DLPFileExtensionConfig:
+      required:
+        - allowLists
+        - blockLists
+      type: object
+      properties:
+        allowLists:
+          type: array
+          description: File extensions that are allowed.
+          items:
+            type: string
+        blockLists:
+          type: array
+          description: File extensions that are blocked.
+          items:
+            type: string
+      description: Extension detection config for allowed and blocked types of file
+        extensions.
+    V3DLPFileSizeConfig:
+      type: object
+      properties:
+        sizeLimit:
+          type: integer
+          format: int32
+      description: File size config defines maximum allowed size of file. Default max size limit is 20 MB.
+    V3DLPTextMatchConfig:
+      type: object
+      required:
+        - dictionaries
+        - applicableFileTypes
+      properties:
+        dictionaries:
+          type: array
+          items:
+            $ref: '#/components/schemas/V3DLPDictionaryMeta'
+        countUniqueOccurrences:
+          type: integer
+          format: int32
+        applicableFileTypes:
+          type: array
+          description: |
+            File types must be applied only for rule type "FileContent", otherwise must be empty.
+            Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
+          items:
+            type: string
+      description: |
+        This is a configuration that can be used to match text or regex.
+        Configuration that can be used by a rule. This is a configuration that can be used to match text or regex.
+        This configuration also corresponds to V2 TextMatch/RegexMatch of dictionaries.
+    V3DLPDictionaryMeta:
+      required:
+        - dictId
+        - name
+        - version
+      type: object
+      properties:
+        dictId:
           type: string
-        description: File extensions that are allowed.
-      blockLists:
-        type: array
-        items:
+        version:
           type: string
-        description: File extensions that are blocked.
-    description: Extension detection config for allowed and blocked types of file extensions.
-  V3DLPFileSizeConfig:
-    type: object
-    properties:
-      sizeLimit:
-        type: integer
-        format: int32
-    description: File size config defines maximum allowed size of file. Default max size limit is 20 MB.
-  V3DLPTextMatchConfig:
-    type: object
-    properties:
-      dictionaries:
-        type: array
-        items:
-         $ref: '#/definitions/V3DLPDictionaryMeta'
-      countUniqueOccurrences:
-        type: integer
-        format: int32
-      applicableFileTypes:
-        type: array
-        items:
-         type: string
-        description: |
-          File types must be applied only for rule type "FileContent", otherwise must be empty.
-          Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
-    description: |
-      This is a configuration that can be used to match text or regex.
-      Configuration that can be used by a rule. This is a configuration that can be used to match text or regex.
-      This configuration also corresponds to V2 TextMatch/RegexMatch of dictionaries.
-  V3DLPDictionaryMeta:
-    type: object
-    required:
-      - "dictId"
-      - "version"
-      - "name"
-    properties:
-      dictId:
-        type: string
-      version:
-        type: string
-      name:
-        type: string
-    description: Identity of a dictionary.
-  V3DLPFileClassifierConfig:
-    type: object
-    required:
-      - "classifiers"
-      - "applicableFileTypes"
-    properties:
-      classifiers:
-        type: object
-        additionalProperties:
-         type: string
-        description: |
-         Classifier is defined as a Key and its Value: e.g.: "classification": "Internal".
-         Name and value can contain UTF-8 characters. Neither the name nor value cannot be left empty.
-         Maximum 30 characters for the name and value, case insensitive.
-         If files contains k-v pairs in the classifers map, it means a match. Maximum 30 classifiers per policy.
-      applicableFileTypes:
-        type: array
-        items:
-         type: string
-        description: |
-          File types that can be applied. Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
-  V3DLPPolicyAppliesTo:
-    type: object
-    required:
-      - "dataType"
-      - "action"
-      - "rules"
-    properties:
-      dataType:
-        type: string
-        description: |
-          The list of data types that policy should apply to. Can't be empty.
-          Can be ["Messages","RoomMeta", "SignalMeta", "FileContent", "FileMeta"].
-      action:
-        type: string
-        description: |
-          Action to be taken on violation detection.
-          Can be ["Block", "Warn", "LogOnly"]. The default is "LogOnly".
-      rules:
-        type: array
-        items:
-          $ref: '#/definitions/V3DLPRule'
-  V3DLPPolicyResponse:
-    type: object
-    properties:
-      data:
-        $ref: '#/definitions/V3DLPPolicy'
-    description: Policy Response.
-  V3DLPPoliciesCollectionResponse:
-    type: object
-    properties:
-      policies:
-        type: array
-        description: List of policies.
-        items:
-          $ref: '#/definitions/V3DLPPolicy'
-      page:
-        type: integer
-        format: int32
-        description: The starting page for pagination.
-      size:
-        type: integer
-        format: int32
-        description: Size of policies displayed per page.
-      pageCount:
-        type: integer
-        format: int32
-        description: Total number of pages available.
-    description: List of policies.
-  V3DLPViolationMessageResponse:
-    type: object
-    properties:
-      violations:
-        type: array
-        description: A representation of list of violations due to messages sent by a user of Symphony
-        items:
-          $ref: '#/definitions/V3DLPViolationMessage'
-      nextOffset:
-        type: string
-        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
-  V3DLPViolationStreamResponse:
-    type: object
-    properties:
-      violations:
-        type: array
-        items:
-          # A representation of list of violations due to rooms creation/update sent by a user of Symphony
-          $ref: '#/definitions/V3DLPViolationStream'
-      nextOffset:
-        type: string
-        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
-  V3DLPViolationSignalResponse:
-    type: object
-    properties:
-      violations:
-        type: array
-        description: A representation of list of violations due to signal creation/update sent by a user of Symphony
-        items:
-          $ref: '#/definitions/V3DLPViolationSignal'
-      nextOffset:
-        type: string
-        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
-  V3DLPViolationMessage:
-    type: object
-    properties:
-      violation:
-        # A representation of a violation due to a message sent by a user of Symphony
-        $ref: '#/definitions/V3DLPViolation'
-      message:
-        # Message details when DLP was enforced
-        $ref: '#/definitions/V4Message'
-      sharedMessage:
-              description: Shared message details if present in message.
-              $ref: '#/definitions/V4Message'
-      diagnostic:
-        type: string
-        description: |
-          A diagnostic message containing an error message in the event there are parsing errors.
-          May also be present in the case of a successful call if there is useful narrative to return.
-  V3DLPViolationStream:
-    type: object
-    properties:
-      violation:
-        # A representation of a violation due to rooms creation/update sent by a user of Symphony
-        $ref: '#/definitions/V3DLPViolation'
-      stream:
-        # Room details when DLP was enforced
-        $ref: '#/definitions/V1DLPStream'
-  V3DLPViolationSignal:
-    type: object
-    properties:
-      violation:
-        # A representation of a violation due to signal creation/update sent by a user of Symphony
-        $ref: '#/definitions/V3DLPViolation'
-      signal:
-        # Signal details when DLP was enforced
-        $ref: '#/definitions/V1DLPSignal'
-  V3DLPViolation:
-    type: object
-    description: A representation of a violation due to an event created by a user of Symphony
-    properties:
-      enforcementEventID:
-        type: string
-        description: Enforcement event ID. Unique ID that identifies this enforcement.
-      entityID:
-        type: string
-        description: Entity ID is the content Id of the violation, for example, for messages, its the Id of the message
-      createTime:
-        type: integer
-        format: int64
-        description: Timestamp of the violation in milliseconds since Jan 1 1970
-      lastModified:
-        type: integer
-        format: int64
-        description: Timestamp of the last modification of violation in milliseconds since Jan 1 1970
-      requesterId:
-        type: integer
-        format: int64
-        description: Id of the requester responsible for the message/stream/signal
-      details:
-        type: array
-        description: JSON representation of the details of the violation.
-        items:
+        name:
+          type: string
+      description: Identity of a dictionary.
+    V3DLPFileClassifierConfig:
+      required:
+        - applicableFileTypes
+        - classifiers
+      type: object
+      properties:
+        classifiers:
           type: object
-      action:
-        type: string
-        description: action taken such as BLOCK or WARN.  See outcome for a more detailed description of the outcome this action.
-      outcome:
-        # Detailed outcome of the DLP enforcement such as REJECTED_VIOLATION, ACCEPTED_WARNING, ACCEPTED_LEGACY_CLIENT etc.
-        $ref: '#/definitions/V1DLPOutcome'
-      version:
-        type: string
-        description: Version of application which processed the message and produced this violation.
-      ignoreDLPwarning:
+          additionalProperties:
+            type: string
+          description: |
+            Classifier is defined as a Key and its Value: e.g.: "classification": "Internal".
+            Name and value can contain UTF-8 characters. Neither the name nor value cannot be left empty.
+            Maximum 30 characters for the name and value, case insensitive.
+            If files contains k-v pairs in the classifers map, it means a match. Maximum 30 classifiers per policy.
+        applicableFileTypes:
+          type: array
+          description: File types that can be applied. Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
+          items:
+            type: string
+    V3DLPPolicyAppliesTo:
+      required:
+        - action
+        - dataType
+        - rules
+      type: object
+      properties:
+        dataType:
+          type: string
+          description: |
+            The list of data types that policy should apply to. Can't be empty.
+            Can be ["Messages","RoomMeta", "SignalMeta", "FileContent", "FileMeta"].
+        action:
+          type: string
+          description: |
+            Action to be taken on violation detection.
+            Can be ["Block", "Warn", "LogOnly"]. The default is "LogOnly".
+        rules:
+          type: array
+          items:
+            $ref: '#/components/schemas/V3DLPRule'
+    V3DLPPolicyResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/V3DLPPolicy'
+      description: Policy Response.
+    V3DLPPoliciesCollectionResponse:
+      type: object
+      required:
+        - policies
+      properties:
+        policies:
+          type: array
+          description: List of policies.
+          items:
+            $ref: '#/components/schemas/V3DLPPolicy'
+        page:
+          type: integer
+          description: The starting page for pagination.
+          format: int32
+        size:
+          type: integer
+          description: Size of policies displayed per page.
+          format: int32
+        pageCount:
+          type: integer
+          description: Total number of pages available.
+          format: int32
+      description: List of policies.
+    V3DLPViolationMessageResponse:
+      type: object
+      required:
+        - violations
+      properties:
+        violations:
+          type: array
+          description: A representation of list of violations due to messages sent
+            by a user of Symphony
+          items:
+            $ref: '#/components/schemas/V3DLPViolationMessage'
+        nextOffset:
+          type: string
+          description: |
+            Offset for the next chunk of violations to be submitted in the next request. 
+            Value is null if there are no further violations.
+    V3DLPViolationStreamResponse:
+      type: object
+      required:
+        - violations
+      properties:
+        violations:
+          type: array
+          items:
+            $ref: '#/components/schemas/V3DLPViolationStream'
+        nextOffset:
+          type: string
+          description: |
+            Offset for the next chunk of violations to be submitted in the next request.
+            Value is null if there are no further violations.
+    V3DLPViolationSignalResponse:
+      type: object
+      required:
+        - violations
+      properties:
+        violations:
+          type: array
+          description: A representation of list of violations due to signal creation/update sent by a user of Symphony
+          items:
+            $ref: '#/components/schemas/V3DLPViolationSignal'
+        nextOffset:
+          type: string
+          description: |
+            Offset for the next chunk of violations to be submitted in the next request.
+            Value is null if there are no further violations.
+    V3DLPViolationMessage:
+      type: object
+      properties:
+        violation:
+          $ref: '#/components/schemas/V3DLPViolation'
+        message:
+          $ref: '#/components/schemas/V4Message'
+        sharedMessage:
+          $ref: '#/components/schemas/V4Message'
+        diagnostic:
+          type: string
+          description: |
+            A diagnostic message containing an error message in the event there are parsing errors.
+            May also be present in the case of a successful call if there is useful narrative to return.
+    V3DLPViolationStream:
+      type: object
+      properties:
+        violation:
+          $ref: '#/components/schemas/V3DLPViolation'
+        stream:
+          $ref: '#/components/schemas/V1DLPStream'
+    V3DLPViolationSignal:
+      type: object
+      properties:
+        violation:
+          $ref: '#/components/schemas/V3DLPViolation'
+        signal:
+          $ref: '#/components/schemas/V1DLPSignal'
+    V3DLPViolation:
+      type: object
+      properties:
+        enforcementEventID:
+          type: string
+          description: Enforcement event ID. Unique ID that identifies this enforcement.
+        entityID:
+          type: string
+          description: Entity ID is the content Id of the violation. For example, for messages it's the Id of the message
+        createTime:
+          type: integer
+          description: Timestamp of the violation in milliseconds since Jan 1 1970
+          format: int64
+        lastModified:
+          type: integer
+          description: Timestamp of the last modification of violation in milliseconds
+            since Jan 1 1970
+          format: int64
+        requesterId:
+          type: integer
+          description: Id of the requester responsible for the message/stream/signal
+          format: int64
+        details:
+          type: array
+          description: JSON representation of the details of the violation.
+          items:
+            type: object
+        action:
+          type: string
+          description: action taken such as BLOCK or WARN.  See outcome for a more detailed description of the outcome this action.
+        outcome:
+          $ref: '#/components/schemas/V1DLPOutcome'
+        version:
+          type: string
+          description: Version of application which processed the message and produced
+            this violation.
+        ignoreDLPwarning:
           type: boolean
           description: Did the user chose to ignore DLP warning that was presented?
-  Pagination:
-    type: object
-    required:
-      - cursors
-    properties:
-      cursors:
-        type: object
-        properties:
-          before:
-            type: string
-            description: |
-              This is the opaque url-safe string that points to the start of the page of data
-              that has been returned.
-            example: "MTAxNTExOTQ1MjAwNzI5NDE="
-          after:
-            type: string
-            description: |
-              This is the opaque url-safe string that points to the end of the page of data
-              that has been returned.
-            example: "NDMyNzQyODI3OTQw"
-      previous:
-        type: string
-        description: |
-          API endpoint that will return the previous page of data. If not included, this is
-          the first page of data.
-        example: "https://tenantapi.d.isym.io/v1/tenantinfo?limit=25&before=MTAxNTExOTQ1MjAwNzI5NDE="
-      next:
-        type: string
-        description: |
-          API endpoint that will return the next page of data. If not included, this is the
-          last page of data. Due to how pagination works with visibility and privacy, it is
-          possible that a page may be empty but contain a 'next' paging link. Stop paging when
-          the 'next' link no longer appears.
-        example: "https://tenantapi.d.isym.io/v1/tenantinfo?limit=25&after=NDMyNzQyODI3OTQw"
-  V1AuditTrailInitiatorResponse:
-    description: |
-      Audit Trail Initiator object response.
-      The attributes may vary according to the action.
-      There are different types of action and each action could have specific attributes.
-    type: object
-    properties:
-      action:
-        description: The audit trail action that has peformed
-        type: string
-      actionName:
-        description: The audit trail action name that has peformed
-        type: string
-      timestamp:
-        description: The timestamp when the action has occurred
-        type: string
-      initiatorId:
-        description: The user's id that has performed the action
-        type: string
-      initiatorUsername:
-        description: The username that has performed the action
-        type: string
-      initiatorEmailAddress:
-        description: The user's e-mail address that has performed the action
-        type: string
-    additionalProperties: true
-  V1AuditTrailInitiatorList:
-    type: object
-    properties:
-      items:
-        type: array
-        items:
-          $ref: '#/definitions/V1AuditTrailInitiatorResponse'
-      pagination:
-        type: object
-        $ref: "#/definitions/Pagination"
-  V5Datafeed:
-    type: object
-    properties:
-      id:
-        type: string
-        description: ID of the datafeed
-      createdAt:
-        type: integer
-        format: int64
-        description: Datafeed creation timestamp
-    description: Container for the feed ID
-    example:
-      id: '8e7c8672-220...'
-  V5DatafeedCreateBody:
-    type: object
-    properties:
-      tag:
-        type: string
-        maxLength: 100
-        description: A unique identifier to ensure uniqueness of the datafeed.
-  AckId:
-    description: An object containing the ackId (and parameters) associated with events that the
-      client has received through an individual feed.
-    type: object
-    properties:
-      ackId:
-        type: string
-        description: A unique id for events that can be deleted from a client's. Empty for the first read. If set to null or missing, it will be considered empty.
-          feed.
-      updatePresence:
-        type: boolean
-        default: true
-        description: Set to false to avoid updating the user's presence when reading events. Default is true.
-  V5EventList:
-    type: object
-    properties:
-      events:
-        type: array
-        items:
-          $ref: '#/definitions/V4Event'
-      ackId:
-        type: string
-        description: The ackId which acknowledges that the current batch of messages have been successfully received by the client
-  V5EventsReadBody:
-    type: object
-    properties:
-      type:
-        type: string
-        description: type of the feed. Allowed values are "fanout" and "datahose"
-      tag:
-        type: string
-        minLength: 1
-        maxLength: 80
-        description: A unique identifier to ensure uniqueness of the datafeed.
-      eventTypes:
-        type: array
-        description: |
-          At least one value is required if the type of feed is "datahose". Values must be a valid Real-Time Event type, i.e. one of:
-          * MESSAGESENT
-          * MESSAGESUPPRESSED
-          * SYMPHONYELEMENTSACTION
-          * SHAREDPOST
-          * INSTANTMESSAGECREATED
-          * ROOMCREATED
-          * ROOMUPDATED
-          * ROOMDEACTIVATED
-          * ROOMREACTIVATED
-          * USERREQUESTEDTOJOINROOM
-          * USERJOINEDROOM
-          * USERLEFTROOM
-          * ROOMMEMBERPROMOTEDTOOWNER
-          * ROOMMEMBERDEMOTEDFROMOWNER
-          * CONNECTIONREQUESTED
-          * CONNECTIONACCEPTED
-        items:
+      description: A representation of a violation due to an event created by a user
+        of Symphony
+    Pagination:
+      required:
+        - cursors
+      type: object
+      properties:
+        cursors:
+          type: object
+          properties:
+            before:
+              type: string
+              description: |
+                This is the opaque url-safe string that points to the start of the page of data
+                that has been returned.
+              example: MTAxNTExOTQ1MjAwNzI5NDE=
+            after:
+              type: string
+              description: |
+                This is the opaque url-safe string that points to the end of the page of data
+                that has been returned.
+              example: NDMyNzQyODI3OTQw
+        previous:
           type: string
-        x-since: 22.7
-      ackId:
-        type: string
-        description: should be empty for the first call, acknowledges that the current batch of messages have been successfully received by the client.
-      updatePresence:
-        type: boolean
-        description: whether to update the presence status of the account to AVAILABLE when calling the endpoint. Default value is true.
-    required:
-      - type
-      - tag
-  V3Health:
+          description: |
+            API endpoint that will return the previous page of data. If not included, this is
+            the first page of data.
+          example: https://tenantapi.d.isym.io/v1/tenantinfo?limit=25&before=MTAxNTExOTQ1MjAwNzI5NDE=
+        next:
+          type: string
+          description: |
+            API endpoint that will return the next page of data. If not included, this is the
+            last page of data. Due to how pagination works with visibility and privacy, it is
+            possible that a page may be empty but contain a 'next' paging link. Stop paging when
+            the 'next' link no longer appears.
+          example: https://tenantapi.d.isym.io/v1/tenantinfo?limit=25&after=NDMyNzQyODI3OTQw
+    V1AuditTrailInitiatorResponse:
+      type: object
+      properties:
+        action:
+          type: string
+          description: The audit trail action that has peformed
+        actionName:
+          type: string
+          description: The audit trail action name that has peformed
+        timestamp:
+          type: string
+          description: The timestamp when the action has occurred
+        initiatorId:
+          type: string
+          description: The user's id that has performed the action
+        initiatorUsername:
+          type: string
+          description: The username that has performed the action
+        initiatorEmailAddress:
+          type: string
+          description: The user's e-mail address that has performed the action
+      description: |
+        Audit Trail Initiator object response.
+        The attributes may vary according to the action.
+        There are different types of action and each action could have specific attributes.
+    V1AuditTrailInitiatorList:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/V1AuditTrailInitiatorResponse'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+    V5Datafeed:
+      type: object
+      properties:
+        id:
+          type: string
+          description: ID of the datafeed
+        createdAt:
+          type: integer
+          description: Datafeed creation timestamp
+          format: int64
+        type:
+          type: string
+          description: type of the feed. Known values are "fanout" and "datahose"
+      description: Container for the feed ID
+      example:
+        id: 8e7c8672-220...
+    V5DatafeedCreateBody:
+      type: object
+      properties:
+        tag:
+          maxLength: 100
+          type: string
+          description: A unique identifier to ensure uniqueness of the datafeed.
+    AckId:
+      type: object
+      properties:
+        ackId:
+          type: string
+          description: |
+            A unique id for events that can be deleted from a client's.
+            Empty for the first read. If set to null or missing, it will be considered empty feed.
+        updatePresence:
+          type: boolean
+          description: Set to false to avoid updating the user's presence when reading events. Default is true.
+          default: true
+      description: |
+        An object containing the ackId (and parameters) associated with 
+        events that the client has received through an individual feed.
+    V5EventList:
+      type: object
+      required:
+        - events
+      properties:
+        events:
+          type: array
+          items:
+            $ref: '#/components/schemas/V4Event'
+        ackId:
+          type: string
+          description: |
+            The ackId which acknowledges that the current batch of messages 
+            have been successfully received by the client
+    V5EventsReadBody:
+      required:
+        - tag
+        - type
+      type: object
+      properties:
+        type:
+          type: string
+          description: Type of the feed. Allowed values are "fanout" and "datahose"
+        tag:
+          maxLength: 80
+          minLength: 1
+          type: string
+          description: A unique identifier to ensure uniqueness of the datafeed.
+        eventTypes:
+          type: array
+          description: |
+            At least one value is required if the type of feed is "datahose". Values must be a valid Real-Time Event type, i.e. one of:
+            * MESSAGESENT
+            * MESSAGESUPPRESSED
+            * SYMPHONYELEMENTSACTION
+            * SHAREDPOST
+            * INSTANTMESSAGECREATED
+            * ROOMCREATED
+            * ROOMUPDATED
+            * ROOMDEACTIVATED
+            * ROOMREACTIVATED
+            * USERREQUESTEDTOJOINROOM
+            * USERJOINEDROOM
+            * USERLEFTROOM
+            * ROOMMEMBERPROMOTEDTOOWNER
+            * ROOMMEMBERDEMOTEDFROMOWNER
+            * CONNECTIONREQUESTED
+            * CONNECTIONACCEPTED
+          items:
+            type: string
+          x-since: 22.7
+        ackId:
+          type: string
+          description: |
+            Should be empty for the first call, acknowledges that the current
+            batch of messages have been successfully received by the client.
+        updatePresence:
+          type: boolean
+          description: |
+            Whether to update the presence status of the account to AVAILABLE 
+            when calling the endpoint. Default value is true.
+          default: true
+    V3Health:
+      type: object
       properties:
         services:
-          additionalProperties:
-            $ref: '#/definitions/V3HealthComponent'
           type: object
+          additionalProperties:
+            $ref: '#/components/schemas/V3HealthComponent'
         status:
-          $ref: '#/definitions/V3HealthStatus'
+          $ref: '#/components/schemas/V3HealthStatus'
         users:
-          additionalProperties:
-            $ref: '#/definitions/V3HealthComponent'
           type: object
+          additionalProperties:
+            $ref: '#/components/schemas/V3HealthComponent'
         version:
-          description: Required Agent verison
           type: string
+          description: Required Agent verison
+    V3HealthAuthType:
+      type: string
+      description: Type of authentication
+      enum:
+        - RSA
+        - CERT
+    V3HealthComponent:
       type: object
-  V3HealthAuthType:
-    description: Type of authentication
-    enum:
-      - RSA
-      - CERT
-    type: string
-  V3HealthComponent:
-    properties:
-      authType:
-        $ref: '#/definitions/V3HealthAuthType'
-      message:
-        description: 'An error message, if the component status is DOWN'
-        type: string
-      status:
-        $ref: '#/definitions/V3HealthStatus'
-      version:
-        description: Optional component version
-        type: string
-    type: object
-  V3HealthStatus:
-    description: Application health status.
-    enum:
-      - UP
-      - DOWN
-    type: string
+      properties:
+        authType:
+          $ref: '#/components/schemas/V3HealthAuthType'
+        message:
+          type: string
+          description: An error message, if the component status is DOWN
+        status:
+          $ref: '#/components/schemas/V3HealthStatus'
+        version:
+          type: string
+          description: Optional component version
+    V3HealthStatus:
+      type: string
+      description: Application health status.
+      enum:
+        - UP
+        - DOWN

--- a/agent/swagger2/agent-api-public-deprecated.yaml
+++ b/agent/swagger2/agent-api-public-deprecated.yaml
@@ -1,0 +1,6780 @@
+swagger: '2.0'
+info:
+  version: '22.7.1'
+  title: Agent API
+  description: |
+    This document refers to Symphony API calls to send and receive messages
+    and content. They need the on-premise Agent installed to perform
+    decryption/encryption of content.
+
+    - sessionToken and keyManagerToken can be obtained by calling the
+    authenticationAPI on the symphony back end and the key manager
+    respectively. Refer to the methods described in authenticatorAPI.yaml.
+    - A new authorizationToken has been introduced in the authenticationAPI
+    response payload. It can be used to replace the sessionToken in any of
+    the API calls and can be passed as "Authorization" header.
+    - Actions are defined to be atomic, ie will succeed in their entirety
+    or fail and have changed nothing.
+    - If it returns a 40X status then it will have sent no message to any
+    stream even if a request to some subset of the requested streams
+    would have succeeded.
+    - If this contract cannot be met for any reason then this is an error
+    and the response code will be 50X.
+    - MessageML is a markup language for messages. See reference here:
+    https://rest-api.symphony.com/docs/messagemlv2
+    - **Real Time Events**: The following events are returned when reading
+    from a real time messages and events stream ("datafeed"). These
+    events will be returned for datafeeds created with the v5 endpoints.
+    To know more about the endpoints, refer to Create Messages/Events
+    Stream and Read Messages/Events Stream. Unless otherwise specified,
+    all events were added in 1.46.
+
+paths:
+  '/v3/health':
+    get:
+      summary: Checks health status
+      description: |
+        _Available on Agent 2.57.0 and above._
+
+        Returns the connectivity status of your Agent server. If your Agent server is started and running, the status value will be `UP`
+      operationId: v3Health
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - System
+      responses:
+        '200':
+          description: Agent application is alive.
+          schema:
+            $ref: '#/definitions/V3Health'
+  '/v3/health/extended':
+    get:
+      summary: Checks health status of services and users
+      description: |
+        _Available on Agent 2.57.0 and above._
+
+        Returns the connectivity status of the Agent services (**pod**, **key manager** and **datafeed**) as well as users
+        connectivity (**agentservice** and **ceservice**).
+
+        The global status will be set to `DOWN` if at least one of the sub-status is also `DOWN`.
+      operationId: v3ExtendedHealth
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - System
+      responses:
+        '200':
+          description: Agent is healthy, all components are `UP`.
+          schema:
+            $ref: '#/definitions/V3Health'
+        '503':
+          description: Agent is unhealthy, some components are `DOWN`.
+          schema:
+            $ref: '#/definitions/V3Health'
+  '/v4/message/import':
+    post:
+      summary: Import messages from other systems into Symphony.
+      description: |
+        Sends a message to be imported into the system.
+        Allows you to override the timestamp and author of the message with your desired values.
+        The requesting user must have the Content Management role.
+        The user that the message is intended to have come from must also be present in the conversation.
+        The intended message timestamp must be a valid time from the past. It cannot be a future timestamp.
+        Optionally the original message ID can be specified to identify the imported message for the purpose of repeat imports.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: messageList
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/V4MessageImportList'
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: Message sent.
+          schema:
+            $ref: '#/definitions/V4ImportResponseList'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v4/message/blast':
+    post:
+      summary: Post a message to multiple existing streams.
+      description: |
+        Post a new message to the given list of streams. The stream can be a chatroom,
+        an IM or a multiparty IM.
+
+        You may include an attachment on the message.
+
+        The message can be provided as MessageMLV2 or PresentationML. Both formats support Freemarker templates.
+
+        The optional parameter "data" can be used to provide a JSON payload containing entity data.
+        If the message contains explicit references to entity data (in "data-entity-id" element attributes),
+        this parameter is required.
+
+        If the message is in MessageML and fails schema validation a client error results
+
+        This endpoint is idempotent, it means that a 200 response will be returned even if the message has not been
+        delivered to some streams. Check the `errors` map from the response in order to see on which stream(s) the
+        message has not been delivered.
+
+        The maximum number of streams where the message can be sent is limitted to 100.
+
+        Regarding authentication, you must either use the sessionToken which was created for delegated app access
+        or both the sessionToken and keyManagerToken together.
+      consumes:
+        - multipart/form-data
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Authorization token used to make delegated calls.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          type: string
+          required: false
+        - name: sids
+          description: A comma-separated list of Stream IDs
+          in: formData
+          required: true
+          type: array
+          items:
+            type: string
+        - name: message
+          description: The message payload in MessageML.
+          in: formData
+          type: string
+          required: false
+        - name: data
+          description: Optional message data in EntityJSON.
+          in: formData
+          type: string
+          required: false
+        - name: version
+          description: |
+            Optional message version in the format "major.minor". If empty, defaults to the latest supported version.
+          in: formData
+          type: string
+          required: false
+        - name: attachment
+          description: Optional file attachment.
+          in: formData
+          type: file
+          required: false
+        - name: preview
+          description: Optional attachment preview.
+          in: formData
+          type: file
+          required: false
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: Blast message sent.
+          schema:
+            $ref: '#/definitions/V4MessageBlastResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '451':
+          description: 'Compliance Issues found in message or file'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/message/{id}':
+    get:
+      summary: Get a message by ID
+      produces:
+        - application/json
+      parameters:
+          - name: sessionToken
+            description: Session authentication token.
+            in: header
+            required: true
+            type: string
+          - name: keyManagerToken
+            description: Key Manager authentication token.
+            in: header
+            required: true
+            type: string
+          - name: id
+            description: Message ID as a URL-safe string
+            in: path
+            required: true
+            type: string
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V4Message'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/message/search':
+    get:
+      summary: Search messages
+      description: |
+          Search messages according to the specified criteria. The "query" parameter takes a search query defined as
+          "field:value" pairs combined by the operator "AND" (e.g. "text:foo AND autor:bar"). Supported fields are
+           (case-insensitive): "text", "author", "hashtag", "cashtag", "mention", "signal", "fromDate", "toDate",
+           "streamId", "streamType".
+           "text" search requires a "streamId" to be specified.
+           "streamType" accepts one of the following values: "chat" (IMs and MIMs), "im", "mim", "chatroom", "post".
+           "signal" queries can only be combined with "fromDate", "toDate", "skip" and "limit" parameters.
+      produces:
+        - application/json
+      parameters:
+        - name: query
+          description: The search query. See above for the query syntax.
+          in: query
+          type: string
+          required: true
+        - name: skip
+          description: |
+            No. of results to skip.
+          in: query
+          type: integer
+        - name: limit
+          description: |
+            Max no. of results to return. If no value is provided, 50 is the default.
+          in: query
+          type: integer
+          required: false
+        - name: scope
+          description: |
+            Describes where content should be searched for that query.
+            It can exclusively apply to Symphony content or to one Connector.
+          in: query
+          type: string
+        - name: sortDir
+          description: |
+            Messages sort direction : ASC or DESC (default to DESC)
+          in: query
+          type: string
+          required: false
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V4MessageList'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+    post:
+      summary: Search messages
+      description: |
+          Search messages according to the specified criteria.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: query
+          description: The search query. See above for the query syntax.
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/MessageSearchQuery'
+        - name: skip
+          description: |
+            No. of results to skip.
+          in: query
+          type: integer
+        - name: limit
+          description: |
+            Max no. of results to return. If no value is provided, 50 is the default.
+          in: query
+          type: integer
+          required: false
+        - name: scope
+          description: |
+            Describes where content should be searched for that query.
+            It can exclusively apply to Symphony content or to one Connector.
+          in: query
+          type: string
+        - name: sortDir
+          description: |
+            Messages sort direction : ASC or DESC (default to DESC)
+          in: query
+          type: string
+          required: false
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V4MessageList'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/stream/{sid}/attachment':
+    get:
+      summary: Download an attachment.
+      description: |
+        Downloads the attachment body by the attachment ID, stream ID, and message ID.
+      consumes:
+        - application/json
+      produces:
+        - application/octet-stream
+      parameters:
+        - name: sid
+          description: Stream ID
+          in: path
+          required: true
+          type: string
+        - name: fileId
+          description: The attachment ID (Base64-encoded)
+          in: query
+          required: true
+          type: string
+        - name: messageId
+          description: The ID of the message containing the attachment
+          in: query
+          required: true
+          type: string
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Attachments
+      responses:
+        '200':
+          description: 'Attachment body as Base64 encoded string.'
+          schema:
+            type: string
+            format: byte
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v4/stream/{sid}/message':
+    get:
+      summary: Get messages from an existing stream.
+      description: |
+          A caller can fetch all unseen messages by passing the timestamp of
+          the last message seen as the since parameter and the number of messages
+          with the same timestamp value already seen as the skip parameter. This
+          means that every message will be seen exactly once even in the case that
+          an additional message is processed with the same timestamp as the last
+          message returned by the previous call, and the case where there are
+          more than maxMessages with the same timestamp value.
+
+          This method is intended for historic queries and is generally reliable
+          but if guaranteed delivery of every message in real time is required
+          then the equivilent firehose method should be called.
+      produces:
+        - application/json
+      parameters:
+        - name: sid
+          description: |
+            Stream ID
+          in: path
+          required: true
+          type: string
+        - name: since
+          description: |
+            Timestamp of first required message.
+
+            This is a long integer value representing milliseconds since
+            Jan 1 1970
+          in: query
+          required: true
+          type: integer
+          format: int64
+        - name: skip
+          description: |
+            No. of messages to skip.
+          in: query
+          type: integer
+        - name: limit
+          description: |
+            Max No. of messages to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          in: query
+          type: integer
+          required: false
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V4MessageList'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v4/stream/{sid}/message/create':
+    post:
+      summary: Post a message to one existing stream.
+      description: |
+        Post a new message to the given stream. The stream can be a chatroom,
+        an IM or a multiparty IM.
+
+        You may include an attachment on the message.
+
+        The message can be provided as MessageMLV2 or PresentationML. Both formats support Freemarker templates.
+
+        The optional parameter "data" can be used to provide a JSON payload containing entity data.
+        If the message contains explicit references to entity data (in "data-entity-id" element attributes),
+        this parameter is required.
+
+        If the message is in MessageML and fails schema validation
+        a client error results
+
+        If the message is sent then 200 is returned.
+
+        Regarding authentication, you must either use the sessionToken which was created for delegated app access
+        or both the sessionToken and keyManagerToken together.
+      consumes:
+        - multipart/form-data
+      produces:
+        - application/json
+      parameters:
+        - name: sid
+          description: Stream ID
+          in: path
+          required: true
+          type: string
+        - name: sessionToken
+          description: Authorization token used to make delegated calls.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          type: string
+          required: false
+        - name: message
+          description: The message payload in MessageML.
+          in: formData
+          type: string
+          required: false
+        - name: data
+          description: Optional message data in EntityJSON.
+          in: formData
+          type: string
+          required: false
+        - name: version
+          description: |
+            Optional message version in the format "major.minor". If empty, defaults to the latest supported version.
+          in: formData
+          type: string
+          required: false
+        - name: attachment
+          description: Optional file attachment.
+          in: formData
+          type: file
+          required: false
+        - name: preview
+          description: Optional attachment preview.
+          in: formData
+          type: file
+          required: false
+
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: Message sent.
+          schema:
+            $ref: '#/definitions/V4Message'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '451':
+          description: 'Compliance Issues found in message or file'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+
+  '/v4/stream/{sid}/message/{mid}/update':
+    post:
+      summary: Update an existing message.
+      description: |
+        Update an existing message. The existing message must be a valid social message, that has not been deleted.
+
+        The message can be provided as MessageMLV2 or PresentationML. Both formats support Freemarker templates.
+
+        The optional parameter "data" can be used to provide a JSON payload containing entity data.
+        If the message contains explicit references to entity data (in "data-entity-id" element attributes),
+        this parameter is required.
+
+        If the message is in MessageML and fails schema validation
+        a client error results
+
+        If the message is updated then 200 is returned.
+
+        Regarding authentication, you must either use the sessionToken which was created for delegated app access
+        or both the sessionToken and keyManagerToken together.
+      consumes:
+        - multipart/form-data
+      produces:
+        - application/json
+      parameters:
+        - name: sid
+          description: Stream ID
+          in: path
+          required: true
+          type: string
+        - name: mid
+          description: Parent message ID
+          in: path
+          required: true
+          type: string
+        - name: sessionToken
+          description: Authorization token used to make delegated calls.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          type: string
+          required: false
+        - name: message
+          description: The message payload in MessageML.
+          in: formData
+          type: string
+          required: false
+        - name: data
+          description: Optional message data in EntityJSON.
+          in: formData
+          type: string
+          required: false
+        - name: version
+          description: |
+            Optional message version in the format "major.minor". If empty, defaults to the latest supported version.
+          in: formData
+          type: string
+          required: false
+        - name: silent
+          in: formData
+          type: string
+          required: false
+          description: |
+            Optional boolean field that will determine if the user/s should receive the message as read or not (true by default). Since Agent 20.14.
+          x-since: 20.14
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: Message sent.
+          schema:
+            $ref: '#/definitions/V4Message'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '451':
+          description: 'Compliance Issues found in message or file'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+
+  '/v3/stream/{sid}/share':
+    post:
+      summary: PROVISIONAL -  Share a piece of content into Symphony
+      description: |
+        Given a 3rd party content (eg. news article), it can share to the given stream.
+        The stream can be a chatroom, an IM or a multiparty IM.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sid
+          description: Stream ID
+          in: path
+          required: true
+          type: string
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: false
+          type: string
+        - name: shareContent
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/ShareContent'
+      tags:
+        - Share
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V2Message'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/util/echo':
+    post:
+      summary: Test endpoint, returns input.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: echoInput
+          description: Message in plain text
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/SimpleMessage'
+      tags:
+        - Util
+      responses:
+        '200':
+          description: Message sent.
+          schema:
+            $ref: '#/definitions/SimpleMessage'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/signals/list':
+    get:
+      summary: |
+          List signals for the requesting user. This includes signals that the user has created and public signals
+          to which they subscribed.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: false
+          type: string
+        - name: skip
+          description: |
+            No. of signals to skip.
+          in: query
+          type: integer
+        - name: limit
+          description: |
+            Max no. of signals to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          in: query
+          type: integer
+          required: false
+      tags:
+        - Signals
+      responses:
+        '200':
+          description: List of signals for the requesting user.
+          schema:
+            $ref: '#/definitions/SignalList'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/signals/{id}/get':
+    get:
+      summary: Get details of the requested signal.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: false
+          type: string
+        - name: id
+          description: |
+            The ID of the signal to display.
+          in: path
+          required: true
+          type: string
+      tags:
+        - Signals
+      responses:
+        '200':
+          description: List of signals for the requesting user.
+          schema:
+            $ref: '#/definitions/Signal'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/signals/create':
+    post:
+      summary: Create a signal.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: false
+          type: string
+        - name: signal
+          description: Signal definition.
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/BaseSignal'
+      tags:
+        - Signals
+      responses:
+        '200':
+          description: Signal created.
+          schema:
+            $ref: '#/definitions/Signal'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '451':
+          description: 'Compliance Issues found in signal'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/signals/{id}/update':
+    post:
+      summary: Update a signal.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: false
+          type: string
+        - name: id
+          description: The id of the signal.
+          in: path
+          required: true
+          type: string
+        - name: signal
+          description: Signal definition.
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/BaseSignal'
+      tags:
+        - Signals
+      responses:
+        '200':
+          description: Signal updated.
+          schema:
+            $ref: '#/definitions/Signal'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '451':
+          description: 'Compliance Issues found in signal'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/signals/{id}/delete':
+    post:
+      summary: Delete a signal.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: false
+          type: string
+        - name: id
+          description: The id of the signal.
+          in: path
+          required: true
+          type: string
+      tags:
+        - Signals
+      responses:
+        '200':
+          description: Signal deleted.
+          schema:
+            $ref: '#/definitions/SuccessResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/signals/{id}/subscribe':
+    post:
+      summary: Subscribe to a Signal.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: false
+          type: string
+        - name: id
+          description: The id of the signal.
+          in: path
+          required: true
+          type: string
+        - name: pushed
+          description: Prevent the user to unsubscribe (only for bulk subscription)
+          in: query
+          required: false
+          type: boolean
+        - name: users
+          description: UserIds to subscribe (only for bulk subscription)
+          in: body
+          required: false
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int64
+      tags:
+        - Signals
+      responses:
+        '200':
+          description: Signal subscribed.
+          schema:
+            $ref: '#/definitions/ChannelSubscriptionResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/signals/{id}/unsubscribe':
+    post:
+      summary: Unsubscribe to a Signal.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: false
+          type: string
+        - name: id
+          description: The id of the signal.
+          in: path
+          required: true
+          type: string
+        - name: users
+          description: UserIds to unsubscribe (only for bulk unsubscription)
+          in: body
+          required: false
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int64
+      tags:
+        - Signals
+      responses:
+        '200':
+          description: Signal unsubscribed.
+          schema:
+            $ref: '#/definitions/ChannelSubscriptionResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/signals/{id}/subscribers':
+    get:
+      summary: Get the subscribers of a signal
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: false
+          type: string
+        - name: id
+          description: The id of the signal.
+          in: path
+          required: true
+          type: string
+        - name: skip
+          description: No. of results to skip.
+          in: query
+          required: false
+          type: integer
+          default: 0
+        - name: limit
+          description: Max No. of subscribers to return. If no value is provided, 100 is the default.
+          in: query
+          required: false
+          type: integer
+          default: 100
+      tags:
+        - Signals
+      responses:
+        '200':
+          description: Signal Subscribers.
+          schema:
+            $ref: '#/definitions/ChannelSubscriberResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/info':
+    get:
+      summary: Get information about the Agent
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - Signals
+      responses:
+        '200':
+          description: Agent info.
+          schema:
+            $ref: '#/definitions/AgentInfo'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/dlp/policies':
+    get:
+      summary: Get all policies
+      description: Get all policies
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: page
+          in: query
+          required: false
+          type: integer
+          format: int32
+          description: Optional parameter to specify which page to return (default is 0)
+        - name: limit
+          in: query
+          required: false
+          type: integer
+          format: int32
+          description: |
+            Optional parameter to specify the number of result to return per page, default is 50. Maximum is 50.
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPPoliciesCollectionResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      summary: Creates a policy
+      description: |
+        Creates a new policy with dictionary references.
+
+        At the time of policy creation, the caller should only provide - contentTypes, name, scopes and type. The rest of the information is populated automatically.
+
+        Note - You need to enable the policy after creation to start enforcing the policy.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/V1DLPPolicyRequest'
+          description: Details about the policy that should be created.
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/dlp/policies/{policyId}':
+    get:
+      summary: Get a policy
+      description: Get a policy
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: policyId
+          in: path
+          required: true
+          type: string
+          description: Unique dictionary identifier.
+        - name: policyVersion
+          in: query
+          required: false
+          type: string
+          description: |
+            Optional parameter, if set to be valid policy version number,  will return policy with specified policyVersion. Otherwise, return the latest policy.
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+    put:
+      summary: Updates a policy. Cannot be used for creation.
+      description: |
+        Update the policy (name, type, contentTypes, scopes) and also the dictionaries for a policy.
+        Warning: If you send empty list of dictionaries during the update operation, then all the
+        dictionaries for this policy are deleted and policy is automatically disabled.
+        Note: The policy should already exist.
+      consumes:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: policyId
+          in: path
+          required: true
+          type: string
+          description: Unique dictionary identifier.
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/V1DLPPolicyRequest'
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      summary: Delete a policy
+      description: |
+        Delete a policy.
+        Note: Only disabled policy can be deleted
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: policyId
+          in: path
+          required: true
+          type: string
+          description: Unique dictionary identifier.
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/dlp/policies/{policyId}/enable':
+    post:
+      summary: Enables a policy.
+      description: Enables a policy.
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: policyId
+          in: path
+          required: true
+          type: string
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/dlp/policies/{policyId}/disable':
+    post:
+      summary: Disables a policy.
+      description: Disables a policy.
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: policyId
+          in: path
+          required: true
+          type: string
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/dlp/dictionaries':
+    get:
+      summary: Get all dictionary metadatas
+      description: |
+        Get all dictionary metadatas with the latest version. Each dictionary object will only contain meta data of the content.
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: page
+          in: query
+          required: false
+          type: integer
+          format: int32
+          description: Optional parameter to specify which page to return (default is 0)
+        - name: limit
+          in: query
+          required: false
+          type: integer
+          format: int32
+          description: |
+            Optional parameter to specify the number of result to return per page, default is 50. Maximum is 50.
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPDictionaryMetadataCollectionResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      summary: Create a dictionary
+      description: |
+        Creates a dictionary with basic metadata and no content. Only "name" and "type" field is used to create a new dictionary entry.
+      consumes:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/V1DLPDictionaryMetadataCreateRequest'
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPDictionaryMetadataResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/dlp/dictionaries/{dictId}':
+    get:
+      summary: Get dictionary metadata
+      description: Get basic information for a dictionary.
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: dictId
+          in: path
+          required: true
+          type: string
+          description: Unique dictionary identifier
+        - name: dictVersion
+          in: query
+          required: false
+          type: string
+          description: |
+            If set to be valid dictionary version number, will return dictionary metadata with specified version. Otherwise, return the latest dictionary metadata.
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPDictionaryMetadataResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+    put:
+      summary: Updates a dictionary
+      description: |
+        Updates the dictionary's basic metadata without content.
+        This API cannot be used for creating a new dictionary.
+        In case of update only "name" can be changed.
+        Note: All related policies will also have versions updated.
+      consumes:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: dictId
+          in: path
+          required: true
+          type: string
+          description: Unique dictionary identifier
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/V1DLPDictionaryMetadataUpdateRequest'
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPDictionaryMetadataResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      summary: Delete a dictionary
+      description: |
+        Deletes a dictionary.
+        Note: All related policies will be affected.
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: dictId
+          in: path
+          required: true
+          type: string
+          description: Unique dictionary identifier
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            # Deleted dictionary's metadata.
+            $ref: '#/definitions/V1DLPDictionaryMetadataResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/dlp/dictionaries/{dictId}/data/download':
+    get:
+      summary: Downloads Base 64 encoded dictionary content.
+      description: Downloads Base 64 encoded dictionary content.
+      consumes:
+        - application/json
+      produces:
+        - application/octet-stream
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: dictId
+          in: path
+          required: true
+          type: string
+          description: Unique dictionary identifier
+        - name: dictVersion
+          in: query
+          required: false
+          type: string
+          description: |
+            If set to be valid dictionary version number, will return dictionary with specified version. Otherwise, return the latest dictionary.
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: 'Attachment body as Base64 encoded string.'
+          schema:
+            type: string
+            format: byte
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/dlp/dictionaries/{dictId}/data/upload':
+    post:
+      summary: Override dictionary content with provided content.
+      description: Override dictionary content with provided content.
+      consumes:
+        - multipart/form-data
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: dictId
+          in: path
+          required: true
+          type: string
+          description: Unique dictionary identifier
+        - name: data
+          in: formData
+          required: true
+          type: file
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPDictionaryMetadataResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/dlp/violations/message':
+    get:
+      summary: Get violations as a result of policy enforcement on messages.
+      description: |
+        TBD
+      produces:
+        - application/json
+      parameters:
+        - name: startTime
+          description: |
+            Timestamp of the first required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+          in: query
+          required: true
+          type: integer
+          format: int64
+        - name: endTime
+          description: |
+            Timestamp of the last required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+            If unspecified, it will default to current time of the request.
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: next
+          description: |
+            Offset of the next chunk of violations. Value is null for the first request.
+          in: query
+          type: string
+          required: false
+        - name: limit
+          description: |
+            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          in: query
+          type: integer
+          required: false
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Violations
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V1DLPViolationMessageResponse'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+
+  '/v1/dlp/violations/stream':
+    get:
+      summary: Get violations as a result of policy enforcement on streams.
+      description: |
+        TBD
+      produces:
+        - application/json
+      parameters:
+        - name: startTime
+          description: |
+            Timestamp of the first required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+          in: query
+          required: true
+          type: integer
+          format: int64
+        - name: endTime
+          description: |
+            Timestamp of the last required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+            If unspecified, it will default to current time of the request.
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: next
+          description: |
+            Offset of the next chunk of violations. Value is null for the first request.
+          in: query
+          type: string
+          required: false
+        - name: limit
+          description: |
+            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          in: query
+          type: integer
+          required: false
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Violations
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V1DLPViolationStreamResponse'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+
+  '/v1/dlp/violations/signal':
+    get:
+      summary: Get violations as a result of policy enforcement on signals.
+      description: |
+        TBD
+      produces:
+        - application/json
+      parameters:
+        - name: startTime
+          description: |
+            Timestamp of the first required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+          in: query
+          required: true
+          type: integer
+          format: int64
+        - name: endTime
+          description: |
+            Timestamp of the last required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+            If unspecified, it will default to current time of the request.
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: next
+          description: |
+            Offset of the next chunk of violations. Value is null for the first request.
+          in: query
+          type: string
+          required: false
+        - name: limit
+          description: |
+            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          in: query
+          type: integer
+          required: false
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Violations
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V1DLPViolationSignalResponse'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+
+  '/v3/dlp/policies':
+    get:
+      summary: Get all policies
+      description: Get all policies
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: page
+          in: query
+          required: false
+          type: integer
+          format: int32
+          description: Optional parameter to specify which page to return (default is 0)
+        - name: limit
+          in: query
+          required: false
+          type: integer
+          format: int32
+          description: |
+            Optional parameter to specify the number of result to return per page, default is 50. Maximum is 50.
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V3DLPPoliciesCollectionResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      summary: Creates a policy
+      description: |
+        Creates a new policy with dictionary references.
+        At the time of policy creation, the caller should only provide - contentTypes, name, scopes and type.
+        The rest of the information is populated automatically.
+        Note - You need to enable the policy after creation to start enforcing the policy.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/V3DLPPolicyRequest'
+          description: Details about the policy that should be created.
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V3DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v3/dlp/policies/{policyId}':
+    get:
+      summary: Get a policy
+      description: Get a policy
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: policyId
+          in: path
+          required: true
+          type: string
+          description: Unique dictionary identifier.
+        - name: policyVersion
+          in: query
+          required: false
+          type: string
+          description: |
+            Optional parameter, if set to be valid policy version number,  will return policy with specified policyVersion. Otherwise, return the latest policy.
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V3DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v3/dlp/policies/{policyId}/update':
+    post:
+      summary: Updates a policy. Cannot be used for creation.
+      description: |
+        Update the policy (name, type, contentTypes, scopes) and also the dictionaries for a policy.
+        Warning: If you send empty list of dictionaries during the update operation, then all the
+        dictionaries for this policy are deleted and policy is automatically disabled.
+        Note: The policy should already exist.
+      consumes:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: policyId
+          in: path
+          required: true
+          type: string
+          description: Unique dictionary identifier.
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/V3DLPPolicyRequest'
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V3DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v3/dlp/policies/{policyId}/delete':
+    post:
+      summary: Delete a policy
+      description: |
+        Delete a policy.
+        Note: Only disabled policy can be deleted
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: policyId
+          in: path
+          required: true
+          type: string
+          description: Unique dictionary identifier.
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V3DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v3/dlp/policies/{policyId}/enable':
+    post:
+      summary: Enables a policy.
+      description: Enables a policy.
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: policyId
+          in: path
+          required: true
+          type: string
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V3DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v3/dlp/policies/{policyId}/disable':
+    post:
+      summary: Disables a policy.
+      description: Disables a policy.
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: policyId
+          in: path
+          required: true
+          type: string
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V3DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v3/dlp/violations/message':
+    get:
+      summary: Get violations as a result of policy enforcement on messages.
+      description: Retrieves DLP v3 message related violations for a given time range
+      produces:
+        - application/json
+      parameters:
+        - name: startTime
+          description: |
+            Timestamp of the first required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+          in: query
+          required: true
+          type: integer
+          format: int64
+        - name: endTime
+          description: |
+            Timestamp of the last required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+            If unspecified, it will default to current time of the request.
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: next
+          description: |
+            Offset of the next chunk of violations. Value is null for the first request.
+          in: query
+          type: string
+          required: false
+        - name: limit
+          description: |
+            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          in: query
+          type: integer
+          required: false
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Violations
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V3DLPViolationMessageResponse'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+
+  '/v3/dlp/violations/stream':
+    get:
+      summary: Get violations as a result of policy enforcement on streams.
+      description: Retrieves DLP v3 signal related violations for a given time range
+      produces:
+        - application/json
+      parameters:
+        - name: startTime
+          description: |
+            Timestamp of the first required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+          in: query
+          required: true
+          type: integer
+          format: int64
+        - name: endTime
+          description: |
+            Timestamp of the last required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+            If unspecified, it will default to current time of the request.
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: next
+          description: |
+            Offset of the next chunk of violations. Value is null for the first request.
+          in: query
+          type: string
+          required: false
+        - name: limit
+          description: |
+            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          in: query
+          type: integer
+          required: false
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Violations
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V3DLPViolationStreamResponse'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+
+  '/v3/dlp/violations/signal':
+    get:
+      summary: Get violations as a result of policy enforcement on signals.
+      description: Retrieves DLP v3 signal related violations for a given time range
+      produces:
+        - application/json
+      parameters:
+        - name: startTime
+          description: |
+            Timestamp of the first required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+          in: query
+          required: true
+          type: integer
+          format: int64
+        - name: endTime
+          description: |
+            Timestamp of the last required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+            If unspecified, it will default to current time of the request.
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: next
+          description: |
+            Offset of the next chunk of violations. Value is null for the first request.
+          in: query
+          type: string
+          required: false
+        - name: limit
+          description: |
+            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          in: query
+          type: integer
+          required: false
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Violations
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V3DLPViolationSignalResponse'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+
+  '/v3/dlp/violation/attachment':
+    get:
+      summary: Get attachments that were sent as part of messages that were flagged by the DLP System.
+      description: Retrieves attachments from related message violations as a base64 encoded String.
+      produces:
+        - application/octet-stream
+      parameters:
+        - name: fileId
+          description: |
+            ID of attachment that will be downloaded.
+          in: query
+          required: true
+          type: string
+        - name: violationId
+          description: |
+            ID of violation that corresponds to the flagged message that contains the attachment
+          in: query
+          required: true
+          type: string
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Violations
+      responses:
+        '200':
+          description: Attachment body as Base64 encoded string.
+          schema:
+            type: string
+            format: byte
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: 'Resource not found.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+
+  '/v1/audittrail/privilegeduser':
+    get:
+      summary: Get a list of  actions performed by a privileged account acting as privileged user given a period of time.
+      description: Get a list of actions performed by a privileged account acting as privileged user given a period of time.
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: startTimestamp
+          description: |
+            Start timestamp in unix timestamp in millseconds.
+          in: query
+          required: true
+          type: integer
+          format: int64
+        - name: endTimestamp
+          description: |
+            End timestamp in unix timestamp in millseconds.
+            If not specified, it assumes to be current time.
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: before
+          description: |
+            Return results from an opaque “before” cursor value as presented via a response cursor.
+          in: query
+          type: string
+          required: false
+        - name: after
+          description: |
+            Return results from an opaque “after” cursor value as presented via a response cursor.
+          in: query
+          type: string
+          required: false
+        - name: limit
+          description: |
+            Max No. of violations to return. If no value is provided, 50 is the default.
+            Some maximums for limit may be enforced for performance reasons.
+            The maximum supported value is 500.
+          in: query
+          type: integer
+          required: false
+        - name: initiatorId
+          description: |
+            If present, only the initiator with this initiator <user id> will be returned.
+          in: query
+          type: integer
+          format: int64
+        - name: role
+          description: |
+            If present, only the audit trail initiated by s user with privileged role acting as
+            privileged user will be returned.
+            Privileged eliglible roles:
+            User Provisioning (USER_PROVISIONING),
+            Content Management (CONTENT_MANAGEMENT),
+            Expression Filter Policy Management (EF_POLICY_MANAGEMENT),
+            SCO (SUPER_COMPLIANCE_OFFICER),
+            CO (COMPLIANCE_OFFICER),
+            Super admin (SUPER_ADMINISTRATOR),
+            Admin (ADMINISTRATOR),
+            L1 (L1_SUPPORT),
+            L2 (L2_SUPPORT),
+            Scope Manager (SCOPE_MANAGEMENT)
+          in: query
+          type: string
+          required: false
+      tags:
+        - AuditTrail
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V1AuditTrailInitiatorList'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+
+  '/v5/datafeeds':
+    post:
+      tags:
+        - Datafeed
+      summary: Create a new real time messages / events stream ("datafeed").
+      description: |
+        _Available on Agent 2.57.0 and above._
+
+        The datafeed provides messages and events from all conversations that the user
+        is in. The types of events surfaced in the datafeed can be found in the Real Time Events list.
+        (see definition on top of the file)
+
+        Returns the ID of the datafeed that has just been created.
+        This ID should then be used as input to the Read Messages/Events Stream v4 endpoint.
+      operationId: createDatafeed
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: false
+          schema:
+            $ref: '#/definitions/V5DatafeedCreateBody'
+      produces:
+        - application/json
+      responses:
+        201:
+          description: Datafeed sucessfully created.
+          schema:
+            $ref: '#/definitions/V5Datafeed'
+        400:
+          description: Bad request.
+          schema:
+            $ref: '#/definitions/V2Error'
+        401:
+          description: Unauthorized.
+          schema:
+            $ref: '#/definitions/V2Error'
+        500:
+          description: Internal server error.
+          schema:
+            $ref: '#/definitions/V2Error'
+
+    get:
+      tags:
+        - Datafeed
+      summary: Read list of real time messages / events stream ("datafeed").
+      description: |
+        _Available on Agent 2.57.0 and above._
+
+        The datafeed provides messages and events from all conversations that the user
+        is in. The types of events surfaced in the datafeed can be found in the [Real Time Events](./docs/real-time-events.md) list.
+
+        Returns the list of the datafeeds for the user.
+        Any datafeed ID of the list can then be used as input to the Read Messages/Events Stream v4 endpoint.
+      operationId: listDatafeed
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: tag
+          maxLength: 100
+          required: false
+          description: A unique identifier to ensure uniqueness of the datafeed. Used to restrict search.
+          in: query
+          type: string
+      responses:
+        200:
+          description: Datafeed sucessfully created.
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/V5Datafeed'
+          examples:
+            application/json:
+              - id: '8e7c8672-220...'
+                createdAt: 1536346282592
+              - id: '8e7c8672-221...'
+                createdAt: 1536346282500
+
+        400:
+          description: Bad request.
+          schema:
+            $ref: '#/definitions/V2Error'
+        401:
+          description: Unauthorized.
+          schema:
+            $ref: '#/definitions/V2Error'
+        500:
+          description: Internal server error.
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v5/datafeeds/{datafeedId}':
+    delete:
+      tags:
+        - Datafeed
+      summary: Delete the specified real time message / event stream ("datafeed").
+      description: |
+        _Available on Agent 2.57.0 and above._
+
+        The datafeed provides messages and events from all conversations that the user
+        is in. The types of events surfaced in the datafeed can be found in the Real Time Events list.
+        (see definition on top of the file)
+
+        Delete the specified datafeed.
+      operationId: deleteDatafeed
+      parameters:
+        - in: path
+          name: datafeedId
+          required: true
+          type: string
+          description: ID of the datafeed
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      responses:
+        204:
+          description: Datafeed successfully deleted.
+          schema:
+            $ref: '#/definitions/V2Error'
+        400:
+          description: Bad request.
+          schema:
+            $ref: '#/definitions/V2Error'
+        401:
+          description: Unauthorized.
+          schema:
+            $ref: '#/definitions/V2Error'
+        500:
+          description: Internal server error.
+          schema:
+            $ref: '#/definitions/V2Error'
+
+  '/v5/datafeeds/{datafeedId}/read':
+    post:
+      tags:
+        - Datafeed
+      summary: Read the specified real time message / event stream ("datafeed").
+      description: |
+        _Available on Agent 2.57.0 and above._
+
+        The datafeed provides messages and events from all conversations that the user
+        is in. The types of events surfaced in the datafeed can be found in the Real Time Events list.
+        (see definition on top of the file)
+
+        Read the specified datafeed.
+
+        The ackId sent as parameter can be empty for the first call. In the response an ackId will be sent back and it can be used for
+        the next call: in this way you acknowledge that you have received the events that came with that ackId; datafeed will remove the events
+        associated with that ackId from your queue
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      operationId: readDatafeed
+      parameters:
+        - in: path
+          name: datafeedId
+          required: true
+          type: string
+          description: ID of the datafeed
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: ackId
+          description: ackId received from last POST Base64 encoded.
+          in: body
+          required: false
+          schema:
+            $ref: '#/definitions/AckId'
+      responses:
+        200:
+          description: Datafeed successfully read.
+          schema:
+            $ref: '#/definitions/V5EventList'
+        400:
+          description: Bad request.
+          schema:
+            $ref: '#/definitions/V2Error'
+        401:
+          description: Unauthorized.
+          schema:
+            $ref: '#/definitions/V2Error'
+        403:
+          description: Forbidden.
+          schema:
+            $ref: '#/definitions/V2Error'
+        500:
+          description: Internal server error.
+          schema:
+            $ref: '#/definitions/V2Error'
+
+  '/v5/events/read':
+    post:
+      tags:
+        - Datafeed
+      summary: Read Real Time Events from an event stream (aka datafeed)
+      description: |
+        _Available on Agent 22.5 and above._
+
+        This endpoint provides messages and events from all conversations that the user
+        is in or events from the whole pod depending on the "type" field value.
+        When "type": "fanout" is provided in the body, then only events from streams the account belongs to are returned.
+        Otherwise, if "type": "datahose" is provided in the body, then events returned are not limited to the streams user
+        belongs to. In this case, at least one event type must be provided in the "filters" field. 
+        In case you are using a datahose feed and retrieving SOCIALMESSAGE events, ceservice account must be properly
+        configured in the Agent.
+
+        The types of events returned can be found in the Real Time Events list (see definition on top of the file).
+
+        The ackId sent as parameter can be empty for the first call. In the response an ackId will be sent back and it can be used for
+        the next call: in this way you acknowledge that you have received the events that came with that ackId.
+
+        If you have several instances of the same bot, they must share the same feed so that events are spread across
+        all bot instances. To do so, you must:
+        * share the same service account
+        * provide the same "tag" and same "filters" values
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      operationId: readEvents
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: body
+          description: body containing all information of events to be fetched
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/V5EventsReadBody'
+      responses:
+        200:
+          description: Datafeed successfully read.
+          schema:
+            $ref: '#/definitions/V5EventList'
+        400:
+          description: Bad request.
+          schema:
+            $ref: '#/definitions/V2Error'
+        401:
+          description: Unauthorized.
+          schema:
+            $ref: '#/definitions/V2Error'
+        403:
+          description: Forbidden.
+          schema:
+            $ref: '#/definitions/V2Error'
+        500:
+          description: Internal server error.
+          schema:
+            $ref: '#/definitions/V2Error'
+#
+# Deprecated paths
+#
+  '/v1/datafeed/create':
+    post:
+      deprecated: true
+      summary: Create a new real time message event stream.
+      description: |
+          A datafeed provides the messages in all conversations that a user is in.
+          System messages like new users joining a chatroom are not part of the datafeed.
+
+          A datafeed will expire after if it isn't read before its capacity is reached.
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - Datafeed
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Datafeed'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '400':
+          description: 'Client error.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '503':
+          description: 'Max number of data feeds reached.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/datafeed/{id}/read':
+    get:
+      deprecated: true
+      summary: Read a given datafeed.
+      description: |
+          Read messages from the given datafeed. If no more messages are available then this method will block.
+          It is intended that the client should re-call this method as soon as it has processed the messages
+          received in the previous call. If the client is able to consume messages more quickly than they become
+          available then each call will initially block, there is no need to delay before re-calling this method.
+
+          A datafeed will expire if its unread capacity is reached.
+          A datafeed can only be consumed by one client thread at a time. E.g. polling the datafeed by two threads may lead to messages being delivered out of order.
+      parameters:
+      - name: id
+        description: |
+          Datafeed ID
+        in: path
+        required: true
+        type: string
+      - name: maxMessages
+        description: |
+            Max No. of messages to return.
+        in: query
+        type: integer
+      - name: sessionToken
+        description: Session authentication token.
+        in: header
+        required: true
+        type: string
+      - name: keyManagerToken
+        description: Key Manager authentication token.
+        in: header
+        required: true
+        type: string
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - Datafeed
+      responses:
+        '200':
+          description: List of messages that have occurred since last time this URL was polled. If the list is empty, it means the request has reached its timeout, and the client should poll again.
+          schema:
+            $ref: '#/definitions/MessageList'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/HealthCheck':
+    get:
+      deprecated: true
+      summary: Checks the health of the Agent.
+      description: |
+          Used to validate the configuration of the agent.
+          Makes a request to the HealthCheck on the Symphony cloud.
+          Makes a request to the HealthCheck on the Key Manager service.
+      produces:
+        - application/json
+      tags:
+        - System
+      responses:
+        '200':
+          description: The Agent is functioning properly.
+          schema:
+            $ref: '#/definitions/V1HealthCheckResponse'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+  '/v2/HealthCheck':
+    get:
+      deprecated: true
+      summary: Checks the health of the Agent.
+      description: |
+        [deprecated] : This endpoint is deprecated.
+        The health check endpoint to be used instead is '/v3/health/extended'.
+        Unlike this deprecated endpoint, the extended health check endpoint provides status on external component such as pod, key manager, ceservice, agentservice...
+      parameters:
+        - name: showFirehoseErrors
+          description: |
+            [deprecated] Firehose Service has never been deployed. However, this request parameter has been kept here
+            for specs backward compatibility.
+          in: query
+          required: false
+          type: boolean
+        - name: failOnPodConnectivity
+          description: |
+            Defines the HealthCheck status code response whenever the Pod connectivity fails. When set to "true",
+            in case of Pod connectivity failure, the response status code will be 503; otherwise, it will be 200.
+            Default value is "false".
+          in: query
+          required: false
+          type: boolean
+        - name: failOnKeyManagerConnectivity
+          description: |
+            Defines the HealthCheck status code response whenever the Key Manager connectivity fails. When set to "true",
+            in case of Key Manager connectivity failure, the response status code will be 503; otherwise, it will be 200.
+            Default value is "false".
+          in: query
+          required: false
+          type: boolean
+        - name: failOnAgentServiceUser
+          description: |
+            Defines the HealthCheck status code response whenever the Agent Service User connectivity fails. When set to "true",
+            in case of Agent Service connectivity failure, the response status code will be 503; otherwise, it will be 200.
+            Default value is "false".
+          in: query
+          required: false
+          type: boolean
+        - name: failOnCeServiceUser
+          description: |
+            This query parameter is not used as the ceservice is deprecated and it is kept for backward compatibility.
+            Default value is "false" but it will not change the response status code if set to true.
+          in: query
+          required: false
+          type: boolean
+        - name: failOnEncryptDecryptSuccess
+          description: |
+            Defines the status code response whenever the Encrypt/Decrypt message check fails. When set to "true",
+            in case of Encrypt or Decrypt failure, the response status code will be 503; otherwise, it will be 200.
+            Default value is "false".
+          in: query
+          required: false
+          type: boolean
+        - name: failOnAny
+          description: |
+            Defines the status code response whenever at least one of the checks fails. When set to "true",
+            in case of any failure, the response status code will be 503; otherwise, it will be 200.
+            Default value is "false".
+          in: query
+          required: false
+          type: boolean
+        - name: failOnDatafeedConnectivity
+          description: |
+            Defines the HealthCheck status code response whenever the Datafeed2 connectivity fails. When set to "true",
+            in case of Datafeed connectivity failure, the response status code will be 503; otherwise, it will be 200.
+            Default value is "false".
+          in: query
+          required: false
+          type: boolean
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: false
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: false
+          type: string
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - System
+      responses:
+        '200':
+          description: The Agent is functioning properly.
+          schema:
+            $ref: '#/definitions/V2HealthCheckResponse'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+  '/v2/datafeed/{id}/read':
+    get:
+      deprecated: true
+      summary: Read a given datafeed.
+      description: |
+          Read messages from the given datafeed. If no more messages are available then this method will block.
+          It is intended that the client should re-call this method as soon as it has processed the messages
+          received in the previous call. If the client is able to consume messages more quickly than they become
+          available then each call will initially block, there is no need to delay before re-calling this method.
+
+          A datafeed will expire if its unread capacity is reached.
+          A datafeed can only be consumed by one client thread at a time. E.g. polling the datafeed by two threads may lead to messages being delivered out of order.
+      parameters:
+      - name: id
+        description: |
+          Datafeed ID
+        in: path
+        required: true
+        type: string
+      - name: maxMessages
+        description: |
+            Max No. of messages to return.
+        in: query
+        type: integer
+      - name: sessionToken
+        description: Session authentication token.
+        in: header
+        required: true
+        type: string
+      - name: keyManagerToken
+        description: Key Manager authentication token.
+        in: header
+        required: true
+        type: string
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - Datafeed
+      responses:
+        '200':
+          description: List of messages that have occurred since last time this URL was polled. If the list is empty, it means the request has reached its timeout, and the client should poll again.
+          schema:
+            $ref: '#/definitions/V2MessageList'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v4/datafeed/create':
+    post:
+      deprecated: true
+      summary: |
+        (Deprecated - Datafeed v1 will be fully replaced by the datafeed 2 service in the future.  
+        Please consider migrating over to datafeed 2 APIs /agent/v5/datafeeds. For more information on the 
+        timeline as well as on the benefits of datafeed 2, please reach out to your Technical Account Manager or to 
+        our developer documentation https://docs.developers.symphony.com/building-bots-on-symphony/datafeed)
+        Create a new real time message event stream.
+      description: |
+        A datafeed provides the messages in all conversations that a user is in.
+        This also includes system messages like new users joining a chatroom.
+
+        A datafeed will expire if it isn't read before its capacity is reached.
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - Datafeed
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Datafeed'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '400':
+          description: 'Client error.'
+          schema:
+            $ref: '#/definitions/V2Error'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '503':
+          description: 'Max number of data feeds reached.'
+          schema:
+            $ref: '#/definitions/V2Error'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+  '/v4/datafeed/{id}/read':
+    get:
+      deprecated: true
+      summary: |
+        (Deprecated - Datafeed v1 will be fully replaced by the datafeed 2 service in the future.  
+        Please consider migrating over to datafeed 2 APIs /agent/v5/datafeeds/{id}/read. For more information on the 
+        timeline as well as on the benefits of datafeed 2, please reach out to your Technical Account Manager or to 
+        our developer documentation https://docs.developers.symphony.com/building-bots-on-symphony/datafeed)
+        Read a given datafeed.
+      description: |
+        Read messages from the given datafeed. If no more messages are available then this method will block.
+        It is intended that the client should re-call this method as soon as it has processed the messages
+        received in the previous call. If the client is able to consume messages more quickly than they become
+        available then each call will initially block, there is no need to delay before re-calling this method.
+
+        A datafeed will expire if its unread capacity is reached.
+        A datafeed can only be consumed by one client thread at a time. E.g. polling the datafeed by two threads may lead to messages being delivered out of order.
+      parameters:
+        - name: id
+          description: |
+            Datafeed ID
+          in: path
+          required: true
+          type: string
+        - name: limit
+          description: |
+            Max No. of messages to return.
+          in: query
+          type: integer
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - Datafeed
+      responses:
+        '200':
+          description: List of messages that have occurred since last time this URL was polled. If the list is empty, it means the request has reached its timeout, and the client should poll again.
+          schema:
+            $ref: '#/definitions/V4EventList'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '204':
+          description: No Messages.
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+  '/v1/message/import':
+    post:
+      deprecated: true
+      summary: Import messages from other systems into Symphony.
+      description: |
+        Sends a message to be imported into the system.
+        Allows you to override the timestamp and author of the message with your desired values.
+        The requesting user must have the Content Management role.
+        The user that the message is intended to have come from must also be present in the conversation.
+        The intended message timestamp must be a valid time from the past. It cannot be a future timestamp.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: messageList
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/MessageImportList'
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: Message sent.
+          schema:
+            $ref: '#/definitions/ImportResponseList'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v2/message/import':
+    post:
+      deprecated: true
+      summary: Import messages from other systems into Symphony.
+      description: |
+        Sends a message to be imported into the system.
+        Allows you to override the timestamp and author of the message with your desired values.
+        The requesting user must have the Content Management role.
+        The user that the message is intended to have come from must also be present in the conversation.
+        The intended message timestamp must be a valid time from the past. It cannot be a future timestamp.
+        Optionally the original message ID can be specified to identify the imported message for the purpose of repeat imports.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: messageList
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/V2MessageImportList'
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: Message sent.
+          schema:
+            $ref: '#/definitions/V2ImportResponseList'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/stream/{sid}/attachment/create':
+    post:
+      deprecated: true
+      summary: Upload an attachment.
+      description: |
+        Upload an attachment to the given stream. The stream can be a chatroom,
+        an IM or a multiparty IM.
+
+        Once uploaded, you can use this attachment on a message you send in that stream.
+
+        If the attachment is uploaded then 200 is returned.
+      consumes:
+        - multipart/form-data
+      produces:
+        - application/json
+      parameters:
+        - name: sid
+          description: Stream ID
+          in: path
+          required: true
+          type: string
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: file
+          description: The attachment body.
+          in: formData
+          required: true
+          type: file
+      tags:
+        - Attachments
+      responses:
+        '200':
+          description: 'Upload successful, return the attachment ID.'
+          schema:
+            $ref: '#/definitions/AttachmentInfo'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '422':
+          description: 'Unprocessable entity: The submitted data could not be processed.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v3/stream/{sid}/attachment/create':
+    post:
+      deprecated: true
+      summary: PROVISIONAL - Upload an attachment.
+      description: |
+        Upload an attachment to the given stream. The stream can be a chatroom,
+        an IM or a multiparty IM.
+
+        Once uploaded, you can use this attachment on a message you send in that stream.
+
+        If the attachment is uploaded then 200 is returned.
+      consumes:
+        - multipart/form-data
+      produces:
+        - application/json
+      parameters:
+        - name: sid
+          description: Stream ID
+          in: path
+          required: true
+          type: string
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: false
+          type: string
+        - name: file
+          description: The attachment body.
+          in: formData
+          required: true
+          type: file
+      tags:
+        - Attachments
+      responses:
+        '200':
+          description: 'Upload successful, return the attachment ID.'
+          schema:
+            $ref: '#/definitions/AttachmentInfo'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '422':
+          description: 'Unprocessable entity: The submitted data could not be processed.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/stream/{sid}/message':
+    get:
+      deprecated: true
+      summary: Get messages from an existing stream.
+      description: |
+          A caller can fetch all unseen messages by passing the timestamp of
+          the last message seen as the since parameter and the number of messages
+          with the same timestamp value already seen as the skip parameter. This
+          means that every message will be seen exactly once even in the case that
+          an additional message is processed with the same timestamp as the last
+          message returned by the previous call, and the case where there are
+          more than maxMessages with the same timestamp value.
+
+          This method is intended for historic queries and is generally reliable
+          but if guaranteed delivery of every message in real time is required
+          then the equivilent firehose method should be called.
+      produces:
+        - application/json
+      parameters:
+        - name: sid
+          description: |
+            Stream ID
+          in: path
+          required: true
+          type: string
+        - name: since
+          description: |
+            Timestamp of first required message.
+
+            This is a long integer value representing milliseconds since
+            Jan 1 1970
+          in: query
+          required: true
+          type: integer
+          format: int64
+        - name: offset
+          description: |
+            No. of messages to skip.
+          in: query
+          type: integer
+        - name: maxMessages
+          description: |
+            Max No. of messages to return. If no value is provided, 50 is the default.
+          in: query
+          type: integer
+          required: false
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/MessageList'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v2/stream/{sid}/message':
+    get:
+      deprecated: true
+      summary: Get messages from an existing stream.
+      description: |
+          A caller can fetch all unseen messages by passing the timestamp of
+          the last message seen as the since parameter and the number of messages
+          with the same timestamp value already seen as the skip parameter. This
+          means that every message will be seen exactly once even in the case that
+          an additional message is processed with the same timestamp as the last
+          message returned by the previous call, and the case where there are
+          more than maxMessages with the same timestamp value.
+
+          This method is intended for historic queries and is generally reliable
+          but if guaranteed delivery of every message in real time is required
+          then the equivilent firehose method should be called.
+      produces:
+        - application/json
+      parameters:
+        - name: sid
+          description: |
+            Stream ID
+          in: path
+          required: true
+          type: string
+        - name: since
+          description: |
+            Timestamp of first required message.
+
+            This is a long integer value representing milliseconds since
+            Jan 1 1970
+          in: query
+          required: true
+          type: integer
+          format: int64
+        - name: offset
+          description: |
+            No. of messages to skip.
+          in: query
+          type: integer
+        - name: limit
+          description: |
+            Max No. of messages to return. If no value is provided, 50 is the default.
+          in: query
+          type: integer
+          required: false
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V2MessageList'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/stream/{sid}/message/create':
+    post:
+      deprecated: true
+      summary: Post a message to one existing stream.
+      description: |
+        Post a new message to the given stream. The stream can be a chatroom,
+        an IM or a multiparty IM.
+
+        If the message parameter type is TEXT then the message contains plain
+        text and cannot include formating, hash tags, mentions etc.
+
+        If the message parameter type is MessageML then the message contains
+        MessageML which allows for these entities.
+
+        If the message is in MessageML and fails schema validation
+        a client error results
+
+        If the message is sent then 200 is returned.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sid
+          description: Stream ID
+          in: path
+          required: true
+          type: string
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: message
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/MessageSubmission'
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: Message sent.
+          schema:
+            $ref: '#/definitions/Message'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v2/stream/{sid}/message/create':
+    post:
+      deprecated: true
+      summary: Post a message to one existing stream.
+      description: |
+        Post a new message to the given stream. The stream can be a chatroom,
+        an IM or a multiparty IM.
+
+        You may include an attachment on the message (see the V2MessageSubmission parameter).
+
+        If the message parameter type is TEXT then the message contains plain
+        text and cannot include formating, hash tags, mentions etc.
+
+        If the message parameter type is MessageML then the message contains
+        MessageML which allows for these entities.
+
+        If the message is in MessageML and fails schema validation
+        a client error results
+
+        If the message is sent then 200 is returned.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sid
+          description: Stream ID
+          in: path
+          required: true
+          type: string
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: message
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/V2MessageSubmission'
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: Message sent.
+          schema:
+            $ref: '#/definitions/V2Message'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v3/stream/{sid}/message/create':
+    post:
+      deprecated: true
+      summary: PROVISIONAL - Post a message to one existing stream.
+      description: |
+        Post a new message to the given stream. The stream can be a chatroom,
+        an IM or a multiparty IM.
+
+        You may include an attachment on the message (see the V2MessageSubmission parameter).
+
+        If the message parameter type is TEXT then the message contains plain
+        text and cannot include formating, hash tags, mentions etc.
+
+        If the message parameter type is MessageML then the message contains
+        MessageML which allows for these entities.
+
+        If the message is in MessageML and fails schema validation
+        a client error results
+
+        If the message is sent then 200 is returned.
+
+        Regarding authentication, you must either use the sessionToken which was created for delegated app access
+        or both the sessionToken and keyManagerToken together.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sid
+          description: Stream ID
+          in: path
+          required: true
+          type: string
+        - name: sessionToken
+          description: Authorization token used to make delegated calls.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: false
+          type: string
+        - name: message
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/V2MessageSubmission'
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: Message sent.
+          schema:
+            $ref: '#/definitions/V2Message'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/stream/{sid}/share':
+    post:
+      deprecated: true
+      summary: Share a piece of content into Symphony
+      description: |
+        Given a 3rd party content (eg. news article), it can share to the given stream.
+        The stream can be a chatroom, an IM or a multiparty IM.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sid
+          description: Stream ID
+          in: path
+          required: true
+          type: string
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: shareContent
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/ShareContent'
+      tags:
+        - Share
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V2Message'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/util/obsolete':
+    post:
+      deprecated: true
+      summary: Example of a deprecated endpoint, returns input.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: echoInput
+          description: Message in plain text
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/SimpleMessage'
+      tags:
+        - Util
+      responses:
+        '200':
+          description: Message sent.
+          schema:
+            $ref: '#/definitions/SimpleMessage'
+          headers:
+            X-Warning:
+              description: This method is deprecated
+              type: string
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '420':
+          description: 'Gone. Returned when the option to hard fail deprecated methods is enabled'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  Error:
+    type: object
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+  V2Error:
+    type: object
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+      details:
+        type: object
+    required:
+    - code
+    - message
+  SuccessResponse:
+    type: object
+    properties:
+      format:
+        type: string
+        enum:
+          - TEXT
+          - XML
+      message:
+        type: string
+  V2BaseMessage:
+    type: object
+    discriminator: v2messageType
+    properties:
+      id:
+        type: string
+        description: The messageId is assigned by the ingestor service when a message is sent.
+      timestamp:
+        type: string
+      v2messageType:
+        type: string
+      streamId:
+        type: string
+    required:
+    - v2messageType
+    - timestamp
+    - streamId
+  V2Message:
+    type: object
+    description: A representation of a message sent by a user of Symphony.
+    allOf:
+    - $ref: '#/definitions/V2BaseMessage'
+    - type: object
+      properties:
+        message:
+          type: string
+          format: MessageML
+          description: Message text in MessageML
+        fromUserId:
+          type: integer
+          format: int64
+          description: the Symphony userId of the user who sent the message. This will be populated by the server (and actually ignored if included when sending a message).
+        attachments:
+          type: array
+          items:
+            $ref: '#/definitions/AttachmentInfo'
+      required:
+      - message
+      - fromUserId
+  RoomCreatedMessage:
+    type: object
+    description: Generated when a room is created.
+    allOf:
+    - $ref: '#/definitions/V2BaseMessage'
+    - type: object
+      properties:
+        creationDate:
+          type: integer
+          format: int64
+        name:
+          type: string
+        keywords:
+          type: array
+          items:
+            $ref: '#/definitions/RoomTag'
+        description:
+          type: string
+        createdByUserId:
+          type: integer
+          format: int64
+          description: The Symphony userId of the user who created the room.
+        readOnly:
+          type: boolean
+        discoverable:
+          type: boolean
+        public:
+          type: boolean
+        membersCanInvite:
+          type: boolean
+        copyProtected:
+          type: boolean
+  RoomDeactivatedMessage:
+    type: object
+    description: Generated when a room is deactivated.
+    allOf:
+    - $ref: '#/definitions/V2BaseMessage'
+    - type: object
+      properties:
+        deactivatedByUserId:
+          type: integer
+          format: int64
+  RoomReactivatedMessage:
+    type: object
+    description: Generated when a room is reactivated.
+    allOf:
+    - $ref: '#/definitions/V2BaseMessage'
+    - type: object
+      properties:
+        reactivatedByUserId:
+          type: integer
+          format: int64
+  RoomUpdatedMessage:
+    type: object
+    description: Generated when a room is updated.
+    allOf:
+    - $ref: '#/definitions/V2BaseMessage'
+    - type: object
+      properties:
+        oldName:
+          type: string
+        newName:
+          type: string
+        keywords:
+          type: array
+          items:
+            $ref: '#/definitions/RoomTag'
+        oldDescription:
+          type: string
+        newDescription:
+          type: string
+        membersCanInvite:
+          type: boolean
+        discoverable:
+          type: boolean
+        readOnly:
+          type: boolean
+        copyProtected:
+          type: boolean
+  UserJoinedRoomMessage:
+    type: object
+    description: Generated when a user joins a room.
+    allOf:
+    - $ref: '#/definitions/V2BaseMessage'
+    - type: object
+      properties:
+        addedByUserId:
+          type: integer
+          format: int64
+        memberAddedUserId:
+          type: integer
+          format: int64
+  UserLeftRoomMessage:
+    type: object
+    description: Generated when a user leaves a room.
+    allOf:
+    - $ref: '#/definitions/V2BaseMessage'
+    - type: object
+      properties:
+        removedByUserId:
+          type: integer
+          format: int64
+        memberLeftUserId:
+          type: integer
+          format: int64
+        informationBarrierRemediation:
+          type: boolean
+  RoomMemberPromotedToOwnerMessage:
+    type: object
+    description: Generated when a room member is promoted to owner.
+    allOf:
+    - $ref: '#/definitions/V2BaseMessage'
+    - type: object
+      properties:
+        promotedByUserId:
+          type: integer
+          format: int64
+        promotedUserId:
+          type: integer
+          format: int64
+  RoomMemberDemotedFromOwnerMessage:
+    type: object
+    description: Generated when a room member is promoted to owner.
+    allOf:
+    - $ref: '#/definitions/V2BaseMessage'
+    - type: object
+      properties:
+        demotedByUserId:
+          type: integer
+          format: int64
+        demotedUserId:
+          type: integer
+          format: int64
+  ConnectionRequestMessage:
+    type: object
+    description: Generated when a connection request is sent.
+    allOf:
+    - $ref: '#/definitions/V2BaseMessage'
+    - type: object
+      properties:
+        requestingUserId:
+          type: integer
+          format: int64
+        targetUserId:
+          type: integer
+          format: int64
+        firstRequestedAt:
+          type: integer
+          format: int64
+        updatedAt:
+          type: integer
+          format: int64
+        requestCounter:
+          type: integer
+        status:
+          type: string
+  AttachmentInfo:
+    type: object
+    properties:
+      id:
+        type: string
+        description: The attachment ID.
+      name:
+        type: string
+        description: The file name.
+      size:
+        type: integer
+        format: int64
+        description: Size in bytes.
+    required:
+    - id
+    - name
+    - size
+  V2MessageList:
+    type: array
+    items:
+      $ref: '#/definitions/V2BaseMessage'
+  SimpleMessage:
+    description: A string wrapped in a JSON object.
+    type: object
+    properties:
+      message:
+        type: string
+
+  RoomTag:
+    description: Room Tag object. A key:value pair describing additional properties of the room.
+    properties:
+      key:
+        description: A unique label of the Tag.
+        type: string
+      value:
+        description: The value of this Tag's label.
+        type: string
+    required:
+    - key
+    - value
+  ShareArticle:
+    type: object
+    properties:
+      articleId:
+        type: string
+        description: An ID for this article that should be unique to the calling application. Either an articleId or an articleUrl is required.
+      title:
+        type: string
+        description: The title of the article
+      subTitle:
+        type: string
+        description: The subtitle of the article
+      message:
+        type: string
+        description: The message text that can be send along with the shared article
+      publisher:
+        type: string
+        description: Publisher of the article
+      publishDate:
+        type: integer
+        format: int64
+        description: Article publish date in unix timestamp
+      thumbnailUrl:
+        type: string
+        description: Url to the thumbnail image
+      author:
+        type: string
+        description: Author of the article
+      articleUrl:
+        type: string
+        description: Url to the article
+      summary:
+        type: string
+        description: Preview summary of the article
+      appId:
+        type: string
+        description: App ID of the calling application
+      appName:
+        type: string
+        description: App name of the calling application
+      appIconUrl:
+        type: string
+        description: App icon url of the calling application
+    required:
+    - title
+    - publisher
+    - author
+    - appId
+  ShareContent:
+    type: object
+    properties:
+      type:
+        type: string
+        description: Type of content to be shared.  Currently only support "com.symphony.sharing.article"
+      content:
+        $ref: '#/definitions/ShareArticle'
+  V2HealthCheckResponse:
+     type: object
+     properties:
+       podConnectivity:
+         type: boolean
+         description: Indicates whether the Agent server can connect to the Pod
+       podConnectivityError:
+         type: string
+         description: Error details in case of no Pod connectivity
+       keyManagerConnectivity:
+         type: boolean
+         description: Indicates whether the Agent server can connect to the Key Manager
+       keyManagerConnectivityError:
+         type: string
+         description: Error details in case of no Key Manager connectivity
+       firehoseConnectivity:
+         type: boolean
+         description: Indicates whether the Agent server can connect to Firehose Service
+       firehoseConnectivityError:
+         type: string
+         description: Error details in case of no Firehose connectivity
+       encryptDecryptSuccess:
+         type: boolean
+         description: Indicates whether the Agent can successfully decrypt and encrypt messages
+       encryptDecryptError:
+         type: string
+         description: Error details in case of the encryption or decryption of the message fails
+       podVersion:
+         type: string
+         description: The version number of the pod
+       agentVersion:
+         type: string
+         description: The version number of the Agent server
+       agentServiceUser:
+         type: boolean
+         description: Indicates whether agent service user is setup correctly.
+       agentServiceUserError:
+         type: string
+         description: Error details in case agent service user is setup incorrectly.
+       ceServiceUser:
+         type: boolean
+         description: Indicates whether CEService user is setup correctly.
+       ceServiceUserError:
+         type: string
+         description: Error details in case CEService user is setup incorrectly.
+  MessageSearchQuery:
+    type: object
+    properties:
+      text:
+        type: string
+        description: Search for messages containing this text. Requires streamId to be specified.
+      streamId:
+        type: string
+        description: Search for messages sent to this stream
+      streamType:
+        type: string
+        description: |
+          Search for messages sent to this type of streams. Accepted values are CHAT, IM, MIM, ROOM, POST.
+      author:
+        type: integer
+        format: int64
+        description: Search for messages sent by this user ID
+      hashtag:
+        type: string
+        description: Search for messages containing this hashtag
+      cashtag:
+        type: string
+        description: Search for messages containing this cashtag
+      mention:
+        type: integer
+        format: int64
+        description: Search for messages mentioning this user ID
+      signal:
+        type: string
+        description: |
+          Search for messages matching this signal. Can only be combined with date filtering and paging parameters.
+      fromDate:
+        type: integer
+        format: int64
+        description: Search for messages sent on or after this timestamp
+      toDate:
+        type: integer
+        format: int64
+        description: Search for messages sent before this timestamp
+  V4MessageImportList:
+    description: |
+      An ordered list of historic messages to be imported.
+      A list of import responsees will be returned in the same order.
+    type: array
+    items:
+      $ref: '#/definitions/V4ImportedMessage'
+  V4ImportedMessage:
+    description: |
+      A historic message to be imported into the system.
+      The importing user must have the Content Management role.
+      Also, the importing user must be a member of the conversation it is importing into.
+      The user that the message is intended to have come from must also be present in the conversation.
+      The intended message timestamp must be a valid time from the past. It cannot be a future timestamp.
+      By design, imported messages do not stream to datafeed or firehose endpoints.
+    type: object
+    properties:
+      message:
+        type: string
+        format: MessageML
+        description: Message text in MessageMLV2
+      data:
+        type: string
+        format: JSON
+        description: Entity data in EntityJSON
+      intendedMessageTimestamp:
+        description: |
+          The timestamp representing the time when the message was sent in the original system
+          in milliseconds since Jan 1st 1970.
+        type: integer
+        format: int64
+      intendedMessageFromUserId:
+        description: |
+          The long integer userid of the Symphony user who you intend to show sent the message.
+        type: integer
+        format: int64
+      originatingSystemId:
+        description: |
+          The ID of the system through which the message was originally sent.
+        type: string
+      originalMessageId:
+        description: |
+          The ID of the message in the original system.
+        type: string
+      streamId:
+        type: string
+      attachments:
+        description: List of message attachments. Since Agent 20.14.
+        type: array
+        items:
+          $ref: '#/definitions/V4ImportedMessageAttachment'
+        x-since: 20.14
+      previews:
+        description: List of attachments previews. Since Agent 20.14.
+        type: array
+        items:
+          $ref: '#/definitions/V4ImportedMessageAttachment'
+        x-since: 20.14
+    required:
+    - message
+    - intendedMessageTimestamp
+    - intendedMessageFromUserId
+    - originatingSystemId
+    - streamId
+  V4ImportedMessageAttachment:
+    type: object
+    properties:
+      filename:
+        description: Attachment filename
+        type: string
+        example: 'car.png'
+      content:
+        description: Attachment content as Base64 encoded string
+        type: string
+  V4ImportResponseList:
+    type: array
+    items:
+      $ref: '#/definitions/V4ImportResponse'
+  V4ImportResponse:
+    type: object
+    properties:
+      messageId:
+        description: |
+          If the message was successfully imported then the message ID in the system
+          of the newly created message.
+        type: string
+      originatingSystemId:
+        description: |
+          The ID of the system through which the message was originally sent.
+        type: string
+      originalMessageId:
+        description: |
+          The ID of the message in the original system.
+        type: string
+      diagnostic:
+        description: |
+          A diagnostic message containing an error message in the event that the
+          message import failed. May also be present in the case of a successful
+          call if there is useful narrative to return.
+        type: string
+  V4AttachmentInfo:
+    type: object
+    properties:
+      id:
+        type: string
+        description: The attachment ID.
+      name:
+        type: string
+        description: The file name.
+      size:
+        type: integer
+        format: int64
+        description: Size in bytes.
+      images:
+        type: array
+        items:
+          $ref: '#/definitions/V4ThumbnailInfo'
+    required:
+    - id
+    - name
+    - size
+  V4ThumbnailInfo:
+    type: object
+    properties:
+      id:
+        type: string
+        description: The thumbnail ID.
+      dimension:
+        type: string
+        description: The thumbnail pixel size.
+  V4MessageList:
+    type: array
+    items:
+      $ref: '#/definitions/V4Message'
+  V4Message:
+    type: object
+    description: A representation of a message sent by a user of Symphony
+    properties:
+      messageId:
+        type: string
+        description: Id of the message
+      parentMessageId:
+        type: string
+        description: Id of the parent message, set when the message is a reply to another message or a forwarded message. Since Agent 20.14.
+        x-since: 20.14
+      timestamp:
+        type: integer
+        format: int64
+        description: Timestamp of the message in milliseconds since Jan 1 1970
+      message:
+        type: string
+        format: MessageMLV2
+        description: Message content in MessageMLV2
+      sharedMessage:
+        description: Only present when the message represented by this class is a wall post sharing another message.
+        $ref: '#/definitions/V4Message'
+      data:
+        type: string
+        format: JSON
+        description: Message data in EntityJSON
+      attachments:
+        description: Message attachments
+        type: array
+        items:
+          $ref: '#/definitions/V4AttachmentInfo'
+      user:
+        $ref: '#/definitions/V4User'
+      stream:
+        $ref: '#/definitions/V4Stream'
+      externalRecipients:
+        description: Indicates if the message have external recipients. Only present on real time messaging.
+        type: boolean
+      diagnostic:
+        type: string
+        description: |
+          Details if event failed to parse for any reason.  The contents of this field may not be useful,
+          depending on the nature of the error. Only present when error occurs.
+      userAgent:
+        type: string
+        description: |
+          User agent string for client that sent the message.  Allows callers to identify which client sent the
+          origin message (e.g. API Agent, SFE Client, mobile, etc)
+      originalFormat:
+        type: string
+        description: |
+          Indicates the format in which the message was originally sent.  This could have been either:
+          - com.symphony.markdown - Markdown OR Message ML V1
+          - com.symphony.messageml.v2 - Message ML V2
+      disclaimer:
+        type: string
+        description: |
+          Message that may be sent along with a regular message if configured for the POD,
+          usually the first message sent in a room that day.
+      sid:
+        type: string
+        description: |
+          Unique session identifier from where the message was created.
+        example: 'fa691cd3-484a-4109-aeb2-57c05b78c95b'
+      replacing:
+        type: string
+        description: Id of the message that the current message is replacing (present only if set)
+      replacedBy:
+        type: string
+        description: Id of the message that the current message is being replaced with (present only if set)
+      initialTimestamp:
+        type: integer
+        format: int64
+        description: Timestamp of when the initial message has been created in milliseconds since Jan 1 1970 (present only if set)
+      initialMessageId:
+        type: string
+        description: Id the the initial message that has been updated (present only if set)
+      silent:
+        type: boolean
+        description: When false the user/s will receive the message update as unread (true by default). Since Agent 20.14.
+        x-since: 20.14
+  V4MessageBlastResponse:
+    type: object
+    description: Wrapper response for a single message sent to multiple streams
+    properties:
+      messages:
+        type: array
+        description: List of messages successfully sent
+        items:
+          $ref: '#/definitions/V4Message'
+      errors:
+        type: object
+        description: List of streams where the messages ingestion has failed
+        additionalProperties:
+          $ref: '#/definitions/Error'
+  V4User:
+    type: object
+    properties:
+      userId:
+        type: integer
+        format: int64
+        description: Id of user
+      firstName:
+        type: string
+        description: First name of user
+      lastName:
+        type: string
+        description: Last name of user
+      displayName:
+        type: string
+        description: User display name
+      email:
+        type: string
+        description: Email of user
+      username:
+        type: string
+        description: Applicable only to internal users
+  V4Stream:
+    type: object
+    properties:
+      streamId:
+        type: string
+        description: Id of stream
+      streamType:
+        type: string
+        description: |
+          Stream type, possible values are:
+            - IM
+            - MIM
+            - ROOM
+            - POST
+      roomName:
+        type: string
+        description: Applicable only to rooms
+      members:
+        description: Applicable only to IM Created
+        type: array
+        items:
+          $ref: '#/definitions/V4User'
+      external:
+        type: boolean
+      crossPod:
+        type: boolean
+  V4RoomProperties:
+    type: object
+    properties:
+      name:
+        type: string
+      description:
+        type: string
+      creatorUser:
+        $ref: '#/definitions/V4User'
+      createdDate:
+        type: integer
+        format: int64
+        description: Timestamp
+      external:
+        type: boolean
+      crossPod:
+        type: boolean
+      public:
+        type: boolean
+      copyProtected:
+        type: boolean
+      readOnly:
+        type: boolean
+      discoverable:
+        type: boolean
+      membersCanInvite:
+        type: boolean
+      keywords:
+        type: array
+        items:
+          $ref: '#/definitions/V4KeyValuePair'
+      canViewHistory:
+        type: boolean
+  V4KeyValuePair:
+    type: object
+    properties:
+      key:
+        type: string
+      value:
+        type: string
+  V4MessageSent:
+    type: object
+    properties:
+      message:
+        $ref: '#/definitions/V4Message'
+  V4Initiator:
+    type: object
+    properties:
+      user:
+        $ref: '#/definitions/V4User'
+  V4SharedPost:
+    type: object
+    properties:
+      message:
+        $ref: '#/definitions/V4Message'
+      sharedMessage:
+        $ref: '#/definitions/V4Message'
+  V4InstantMessageCreated:
+    type: object
+    properties:
+      stream:
+        $ref: '#/definitions/V4Stream'
+  V4RoomCreated:
+    type: object
+    properties:
+      stream:
+        $ref: '#/definitions/V4Stream'
+      roomProperties:
+        $ref: '#/definitions/V4RoomProperties'
+  V4RoomUpdated:
+    type: object
+    properties:
+      stream:
+        $ref: '#/definitions/V4Stream'
+      newRoomProperties:
+        $ref: '#/definitions/V4RoomProperties'
+  V4RoomDeactivated:
+    type: object
+    properties:
+      stream:
+        $ref: '#/definitions/V4Stream'
+  V4RoomReactivated:
+    type: object
+    properties:
+      stream:
+        $ref: '#/definitions/V4Stream'
+  V4UserJoinedRoom:
+    type: object
+    properties:
+      stream:
+        $ref: '#/definitions/V4Stream'
+      affectedUser:
+        # User who was affected by the action (i.e. added to the room)
+        $ref: '#/definitions/V4User'
+  V4UserLeftRoom:
+    type: object
+    properties:
+      stream:
+        $ref: '#/definitions/V4Stream'
+      affectedUser:
+        # User who was affected by the action (i.e. left the room)
+        $ref: '#/definitions/V4User'
+  V4RoomMemberPromotedToOwner:
+    type: object
+    properties:
+      stream:
+        $ref: '#/definitions/V4Stream'
+      affectedUser:
+        # User who was affected by the action (i.e. promoted to owner)
+        $ref: '#/definitions/V4User'
+  V4RoomMemberDemotedFromOwner:
+    type: object
+    properties:
+      stream:
+        $ref: '#/definitions/V4Stream'
+      affectedUser:
+        # User who was affected by the action (i.e. demoted from owner)
+        $ref: '#/definitions/V4User'
+  V4ConnectionRequested:
+    type: object
+    properties:
+      toUser:
+        # User who received the connection request
+        $ref: '#/definitions/V4User'
+  V4ConnectionAccepted:
+    type: object
+    properties:
+      fromUser:
+        # User who sent the connection request
+        $ref: '#/definitions/V4User'
+  V4MessageSuppressed:
+    type: object
+    properties:
+      messageId:
+        type: string
+      stream:
+        # the stream holding the suppressed message
+        $ref: '#/definitions/V4Stream'
+  V4SymphonyElementsAction:
+    type: object
+    properties:
+      stream:
+        description: "The stream where the Form message was posted"
+        $ref: '#/definitions/V4Stream'
+      formMessageId:
+        description: "The id of the message that contains the Form"
+        type: string
+      formId:
+        description: "The id of the Form element"
+        type: string
+      formValues:
+        description: "The values (in JSON format) answered on the Form"
+        type: object
+  V4UserRequestedToJoinRoom:
+    type: object
+    properties:
+      stream:
+        description: "The stream that the user requested to join"
+        $ref: '#/definitions/V4Stream'
+      affectedUsers:
+        type: array
+        description: "List of affected users by the action (i.e. owners of the room)"
+        items:
+          $ref: '#/definitions/V4User'
+  V4Payload:
+    type: object
+    properties:
+      messageSent:
+        $ref: '#/definitions/V4MessageSent'
+      sharedPost:
+        $ref: '#/definitions/V4SharedPost'
+      instantMessageCreated:
+        $ref: '#/definitions/V4InstantMessageCreated'
+      roomCreated:
+        $ref: '#/definitions/V4RoomCreated'
+      roomUpdated:
+        $ref: '#/definitions/V4RoomUpdated'
+      roomDeactivated:
+        $ref: '#/definitions/V4RoomDeactivated'
+      roomReactivated:
+        $ref: '#/definitions/V4RoomReactivated'
+      userJoinedRoom:
+        $ref: '#/definitions/V4UserJoinedRoom'
+      userLeftRoom:
+        $ref: '#/definitions/V4UserLeftRoom'
+      roomMemberPromotedToOwner:
+        $ref: '#/definitions/V4RoomMemberPromotedToOwner'
+      roomMemberDemotedFromOwner:
+        $ref: '#/definitions/V4RoomMemberDemotedFromOwner'
+      connectionRequested:
+        $ref: '#/definitions/V4ConnectionRequested'
+      connectionAccepted:
+        $ref: '#/definitions/V4ConnectionAccepted'
+      messageSuppressed:
+        $ref: '#/definitions/V4MessageSuppressed'
+      symphonyElementsAction:
+        $ref: '#/definitions/V4SymphonyElementsAction'
+      userRequestedToJoinRoom:
+        $ref: '#/definitions/V4UserRequestedToJoinRoom'
+  V4Event:
+    type: object
+    properties:
+      id:
+        type: string
+        description: Event ID
+      messageId:
+        type: string
+        description: Message ID
+      timestamp:
+        type: integer
+        format: int64
+        description: Timestamp of event
+      type:
+        type: string
+        description: |
+          Event type, possible events are:
+            - MESSAGESENT
+            - SHAREDPOST
+            - INSTANTMESSAGECREATED
+            - ROOMCREATED
+            - ROOMUPDATED
+            - ROOMDEACTIVATED
+            - ROOMREACTIVATED
+            - USERJOINEDROOM
+            - USERLEFTROOM
+            - ROOMMEMBERPROMOTEDTOOWNER
+            - ROOMMEMBERDEMOTEDFROMOWNER
+            - CONNECTIONREQUESTED
+            - CONNECTIONACCEPTED
+            - MESSAGESUPPRESSED
+            - SYMPHONYELEMENTSACTION
+            - USERREQUESTEDTOJOINROOM
+      diagnostic:
+        type: string
+        description: |
+          Details if event failed to parse for any reason.  The contents of this field may not be useful,
+          depending on the nature of the error. Only present when error occurs.
+      initiator:
+        # Actor who initiated the event
+        $ref: '#/definitions/V4Initiator'
+      payload:
+        # Holds payload for all event types
+        $ref: '#/definitions/V4Payload'
+  V4EventList:
+    type: array
+    items:
+      $ref: '#/definitions/V4Event'
+  BaseSignal:
+    type: object
+    properties:
+      name:
+        type: string
+        description: Signal name
+      query:
+        type: string
+        description: |
+          The query used to define this signal. The query is defined as "field:value" pairs combined by the operators
+          "AND" or "OR". Supported fields are (case-insensitive): "author", "hashtag" and "cashtag".
+          MUST contain at least one "hashtag" or "cashtag" definition.
+      visibleOnProfile:
+        type: boolean
+        description: Whether the signal is visible on its creator's profile
+      companyWide:
+        type: boolean
+        description: Whether the signal is a push signal
+  Signal:
+    allOf:
+      - $ref: '#/definitions/BaseSignal'
+      - type: object
+        properties:
+          id:
+            type: string
+            description: Signal ID
+          timestamp:
+            type: integer
+            format: int64
+            description: Timestamp when the signal was created, in milliseconds since Jan 1 1970
+          companyWide:
+            type: boolean
+            description: Whether the signal is a push signal
+  SignalList:
+    type: array
+    items:
+      $ref: '#/definitions/Signal'
+  ChannelSubscriptionResponse:
+    type: object
+    properties:
+      requestedSubscription:
+        type: integer
+        format: int64
+        description: The number of requested userIds to subscribe
+      successfulSubscription:
+        type: integer
+        format: int64
+        description: The number of successful subscriptions done
+      failedSubscription:
+        type: integer
+        format: int64
+        description: The number of subscription failures
+      subscriptionErrors:
+        type: array
+        items:
+          $ref: '#/definitions/ChannelSubscriptionError'
+  ChannelSubscriptionError:
+    type: object
+    properties:
+      userId:
+        type: integer
+        format: int64
+        description: The userId on which failure happened
+      code:
+        type: string
+        description: subscription failure code
+      message:
+        type: string
+        description: subscription failure message
+  ChannelSubscriberResponse:
+    type: object
+    properties:
+      offset:
+        type: integer
+        format: int64
+        description: The number of subscribers skipped
+      hasMore:
+        type: boolean
+        description: True if there are more subscribers
+      total:
+        type: integer
+        description: The total number of subscribers
+      data:
+        type: array
+        items:
+          $ref: '#/definitions/ChannelSubscriber'
+  ChannelSubscriber:
+    type: object
+    properties:
+      subscriptionId:
+        type: string
+      pushed:
+        type: boolean
+        description: True if the subscriber is allowed to unsubscribe
+      owner:
+        type: boolean
+        description: True if the subscriber is the creator
+      subscriberName:
+        type: string
+        description: User display name
+      userId:
+        type: integer
+        format: int64
+        description: The user ID of the subscriber
+      timestamp:
+        type: integer
+        format: int64
+        description: Timestamp when the signal was subscribed, in milliseconds since Jan 1 1970
+  AgentInfo:
+    type: object
+    properties:
+      ipAddress:
+        type: string
+        description: The IP address of the Agent server.
+      hostname:
+        type: string
+        description: The hostname of the Agent server.
+      serverFqdn:
+        type: string
+        description: The fully-qualified domain name of the Agent server. Must be set by the user at startup.
+      version:
+        type: string
+        description: The version of the Agent.
+      url:
+        type: string
+        description: The URL under which the Agent is available.
+      onPrem:
+        type: boolean
+        description: Whether this is an on-prem or cloud installation.
+      commitId:
+        type: string
+        description: The Git commit ID of the running revision.
+  V1DLPPoliciesCollectionResponse:
+    type: object
+    properties:
+      policies:
+        type: array
+        description: List of policies
+        items:
+          $ref: '#/definitions/V1DLPPolicy'
+      page:
+        type: integer
+        format: int32
+        description: Page number of current page
+      pageCount:
+        type: integer
+        format: int32
+        description: Total number of pages available
+    description: List of policies
+  V1DLPPolicy:
+    type: object
+    required:
+    - "contentTypes"
+    - "name"
+    - "scopes"
+    - "type"
+    properties:
+      active:
+        type: boolean
+        description: Indicate whether the policy is active or not
+      contentTypes:
+        type: array
+        description: |
+          The list of content types that policy should apply to. Cannot be empty. Policy content types could be either of "Messages", "RoomMeta", "SignalMeta".
+          Default is set to ["Messages"] if not specified.
+        items:
+          type: string
+      creationDate:
+        type: integer
+        format: int64
+        description: |
+          Creation time of the policy in milliseconds elapsed as of epoch time.
+      creatorId:
+        type: string
+        description: Numeric userId of the creator
+      dictionaryRefs:
+        type: array
+        description: List of dictionaries.
+        items:
+          $ref: '#/definitions/V1DLPDictionaryRef'
+      lastDisabledDate:
+        type: integer
+        format: int64
+        description: |
+          Recent disable time of the policy in milliseconds elapsed as of epoch time.
+      lastUpdatedDate:
+        type: integer
+        format: int64
+        description: Recent update time of the policy in milliseconds elapsed as of epoch time.
+      name:
+        type: string
+        description: Unique name of a policy, max 30 characters. Cannot be empty. All the leading and trailing blank spaces are trimmed.
+      policyId:
+        type: string
+        description: Policy Id
+      scopes:
+        type: array
+        description: |
+          List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
+          You can apply both scopes if you set it to ["Internal", "External"].
+        items:
+          type: string
+      type:
+        type: string
+        description: Type of policy. Possible values "Block" or "Warn".
+      version:
+        type: string
+        description: |
+          The version of a dictionary, in format "major.minor". Initial value will set by backend as "1.0" when created.
+          Whenever the dictionary version needs to be changed, the minor version by 1 unless minor == 999, then the major version is increased by 1 until it reaches 999.
+    description: The policy object for expression filter, one policy can have multiple dictionaries
+  V1DLPPolicyRequest:
+    type: object
+    required:
+    - "contentTypes"
+    - "name"
+    - "scopes"
+    - "type"
+    properties:
+      contentTypes:
+        type: array
+        description: |
+          The list of content types that policy should apply to. Cannot be empty. Policy content types could be either of "Messages", "RoomMeta", "SignalMeta".
+          Default is set to ["Messages"] if not specified.
+        items:
+          type: string
+      dictionaryIds:
+        type: array
+        description: List of dictionaries Ids for the policy.
+        items:
+          type: string
+      name:
+        type: string
+        description: Unique name of a policy, max 30 characters. Cannot be empty. All the leading and trailing blank spaces are trimmed.
+      scopes:
+        type: array
+        description: |
+          List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
+          You can apply both scopes if you set it to ["Internal", "External"].
+        items:
+          type: string
+      type:
+        type: string
+        description: Type of policy. Possible values "Block" or "Warn".
+    description: The policy object to use for creating/updating a policy.
+  V1DLPPolicyResponse:
+    type: object
+    properties:
+      data:
+        $ref: '#/definitions/V1DLPPolicy'
+    description: Policy Response
+  V1DLPDictionary:
+    type: object
+    required:
+    - dictionaryMetadata
+    properties:
+      content:
+        $ref: '#/definitions/V1DLPDictionaryContent'
+      dictionaryMetadata:
+        $ref: '#/definitions/V1DLPDictionaryMetadata'
+    description: Dictionary object
+  V1DLPDictionaryContent:
+    type: object
+    properties:
+      data:
+        type: string
+        description: |
+          A comma separated string which contains a lot of keywords/regexes.
+      numKeywords:
+        type: integer
+        format: int32
+        description: Number of Keywords in dictionary
+      md5:
+        type: string
+        description: MD5 value of the content
+    description: Content of a dictionary
+  V1DLPDictionaryMetadataCollectionResponse:
+    type: object
+    properties:
+      items:
+        type: array
+        description: List of dictionary metadata
+        items:
+          $ref: '#/definitions/V1DLPDictionaryMetadata'
+      page:
+        type: integer
+        format: int32
+        description: Page number of current page
+      pageCount:
+        type: integer
+        format: int32
+        description: Total number of pages available
+    description: List of dictionary metadata.
+  V1DLPDictionaryMetadataResponse:
+    type: object
+    required:
+    - data
+    properties:
+      data:
+        $ref: '#/definitions/V1DLPDictionaryMetadata'
+    description: Dictionary response containing dictionary metadata.
+  V1DLPDictionaryMetadataCreateRequest:
+    type: object
+    required:
+    - name
+    - type
+    properties:
+      name:
+        type: string
+        description: |
+          The name of dictionary
+      type:
+        type: string
+        description: |
+          The type of dictionary, which specify the content is a list of words or a list of regexes.
+          By default set to "Word" if not specified. Possible values - Word, Regex
+    description: Dictionary's metadata (excluding content) to use for dictionary create operations.
+  V1DLPDictionaryMetadataUpdateRequest:
+    type: object
+    required:
+    - name
+    properties:
+      name:
+        type: string
+        description: |
+          The name of dictionary
+    description: Dictionary's metadata (excluding content) to use for dictionary update operations.
+  V1DLPDictionaryMetadata:
+    type: object
+    required:
+    - dictRef
+    - type
+    properties:
+      creationDate:
+        type: integer
+        format: int64
+        description: Creation time of the dictionary in milliseconds elapsed as of epoch time.
+      creatorId:
+        type: string
+        description: Numeric userId of the creator
+      dictRef:
+        $ref: '#/definitions/V1DLPDictionaryRef'
+      lastUpdatedDate:
+        type: integer
+        format: int64
+        description: The recent update time of the dictionary in milliseconds
+      type:
+        type: string
+        description: |
+          The type of dictionary, which specify the content is a list of words or a list of regexes.
+          By default set to "Word" if not specified. Possible values - Word, Regex
+    description: Dictionary's metadata (excluding content)
+  V1DLPDictionaryRef:
+    type: object
+    required:
+    - name
+    properties:
+      dictId:
+        type: string
+        description: Unique dictionary id
+      name:
+        type: string
+        description: Unique name of a dictionary, max 30 characters, with trimmed leading and trailing blank spaces.
+      version:
+        type: string
+        description: |
+          The version of a dictionary, in format "major.minor".
+          Initial value will set by backend as "1.0" when created.
+          Whenever the dictionary version needs to be changed, the minor version by 1 unless minor == 999, then the major version is increased by 1 until it reaches 999.
+    description: Basic information needed to identify a dictionary
+  V1DLPViolationMessageResponse:
+    type: object
+    properties:
+      violations:
+        type: array
+        description: A representation of list of violations due to messages sent by a user of Symphony
+        items:
+          $ref: '#/definitions/V1DLPViolationMessage'
+      nextOffset:
+        type: string
+        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
+  V1DLPViolationStreamResponse:
+    type: object
+    properties:
+      violations:
+        type: array
+        items:
+          # A representation of list of violations due to rooms creation/update sent by a user of Symphony
+          $ref: '#/definitions/V1DLPViolationStream'
+      nextOffset:
+        type: string
+        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
+  V1DLPViolationSignalResponse:
+    type: object
+    properties:
+      violations:
+        type: array
+        description: A representation of list of violations due to signal creation/update sent by a user of Symphony
+        items:
+          $ref: '#/definitions/V1DLPViolationSignal'
+      nextOffset:
+        type: string
+        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
+  V1DLPViolationMessage:
+    type: object
+    properties:
+      violation:
+        # A representation of a violation due to a message sent by a user of Symphony
+        $ref: '#/definitions/V1DLPViolation'
+      message:
+        # Message details when DLP was enforced
+        $ref: '#/definitions/V4Message'
+      diagnostic:
+        type: string
+        description: |
+            A diagnostic message containing an error message in the event there are parsing errors.
+            May also be present in the case of a successful call if there is useful narrative to return.
+  V1DLPViolationStream:
+    type: object
+    properties:
+      violation:
+        # A representation of a violation due to rooms creation/update sent by a user of Symphony
+        $ref: '#/definitions/V1DLPViolation'
+      stream:
+        # Room details when DLP was enforced
+        $ref: '#/definitions/V1DLPStream'
+  V1DLPViolationSignal:
+    type: object
+    properties:
+      violation:
+        # A representation of a violation due to signal creation/update sent by a user of Symphony
+        $ref: '#/definitions/V1DLPViolation'
+      signal:
+        # Signal details when DLP was enforced
+        $ref: '#/definitions/V1DLPSignal'
+  V1DLPViolation:
+    type: object
+    description: A representation of a violation due to a message sent by a user of Symphony
+    properties:
+      enforcementEventID:
+        type: string
+        description: Enforcement event ID. Unique ID that identifies this enforcement.
+      entityID:
+        type: string
+        description: Entity ID is the content Id of the violation, for example, for messages, its the Id of the message
+      createTime:
+        type: integer
+        format: int64
+        description: Timestamp of the violation in milliseconds since Jan 1 1970
+      lastModified:
+        type: integer
+        format: int64
+        description: Timestamp of the last modification of violation in milliseconds since Jan 1 1970
+      requesterId:
+        type: integer
+        format: int64
+        description: Id of the requester responsible for the message/stream/signal
+      matchedPolicies:
+        # Policies that matched when DLP was enforced and the list of matched terms decrypted.
+        $ref: '#/definitions/V1DLPMatchedPolicyList'
+      action:
+        type: string
+        description: action taken such as BLOCK or WARN.  See outcome for a more detailed description of the outcome this action.
+      outcome:
+        # Detailed outcome of the DLP enforcement such as REJECTED_VIOLATION, ACCEPTED_WARNING, ACCEPTED_LEGACY_CLIENT etc.
+        $ref: '#/definitions/V1DLPOutcome'
+      version:
+        type: string
+        description: Version of application which processed the message and produced this violation.
+      ignoreDLPwarning:
+          type: boolean
+          description: Did the user chose to ignore DLP warning that was presented?
+  V1DLPMatchedPolicyList:
+    type: array
+    items:
+      $ref: '#/definitions/V1DLPMatchedPolicy'
+    description: List of policies that matched the violation.
+  V1DLPMatchedPolicy:
+    type: object
+    description: A representation of policy that matched the violation with a list of matched keywords in the policy
+    properties:
+      id:
+        type: string
+        description: Id of the policy
+      version:
+        type: string
+        description: Version of the policy
+      policyName:
+        type: string
+        description: Name of the policy
+      type:
+        type: string
+        description: Whether BLOCK or WARN
+      terms:
+        type: string
+        description: List of decrypted matched keywords in the policy
+      diagnostic:
+        type: string
+        description: |
+            A diagnostic message containing an error message in the event that the
+            decryption of terms failed. May also be present in the case of a successful
+            call if there is useful narrative to return.
+  V1DLPOutcome:
+    type: object
+    description: A representation of outcome of DLP message/stream/signal sent by a user of Symphony
+    properties:
+      type:
+        type: string
+        description: Outcome of DLP enforcement
+  V1DLPContentType:
+    type: object
+    description: A representation of content type of message sent by a user of Symphony (message/stream/signal)
+    properties:
+      type:
+        type: string
+        description: content type
+  V1DLPStream:
+    type: object
+    description: Room details in the context of violation.
+    properties:
+        name:
+          type: string
+          description:  Name of the Stream/Room.
+        creatorPrettyName:
+          type: string
+          description:  Name of the creator of the Room.
+        publicRoom:
+          type: boolean
+          description:  Is this a public room?
+        crossPod:
+          type: boolean
+          description:  Is this a cross pod scenario?
+        allowExternal:
+          type: boolean
+          description:  Is external messaging allowed
+        creatorId:
+          type: string
+          description:  Id of the creator of the Room.
+        roomDescription:
+          type: string
+          description:  Description of the Room.
+        streamId:
+          type: string
+          description:  ThreadId of the Room.
+        state:
+          type: string
+          description:  State of the Room (example CREATED etc)
+        type:
+          type: string
+          description:  Type of the Room (example ROOM (or IM or Wall))
+        lastDisabled:
+          type: integer
+          format: int64
+          description: Timestamp of last time the room is Disabled
+        memberAddUserEnabled:
+          type: boolean
+          description:  Is memberAddUserEnabled
+        active:
+          type: boolean
+          description:  Is Room Active
+        discoverable:
+          type: boolean
+          description:  Is Room discoverable
+        readOnly:
+          type: boolean
+          description:  Is Room read-only
+        copyDisabled:
+          type: boolean
+          description:  Is Room copyDisabled
+        externalOwned:
+          type: boolean
+          description:  Is Room externalOwned
+        sendMessageDisabled:
+          type: boolean
+          description:  Is sendMessage Disabled for this Room
+        moderated:
+          type: boolean
+          description:  Is room moderated
+        shareHistoryEnabled:
+          type: boolean
+          description:  Is room shareHistoryEnabled
+        diagnostic:
+          type: string
+          description: |
+              A diagnostic message containing an error message in the event that the
+              stream retrieval failed. May also be present in the case of a successful
+              call if there is useful narrative to return.
+  V1DLPSignal:
+    type: object
+    description: Signal details
+    properties:
+        name:
+          type: string
+          description:  Name of the Signal
+        rules:
+          type: string
+          description:  Signal rules decrypted.
+        diagnostic:
+          type: string
+          description: |
+              A diagnostic message containing an error message in the event that the
+              signal decryption failed. May also be present in the case of a successful
+              call if there is useful narrative to return.
+
+#
+# V3 Policies definitions
+#
+  V3DLPPolicyRequest:
+    type: object
+    required:
+      - "name"
+      - "scopes"
+      - "appliesTo"
+    properties:
+      name:
+        type: string
+        description: |
+          Unique name of a policy, max 30 characters. Cannot be empty. All the leading and trailing blank spaces are trimmed.
+      scopes:
+        type: array
+        description: |
+          List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
+          You can apply both scopes if you set it to ["Internal", "External"].
+        items:
+          type: string
+      appliesTo:
+        type: array
+        items:
+          $ref: '#/definitions/V3DLPPolicyAppliesTo'
+    description: Request to be used to get policies.
+  V3DLPPolicy:
+    type: object
+    properties:
+      id:
+        type: string
+        description: Unique identifier for policy.
+      policyId:
+        type: string
+        description: Policy Id.
+      version:
+        type: string
+        description: |
+          The version of the policy, in format "major.minor". Initial value will set by backend as "3.0" when created.
+          Whenever the policy version needs to be changed, the minor version by 1 unless minor == 999,
+          then the major version is increased by 1 until it reaches 999.
+      name:
+        type: string
+        description: |
+          Unique name of policy, max 30 characters. Cannot be empty. All the leading and trailing blank spaces are trimmed.
+      creatorId:
+        type: integer
+        format: int64
+        description: Numeric userId of the creator.
+      scopes:
+        type: array
+        description: |
+          List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
+          You can apply both scopes if you set it to ["Internal", "External"].
+        items:
+          type: string
+      appliesTo:
+        type: array
+        items:
+          $ref: '#/definitions/V3DLPPolicyAppliesTo'
+      active:
+        type: boolean
+        description: Indicate whether the policy is active or not.
+      deleted:
+        type: boolean
+        description: Indicate whether the policy is deleted or not.
+      creationDate:
+        type: integer
+        format: int64
+        description: |
+          Creation time of the policy in milliseconds elapsed as of epoch time.
+      lastUpdatedDate:
+        type: integer
+        format: int64
+        description: |
+          Recent update time of the policy in milliseconds elapsed as of epoch.
+          time.
+      lastDisabledDate:
+        type: integer
+        format: int64
+        description: |
+          Recent disable time of the policy in milliseconds elapsed as of epoch.
+          time.
+      systemPolicy:
+        type: boolean
+    description : |
+      A policy is the main entity of V3 policy/rule system. It is responsible to define rules and add scope constraints to the engine.
+  V3DLPRule:
+    type: object
+    required:
+     - "type"
+     - "name"
+    properties:
+      id:
+        type: string
+      type:
+        type: string
+        description: Type of a rule used by policy. Can be ["UNKNOWN", "TEXT_MATCH", "FILE_EXTENSION", "FILE_SIZE", "FILE_PASSWORD", "FILE_CLASSIFIER"].
+      name:
+        type: string
+        description: Name for rule.
+      textMatchConfig:
+        $ref: '#/definitions/V3DLPTextMatchConfig'
+      fileSizeConfig:
+        $ref: '#/definitions/V3DLPFileSizeConfig'
+      fileExtensionConfig:
+        $ref: '#/definitions/V3DLPFileExtensionConfig'
+      filePasswordConfig:
+        $ref: '#/definitions/V3DLPFilePasswordConfig'
+      fileClassifierConfig:
+        $ref: '#/definitions/V3DLPFileClassifierConfig'
+    description: |
+     A Rule defines the actual matching specification for policies. It holds a type and a configuration
+     for the rule, these properties should be used to build the corresponding matching implementation.
+     Only one of the configuration property should be set [textMatchConfig, fileSizeConfig, fileExtensionConfig, filePasswordConfig, fileClassifierConfig].
+  V3DLPFilePasswordConfig:
+    type: object
+    required:
+      - "applicableFileTypes"
+      - "matchCriteria"
+    properties:
+        applicableFileTypes:
+          type: array
+          items:
+            type: string
+          description: File types that can be applied. Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
+        matchCriteria:
+          type: string
+          description: |
+           Based on the criteria, whether a file is password protected or not means a match.
+           Can be ["PASSWORD_PROTECTED", "NOT_PASSWORD_PROTECTED"]. The default is "NOT_PASSWORD_PROTECTED".
+    description: Password protected detection config for files that are password protected or not.
+  V3DLPFileExtensionConfig:
+    type: object
+    required:
+      - "allowLists"
+    properties:
+      allowLists:
+        type: array
+        items:
+          type: string
+        description: File extensions that are allowed.
+      blockLists:
+        type: array
+        items:
+          type: string
+        description: File extensions that are blocked.
+    description: Extension detection config for allowed and blocked types of file extensions.
+  V3DLPFileSizeConfig:
+    type: object
+    properties:
+      sizeLimit:
+        type: integer
+        format: int32
+    description: File size config defines maximum allowed size of file. Default max size limit is 20 MB.
+  V3DLPTextMatchConfig:
+    type: object
+    properties:
+      dictionaries:
+        type: array
+        items:
+         $ref: '#/definitions/V3DLPDictionaryMeta'
+      countUniqueOccurrences:
+        type: integer
+        format: int32
+      applicableFileTypes:
+        type: array
+        items:
+         type: string
+        description: |
+          File types must be applied only for rule type "FileContent", otherwise must be empty.
+          Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
+    description: |
+      This is a configuration that can be used to match text or regex.
+      Configuration that can be used by a rule. This is a configuration that can be used to match text or regex.
+      This configuration also corresponds to V2 TextMatch/RegexMatch of dictionaries.
+  V3DLPDictionaryMeta:
+    type: object
+    required:
+      - "dictId"
+      - "version"
+      - "name"
+    properties:
+      dictId:
+        type: string
+      version:
+        type: string
+      name:
+        type: string
+    description: Identity of a dictionary.
+  V3DLPFileClassifierConfig:
+    type: object
+    required:
+      - "classifiers"
+      - "applicableFileTypes"
+    properties:
+      classifiers:
+        type: object
+        additionalProperties:
+         type: string
+        description: |
+         Classifier is defined as a Key and its Value: e.g.: "classification": "Internal".
+         Name and value can contain UTF-8 characters. Neither the name nor value cannot be left empty.
+         Maximum 30 characters for the name and value, case insensitive.
+         If files contains k-v pairs in the classifers map, it means a match. Maximum 30 classifiers per policy.
+      applicableFileTypes:
+        type: array
+        items:
+         type: string
+        description: |
+          File types that can be applied. Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
+  V3DLPPolicyAppliesTo:
+    type: object
+    required:
+      - "dataType"
+      - "action"
+      - "rules"
+    properties:
+      dataType:
+        type: string
+        description: |
+          The list of data types that policy should apply to. Can't be empty.
+          Can be ["Messages","RoomMeta", "SignalMeta", "FileContent", "FileMeta"].
+      action:
+        type: string
+        description: |
+          Action to be taken on violation detection.
+          Can be ["Block", "Warn", "LogOnly"]. The default is "LogOnly".
+      rules:
+        type: array
+        items:
+          $ref: '#/definitions/V3DLPRule'
+  V3DLPPolicyResponse:
+    type: object
+    properties:
+      data:
+        $ref: '#/definitions/V3DLPPolicy'
+    description: Policy Response.
+  V3DLPPoliciesCollectionResponse:
+    type: object
+    properties:
+      policies:
+        type: array
+        description: List of policies.
+        items:
+          $ref: '#/definitions/V3DLPPolicy'
+      page:
+        type: integer
+        format: int32
+        description: The starting page for pagination.
+      size:
+        type: integer
+        format: int32
+        description: Size of policies displayed per page.
+      pageCount:
+        type: integer
+        format: int32
+        description: Total number of pages available.
+    description: List of policies.
+  V3DLPViolationMessageResponse:
+    type: object
+    properties:
+      violations:
+        type: array
+        description: A representation of list of violations due to messages sent by a user of Symphony
+        items:
+          $ref: '#/definitions/V3DLPViolationMessage'
+      nextOffset:
+        type: string
+        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
+  V3DLPViolationStreamResponse:
+    type: object
+    properties:
+      violations:
+        type: array
+        items:
+          # A representation of list of violations due to rooms creation/update sent by a user of Symphony
+          $ref: '#/definitions/V3DLPViolationStream'
+      nextOffset:
+        type: string
+        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
+  V3DLPViolationSignalResponse:
+    type: object
+    properties:
+      violations:
+        type: array
+        description: A representation of list of violations due to signal creation/update sent by a user of Symphony
+        items:
+          $ref: '#/definitions/V3DLPViolationSignal'
+      nextOffset:
+        type: string
+        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
+  V3DLPViolationMessage:
+    type: object
+    properties:
+      violation:
+        # A representation of a violation due to a message sent by a user of Symphony
+        $ref: '#/definitions/V3DLPViolation'
+      message:
+        # Message details when DLP was enforced
+        $ref: '#/definitions/V4Message'
+      sharedMessage:
+              description: Shared message details if present in message.
+              $ref: '#/definitions/V4Message'
+      diagnostic:
+        type: string
+        description: |
+          A diagnostic message containing an error message in the event there are parsing errors.
+          May also be present in the case of a successful call if there is useful narrative to return.
+  V3DLPViolationStream:
+    type: object
+    properties:
+      violation:
+        # A representation of a violation due to rooms creation/update sent by a user of Symphony
+        $ref: '#/definitions/V3DLPViolation'
+      stream:
+        # Room details when DLP was enforced
+        $ref: '#/definitions/V1DLPStream'
+  V3DLPViolationSignal:
+    type: object
+    properties:
+      violation:
+        # A representation of a violation due to signal creation/update sent by a user of Symphony
+        $ref: '#/definitions/V3DLPViolation'
+      signal:
+        # Signal details when DLP was enforced
+        $ref: '#/definitions/V1DLPSignal'
+  V3DLPViolation:
+    type: object
+    description: A representation of a violation due to an event created by a user of Symphony
+    properties:
+      enforcementEventID:
+        type: string
+        description: Enforcement event ID. Unique ID that identifies this enforcement.
+      entityID:
+        type: string
+        description: Entity ID is the content Id of the violation, for example, for messages, its the Id of the message
+      createTime:
+        type: integer
+        format: int64
+        description: Timestamp of the violation in milliseconds since Jan 1 1970
+      lastModified:
+        type: integer
+        format: int64
+        description: Timestamp of the last modification of violation in milliseconds since Jan 1 1970
+      requesterId:
+        type: integer
+        format: int64
+        description: Id of the requester responsible for the message/stream/signal
+      details:
+        type: array
+        description: JSON representation of the details of the violation.
+        items:
+          type: object
+      action:
+        type: string
+        description: action taken such as BLOCK or WARN.  See outcome for a more detailed description of the outcome this action.
+      outcome:
+        # Detailed outcome of the DLP enforcement such as REJECTED_VIOLATION, ACCEPTED_WARNING, ACCEPTED_LEGACY_CLIENT etc.
+        $ref: '#/definitions/V1DLPOutcome'
+      version:
+        type: string
+        description: Version of application which processed the message and produced this violation.
+      ignoreDLPwarning:
+          type: boolean
+          description: Did the user chose to ignore DLP warning that was presented?
+  Pagination:
+    type: object
+    required:
+      - cursors
+    properties:
+      cursors:
+        type: object
+        properties:
+          before:
+            type: string
+            description: |
+              This is the opaque url-safe string that points to the start of the page of data
+              that has been returned.
+            example: "MTAxNTExOTQ1MjAwNzI5NDE="
+          after:
+            type: string
+            description: |
+              This is the opaque url-safe string that points to the end of the page of data
+              that has been returned.
+            example: "NDMyNzQyODI3OTQw"
+      previous:
+        type: string
+        description: |
+          API endpoint that will return the previous page of data. If not included, this is
+          the first page of data.
+        example: "https://tenantapi.d.isym.io/v1/tenantinfo?limit=25&before=MTAxNTExOTQ1MjAwNzI5NDE="
+      next:
+        type: string
+        description: |
+          API endpoint that will return the next page of data. If not included, this is the
+          last page of data. Due to how pagination works with visibility and privacy, it is
+          possible that a page may be empty but contain a 'next' paging link. Stop paging when
+          the 'next' link no longer appears.
+        example: "https://tenantapi.d.isym.io/v1/tenantinfo?limit=25&after=NDMyNzQyODI3OTQw"
+  V1AuditTrailInitiatorResponse:
+    description: |
+      Audit Trail Initiator object response.
+      The attributes may vary according to the action.
+      There are different types of action and each action could have specific attributes.
+    type: object
+    properties:
+      action:
+        description: The audit trail action that has peformed
+        type: string
+      actionName:
+        description: The audit trail action name that has peformed
+        type: string
+      timestamp:
+        description: The timestamp when the action has occurred
+        type: string
+      initiatorId:
+        description: The user's id that has performed the action
+        type: string
+      initiatorUsername:
+        description: The username that has performed the action
+        type: string
+      initiatorEmailAddress:
+        description: The user's e-mail address that has performed the action
+        type: string
+    additionalProperties: true
+  V1AuditTrailInitiatorList:
+    type: object
+    properties:
+      items:
+        type: array
+        items:
+          $ref: '#/definitions/V1AuditTrailInitiatorResponse'
+      pagination:
+        type: object
+        $ref: "#/definitions/Pagination"
+  V5Datafeed:
+    type: object
+    properties:
+      id:
+        type: string
+        description: ID of the datafeed
+      createdAt:
+        type: integer
+        format: int64
+        description: Datafeed creation timestamp
+    description: Container for the feed ID
+    example:
+      id: '8e7c8672-220...'
+  V5DatafeedCreateBody:
+    type: object
+    properties:
+      tag:
+        type: string
+        maxLength: 100
+        description: A unique identifier to ensure uniqueness of the datafeed.
+  AckId:
+    description: An object containing the ackId (and parameters) associated with events that the
+      client has received through an individual feed.
+    type: object
+    properties:
+      ackId:
+        type: string
+        description: A unique id for events that can be deleted from a client's. Empty for the first read. If set to null or missing, it will be considered empty.
+          feed.
+      updatePresence:
+        type: boolean
+        default: true
+        description: Set to false to avoid updating the user's presence when reading events. Default is true.
+  V5EventList:
+    type: object
+    properties:
+      events:
+        type: array
+        items:
+          $ref: '#/definitions/V4Event'
+      ackId:
+        type: string
+        description: The ackId which acknowledges that the current batch of messages have been successfully received by the client
+  V5EventsReadBody:
+    type: object
+    properties:
+      type:
+        type: string
+        description: type of the feed. Allowed values are "fanout" and "datahose"
+      tag:
+        type: string
+        minLength: 1
+        maxLength: 80
+        description: A unique identifier to ensure uniqueness of the datafeed.
+      eventTypes:
+        type: array
+        description: |
+          At least one value is required if the type of feed is "datahose". Values must be a valid Real-Time Event type, i.e. one of:
+          * MESSAGESENT
+          * MESSAGESUPPRESSED
+          * SYMPHONYELEMENTSACTION
+          * SHAREDPOST
+          * INSTANTMESSAGECREATED
+          * ROOMCREATED
+          * ROOMUPDATED
+          * ROOMDEACTIVATED
+          * ROOMREACTIVATED
+          * USERREQUESTEDTOJOINROOM
+          * USERJOINEDROOM
+          * USERLEFTROOM
+          * ROOMMEMBERPROMOTEDTOOWNER
+          * ROOMMEMBERDEMOTEDFROMOWNER
+          * CONNECTIONREQUESTED
+          * CONNECTIONACCEPTED
+        items:
+          type: string
+        x-since: 22.7
+      ackId:
+        type: string
+        description: should be empty for the first call, acknowledges that the current batch of messages have been successfully received by the client.
+      updatePresence:
+        type: boolean
+        description: whether to update the presence status of the account to AVAILABLE when calling the endpoint. Default value is true.
+    required:
+      - type
+      - tag
+  V3Health:
+      properties:
+        services:
+          additionalProperties:
+            $ref: '#/definitions/V3HealthComponent'
+          type: object
+        status:
+          $ref: '#/definitions/V3HealthStatus'
+        users:
+          additionalProperties:
+            $ref: '#/definitions/V3HealthComponent'
+          type: object
+        version:
+          description: Required Agent verison
+          type: string
+      type: object
+  V3HealthAuthType:
+    description: Type of authentication
+    enum:
+      - RSA
+      - CERT
+    type: string
+  V3HealthComponent:
+    properties:
+      authType:
+        $ref: '#/definitions/V3HealthAuthType'
+      message:
+        description: 'An error message, if the component status is DOWN'
+        type: string
+      status:
+        $ref: '#/definitions/V3HealthStatus'
+      version:
+        description: Optional component version
+        type: string
+    type: object
+  V3HealthStatus:
+    description: Application health status.
+    enum:
+      - UP
+      - DOWN
+    type: string
+#
+# Deprecated definitions
+#
+  MessageSubmission:
+    type: object
+    properties:
+      format:
+        type: string
+        enum:
+          - TEXT
+          - MESSAGEML
+      message:
+        type: string
+  V2MessageSubmission:
+    type: object
+    properties:
+      format:
+        type: string
+        enum:
+          - TEXT
+          - MESSAGEML
+      message:
+        type: string
+      attachments:
+        type: array
+        items:
+          $ref: '#/definitions/AttachmentInfo'
+  MessageImportList:
+    description: |
+      An ordered list of historic messages to be imported.
+      A list of import responsees will be returned in the same order.
+    type: array
+    items:
+      $ref: '#/definitions/ImportedMessage'
+  ImportedMessage:
+    description: |
+      A historic message to be imported into the system.
+      The importing user must have the Content Management role.
+      Also, the importing user must be a member of the conversation it is importing into.
+      The user that the message is intended to have come from must also be present in the conversation.
+      The intended message timestamp must be a valid time from the past. It cannot be a future timestamp.
+      By design, imported messages do not stream to datafeed or firehose endpoints.
+    type: object
+    properties:
+      message:
+        type: string
+        format: MessageML
+        description: Message text in MessageML
+      format:
+        type: string
+        enum:
+          - TEXT
+          - MESSAGEML
+      intendedMessageTimestamp:
+        description: |
+          The timestamp representing the time when the message was sent in the original system
+          in milliseconds since Jan 1st 1970.
+        type: integer
+        format: int64
+      intendedMessageFromUserId:
+        description: |
+          The long integer userid of the Symphony user who you intend to show sent the message.
+        type: integer
+        format: int64
+      originatingSystemId:
+        description: |
+          The ID of the system through which the message was originally sent.
+        type: string
+      streamId:
+        type: string
+    required:
+    - message
+    - intendedMessageTimestamp
+    - intendedMessageFromUserId
+    - originatingSystemId
+    - streamId
+  V2MessageImportList:
+      description: |
+        An ordered list of historic messages to be imported.
+        A list of import responsees will be returned in the same order.
+      type: array
+      items:
+        $ref: '#/definitions/V2ImportedMessage'
+  V2ImportedMessage:
+    description: |
+      A historic message to be imported into the system.
+      The importing user must have the Content Management role.
+      Also, the importing user must be a member of the conversation it is importing into.
+      The user that the message is intended to have come from must also be present in the conversation.
+      The intended message timestamp must be a valid time from the past. It cannot be a future timestamp.
+      By design, imported messages do not stream to datafeed or firehose endpoints.
+    type: object
+    properties:
+      message:
+        type: string
+        format: MessageML
+        description: Message text in MessageML
+      format:
+        type: string
+        enum:
+          - TEXT
+          - MESSAGEML
+      intendedMessageTimestamp:
+        description: |
+          The timestamp representing the time when the message was sent in the original system
+          in milliseconds since Jan 1st 1970.
+        type: integer
+        format: int64
+      intendedMessageFromUserId:
+        description: |
+          The long integer userid of the Symphony user who you intend to show sent the message.
+        type: integer
+        format: int64
+      originatingSystemId:
+        description: |
+          The ID of the system through which the message was originally sent.
+        type: string
+      originalMessageId:
+        description: |
+          The ID of the message in the original system.
+        type: string
+      streamId:
+        type: string
+    required:
+    - message
+    - intendedMessageTimestamp
+    - intendedMessageFromUserId
+    - originatingSystemId
+    - streamId
+  ImportResponseList:
+    type: array
+    items:
+      $ref: '#/definitions/ImportResponse'
+  ImportResponse:
+    type: object
+    properties:
+      messageId:
+        description: |
+          If the message was successfully imported then the message ID in the system
+          of the newly created message.
+        type: string
+      diagnostic:
+        description: |
+          A diagnostic message containing an error message in the event that the
+          message import failed. May also be present in the case of a successful
+          call if there is useful narrative to return.
+        type: string
+  V2ImportResponseList:
+    type: array
+    items:
+      $ref: '#/definitions/V2ImportResponse'
+  V2ImportResponse:
+    type: object
+    properties:
+      messageId:
+        description: |
+          If the message was successfully imported then the message ID in the system
+          of the newly created message.
+        type: string
+      originatingSystemId:
+        description: |
+          The ID of the system through which the message was originally sent.
+        type: string
+      originalMessageId:
+        description: |
+          The ID of the message in the original system.
+        type: string
+      diagnostic:
+        description: |
+          A diagnostic message containing an error message in the event that the
+          message import failed. May also be present in the case of a successful
+          call if there is useful narrative to return.
+        type: string
+  BaseMessage:
+    type: object
+    discriminator: messageType
+    properties:
+      id:
+        type: string
+        description: The messageId is assigned by the ingestor service when a message is sent.
+      timestamp:
+        type: string
+      messageType:
+        type: string
+      streamId:
+        type: string
+    required:
+    - messageType
+    - timestamp
+    - streamId
+  V1HealthCheckResponse:
+    type: object
+    properties:
+      podConnectivity:
+        type: boolean
+        description: Indicates whether the Agent server can connect to the Pod
+      podConnectivityError:
+        type: string
+        description: Error details in case of no Pod connectivity
+      keyManagerConnectivity:
+        type: boolean
+        description: Indicates whether the Agent server can connect to the Key Manager
+      keyManagerConnectivityError:
+        type: string
+        description: Error details in case of no Key Manager connectivity
+      version:
+        type: string
+        description: The version number of the Agent server
+  Message:
+    type: object
+    description: A representation of a message sent by a user of Symphony.
+    allOf:
+    - $ref: '#/definitions/BaseMessage'
+    - type: object
+      properties:
+        message:
+          type: string
+          format: MessageML
+          description: Message text in MessageML
+        fromUserId:
+          type: integer
+          format: int64
+          description: the Symphony userId of the user who sent the message. This will be populated by the server (and actually ignored if included when sending a message).
+      required:
+      - message
+      - fromUserId
+  MessageList:
+    type: array
+    items:
+      $ref: '#/definitions/Message'
+  Datafeed:
+    type: object
+    properties:
+      id:
+        type: string

--- a/agent/swagger2/agent-api-public.yaml
+++ b/agent/swagger2/agent-api-public.yaml
@@ -1,0 +1,5314 @@
+swagger: '2.0'
+info:
+  version: '22.7.1'
+  title: Agent API
+  description: |
+    This document refers to Symphony API calls to send and receive messages
+    and content. They need the on-premise Agent installed to perform
+    decryption/encryption of content.
+
+    - sessionToken and keyManagerToken can be obtained by calling the
+    authenticationAPI on the symphony back end and the key manager
+    respectively. Refer to the methods described in authenticatorAPI.yaml.
+    - A new authorizationToken has been introduced in the authenticationAPI
+    response payload. It can be used to replace the sessionToken in any of
+    the API calls and can be passed as "Authorization" header.
+    - Actions are defined to be atomic, ie will succeed in their entirety
+    or fail and have changed nothing.
+    - If it returns a 40X status then it will have sent no message to any
+    stream even if a request to some subset of the requested streams
+    would have succeeded.
+    - If this contract cannot be met for any reason then this is an error
+    and the response code will be 50X.
+    - MessageML is a markup language for messages. See reference here:
+    https://rest-api.symphony.com/docs/messagemlv2
+    - **Real Time Events**: The following events are returned when reading
+    from a real time messages and events stream ("datafeed"). These
+    events will be returned for datafeeds created with the v5 endpoints.
+    To know more about the endpoints, refer to Create Messages/Events
+    Stream and Read Messages/Events Stream. Unless otherwise specified,
+    all events were added in 1.46.
+
+paths:
+  '/v3/health':
+    get:
+      summary: Checks health status
+      description: |
+        _Available on Agent 2.57.0 and above._
+
+        Returns the connectivity status of your Agent server. If your Agent server is started and running, the status value will be `UP`
+      operationId: v3Health
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - System
+      responses:
+        '200':
+          description: Agent application is alive.
+          schema:
+            $ref: '#/definitions/V3Health'
+  '/v3/health/extended':
+    get:
+      summary: Checks health status of services and users
+      description: |
+        _Available on Agent 2.57.0 and above._
+
+        Returns the connectivity status of the Agent services (**pod**, **key manager** and **datafeed**) as well as users
+        connectivity (**agentservice** and **ceservice**).
+
+        The global status will be set to `DOWN` if at least one of the sub-status is also `DOWN`.
+      operationId: v3ExtendedHealth
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - System
+      responses:
+        '200':
+          description: Agent is healthy, all components are `UP`.
+          schema:
+            $ref: '#/definitions/V3Health'
+        '503':
+          description: Agent is unhealthy, some components are `DOWN`.
+          schema:
+            $ref: '#/definitions/V3Health'
+  '/v4/message/import':
+    post:
+      summary: Import messages from other systems into Symphony.
+      description: |
+        Sends a message to be imported into the system.
+        Allows you to override the timestamp and author of the message with your desired values.
+        The requesting user must have the Content Management role.
+        The user that the message is intended to have come from must also be present in the conversation.
+        The intended message timestamp must be a valid time from the past. It cannot be a future timestamp.
+        Optionally the original message ID can be specified to identify the imported message for the purpose of repeat imports.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: messageList
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/V4MessageImportList'
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: Message sent.
+          schema:
+            $ref: '#/definitions/V4ImportResponseList'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v4/message/blast':
+    post:
+      summary: Post a message to multiple existing streams.
+      description: |
+        Post a new message to the given list of streams. The stream can be a chatroom,
+        an IM or a multiparty IM.
+
+        You may include an attachment on the message.
+
+        The message can be provided as MessageMLV2 or PresentationML. Both formats support Freemarker templates.
+
+        The optional parameter "data" can be used to provide a JSON payload containing entity data.
+        If the message contains explicit references to entity data (in "data-entity-id" element attributes),
+        this parameter is required.
+
+        If the message is in MessageML and fails schema validation a client error results
+
+        This endpoint is idempotent, it means that a 200 response will be returned even if the message has not been
+        delivered to some streams. Check the `errors` map from the response in order to see on which stream(s) the
+        message has not been delivered.
+
+        The maximum number of streams where the message can be sent is limitted to 100.
+
+        Regarding authentication, you must either use the sessionToken which was created for delegated app access
+        or both the sessionToken and keyManagerToken together.
+      consumes:
+        - multipart/form-data
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Authorization token used to make delegated calls.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          type: string
+          required: false
+        - name: sids
+          description: A comma-separated list of Stream IDs
+          in: formData
+          required: true
+          type: array
+          items:
+            type: string
+        - name: message
+          description: The message payload in MessageML.
+          in: formData
+          type: string
+          required: false
+        - name: data
+          description: Optional message data in EntityJSON.
+          in: formData
+          type: string
+          required: false
+        - name: version
+          description: |
+            Optional message version in the format "major.minor". If empty, defaults to the latest supported version.
+          in: formData
+          type: string
+          required: false
+        - name: attachment
+          description: Optional file attachment.
+          in: formData
+          type: file
+          required: false
+        - name: preview
+          description: Optional attachment preview.
+          in: formData
+          type: file
+          required: false
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: Blast message sent.
+          schema:
+            $ref: '#/definitions/V4MessageBlastResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '451':
+          description: 'Compliance Issues found in message or file'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/message/{id}':
+    get:
+      summary: Get a message by ID
+      produces:
+        - application/json
+      parameters:
+          - name: sessionToken
+            description: Session authentication token.
+            in: header
+            required: true
+            type: string
+          - name: keyManagerToken
+            description: Key Manager authentication token.
+            in: header
+            required: true
+            type: string
+          - name: id
+            description: Message ID as a URL-safe string
+            in: path
+            required: true
+            type: string
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V4Message'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/message/search':
+    get:
+      summary: Search messages
+      description: |
+          Search messages according to the specified criteria. The "query" parameter takes a search query defined as
+          "field:value" pairs combined by the operator "AND" (e.g. "text:foo AND autor:bar"). Supported fields are
+           (case-insensitive): "text", "author", "hashtag", "cashtag", "mention", "signal", "fromDate", "toDate",
+           "streamId", "streamType".
+           "text" search requires a "streamId" to be specified.
+           "streamType" accepts one of the following values: "chat" (IMs and MIMs), "im", "mim", "chatroom", "post".
+           "signal" queries can only be combined with "fromDate", "toDate", "skip" and "limit" parameters.
+      produces:
+        - application/json
+      parameters:
+        - name: query
+          description: The search query. See above for the query syntax.
+          in: query
+          type: string
+          required: true
+        - name: skip
+          description: |
+            No. of results to skip.
+          in: query
+          type: integer
+        - name: limit
+          description: |
+            Max no. of results to return. If no value is provided, 50 is the default.
+          in: query
+          type: integer
+          required: false
+        - name: scope
+          description: |
+            Describes where content should be searched for that query.
+            It can exclusively apply to Symphony content or to one Connector.
+          in: query
+          type: string
+        - name: sortDir
+          description: |
+            Messages sort direction : ASC or DESC (default to DESC)
+          in: query
+          type: string
+          required: false
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V4MessageList'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+    post:
+      summary: Search messages
+      description: |
+          Search messages according to the specified criteria.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: query
+          description: The search query. See above for the query syntax.
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/MessageSearchQuery'
+        - name: skip
+          description: |
+            No. of results to skip.
+          in: query
+          type: integer
+        - name: limit
+          description: |
+            Max no. of results to return. If no value is provided, 50 is the default.
+          in: query
+          type: integer
+          required: false
+        - name: scope
+          description: |
+            Describes where content should be searched for that query.
+            It can exclusively apply to Symphony content or to one Connector.
+          in: query
+          type: string
+        - name: sortDir
+          description: |
+            Messages sort direction : ASC or DESC (default to DESC)
+          in: query
+          type: string
+          required: false
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V4MessageList'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/stream/{sid}/attachment':
+    get:
+      summary: Download an attachment.
+      description: |
+        Downloads the attachment body by the attachment ID, stream ID, and message ID.
+      consumes:
+        - application/json
+      produces:
+        - application/octet-stream
+      parameters:
+        - name: sid
+          description: Stream ID
+          in: path
+          required: true
+          type: string
+        - name: fileId
+          description: The attachment ID (Base64-encoded)
+          in: query
+          required: true
+          type: string
+        - name: messageId
+          description: The ID of the message containing the attachment
+          in: query
+          required: true
+          type: string
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Attachments
+      responses:
+        '200':
+          description: 'Attachment body as Base64 encoded string.'
+          schema:
+            type: string
+            format: byte
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v4/stream/{sid}/message':
+    get:
+      summary: Get messages from an existing stream.
+      description: |
+          A caller can fetch all unseen messages by passing the timestamp of
+          the last message seen as the since parameter and the number of messages
+          with the same timestamp value already seen as the skip parameter. This
+          means that every message will be seen exactly once even in the case that
+          an additional message is processed with the same timestamp as the last
+          message returned by the previous call, and the case where there are
+          more than maxMessages with the same timestamp value.
+
+          This method is intended for historic queries and is generally reliable
+          but if guaranteed delivery of every message in real time is required
+          then the equivilent firehose method should be called.
+      produces:
+        - application/json
+      parameters:
+        - name: sid
+          description: |
+            Stream ID
+          in: path
+          required: true
+          type: string
+        - name: since
+          description: |
+            Timestamp of first required message.
+
+            This is a long integer value representing milliseconds since
+            Jan 1 1970
+          in: query
+          required: true
+          type: integer
+          format: int64
+        - name: skip
+          description: |
+            No. of messages to skip.
+          in: query
+          type: integer
+        - name: limit
+          description: |
+            Max No. of messages to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          in: query
+          type: integer
+          required: false
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V4MessageList'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v4/stream/{sid}/message/create':
+    post:
+      summary: Post a message to one existing stream.
+      description: |
+        Post a new message to the given stream. The stream can be a chatroom,
+        an IM or a multiparty IM.
+
+        You may include an attachment on the message.
+
+        The message can be provided as MessageMLV2 or PresentationML. Both formats support Freemarker templates.
+
+        The optional parameter "data" can be used to provide a JSON payload containing entity data.
+        If the message contains explicit references to entity data (in "data-entity-id" element attributes),
+        this parameter is required.
+
+        If the message is in MessageML and fails schema validation
+        a client error results
+
+        If the message is sent then 200 is returned.
+
+        Regarding authentication, you must either use the sessionToken which was created for delegated app access
+        or both the sessionToken and keyManagerToken together.
+      consumes:
+        - multipart/form-data
+      produces:
+        - application/json
+      parameters:
+        - name: sid
+          description: Stream ID
+          in: path
+          required: true
+          type: string
+        - name: sessionToken
+          description: Authorization token used to make delegated calls.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          type: string
+          required: false
+        - name: message
+          description: The message payload in MessageML.
+          in: formData
+          type: string
+          required: false
+        - name: data
+          description: Optional message data in EntityJSON.
+          in: formData
+          type: string
+          required: false
+        - name: version
+          description: |
+            Optional message version in the format "major.minor". If empty, defaults to the latest supported version.
+          in: formData
+          type: string
+          required: false
+        - name: attachment
+          description: Optional file attachment.
+          in: formData
+          type: file
+          required: false
+        - name: preview
+          description: Optional attachment preview.
+          in: formData
+          type: file
+          required: false
+
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: Message sent.
+          schema:
+            $ref: '#/definitions/V4Message'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '451':
+          description: 'Compliance Issues found in message or file'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+
+  '/v4/stream/{sid}/message/{mid}/update':
+    post:
+      summary: Update an existing message.
+      description: |
+        Update an existing message. The existing message must be a valid social message, that has not been deleted.
+
+        The message can be provided as MessageMLV2 or PresentationML. Both formats support Freemarker templates.
+
+        The optional parameter "data" can be used to provide a JSON payload containing entity data.
+        If the message contains explicit references to entity data (in "data-entity-id" element attributes),
+        this parameter is required.
+
+        If the message is in MessageML and fails schema validation
+        a client error results
+
+        If the message is updated then 200 is returned.
+
+        Regarding authentication, you must either use the sessionToken which was created for delegated app access
+        or both the sessionToken and keyManagerToken together.
+      consumes:
+        - multipart/form-data
+      produces:
+        - application/json
+      parameters:
+        - name: sid
+          description: Stream ID
+          in: path
+          required: true
+          type: string
+        - name: mid
+          description: Parent message ID
+          in: path
+          required: true
+          type: string
+        - name: sessionToken
+          description: Authorization token used to make delegated calls.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          type: string
+          required: false
+        - name: message
+          description: The message payload in MessageML.
+          in: formData
+          type: string
+          required: false
+        - name: data
+          description: Optional message data in EntityJSON.
+          in: formData
+          type: string
+          required: false
+        - name: version
+          description: |
+            Optional message version in the format "major.minor". If empty, defaults to the latest supported version.
+          in: formData
+          type: string
+          required: false
+        - name: silent
+          in: formData
+          type: string
+          required: false
+          description: |
+            Optional boolean field that will determine if the user/s should receive the message as read or not (true by default). Since Agent 20.14.
+          x-since: 20.14
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: Message sent.
+          schema:
+            $ref: '#/definitions/V4Message'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '451':
+          description: 'Compliance Issues found in message or file'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+
+  '/v3/stream/{sid}/share':
+    post:
+      summary: PROVISIONAL -  Share a piece of content into Symphony
+      description: |
+        Given a 3rd party content (eg. news article), it can share to the given stream.
+        The stream can be a chatroom, an IM or a multiparty IM.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sid
+          description: Stream ID
+          in: path
+          required: true
+          type: string
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: false
+          type: string
+        - name: shareContent
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/ShareContent'
+      tags:
+        - Share
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V2Message'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/util/echo':
+    post:
+      summary: Test endpoint, returns input.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: echoInput
+          description: Message in plain text
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/SimpleMessage'
+      tags:
+        - Util
+      responses:
+        '200':
+          description: Message sent.
+          schema:
+            $ref: '#/definitions/SimpleMessage'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/signals/list':
+    get:
+      summary: |
+          List signals for the requesting user. This includes signals that the user has created and public signals
+          to which they subscribed.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: false
+          type: string
+        - name: skip
+          description: |
+            No. of signals to skip.
+          in: query
+          type: integer
+        - name: limit
+          description: |
+            Max no. of signals to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          in: query
+          type: integer
+          required: false
+      tags:
+        - Signals
+      responses:
+        '200':
+          description: List of signals for the requesting user.
+          schema:
+            $ref: '#/definitions/SignalList'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/signals/{id}/get':
+    get:
+      summary: Get details of the requested signal.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: false
+          type: string
+        - name: id
+          description: |
+            The ID of the signal to display.
+          in: path
+          required: true
+          type: string
+      tags:
+        - Signals
+      responses:
+        '200':
+          description: List of signals for the requesting user.
+          schema:
+            $ref: '#/definitions/Signal'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/signals/create':
+    post:
+      summary: Create a signal.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: false
+          type: string
+        - name: signal
+          description: Signal definition.
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/BaseSignal'
+      tags:
+        - Signals
+      responses:
+        '200':
+          description: Signal created.
+          schema:
+            $ref: '#/definitions/Signal'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '451':
+          description: 'Compliance Issues found in signal'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/signals/{id}/update':
+    post:
+      summary: Update a signal.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: false
+          type: string
+        - name: id
+          description: The id of the signal.
+          in: path
+          required: true
+          type: string
+        - name: signal
+          description: Signal definition.
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/BaseSignal'
+      tags:
+        - Signals
+      responses:
+        '200':
+          description: Signal updated.
+          schema:
+            $ref: '#/definitions/Signal'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '451':
+          description: 'Compliance Issues found in signal'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/signals/{id}/delete':
+    post:
+      summary: Delete a signal.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: false
+          type: string
+        - name: id
+          description: The id of the signal.
+          in: path
+          required: true
+          type: string
+      tags:
+        - Signals
+      responses:
+        '200':
+          description: Signal deleted.
+          schema:
+            $ref: '#/definitions/SuccessResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/signals/{id}/subscribe':
+    post:
+      summary: Subscribe to a Signal.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: false
+          type: string
+        - name: id
+          description: The id of the signal.
+          in: path
+          required: true
+          type: string
+        - name: pushed
+          description: Prevent the user to unsubscribe (only for bulk subscription)
+          in: query
+          required: false
+          type: boolean
+        - name: users
+          description: UserIds to subscribe (only for bulk subscription)
+          in: body
+          required: false
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int64
+      tags:
+        - Signals
+      responses:
+        '200':
+          description: Signal subscribed.
+          schema:
+            $ref: '#/definitions/ChannelSubscriptionResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/signals/{id}/unsubscribe':
+    post:
+      summary: Unsubscribe to a Signal.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: false
+          type: string
+        - name: id
+          description: The id of the signal.
+          in: path
+          required: true
+          type: string
+        - name: users
+          description: UserIds to unsubscribe (only for bulk unsubscription)
+          in: body
+          required: false
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int64
+      tags:
+        - Signals
+      responses:
+        '200':
+          description: Signal unsubscribed.
+          schema:
+            $ref: '#/definitions/ChannelSubscriptionResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/signals/{id}/subscribers':
+    get:
+      summary: Get the subscribers of a signal
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: false
+          type: string
+        - name: id
+          description: The id of the signal.
+          in: path
+          required: true
+          type: string
+        - name: skip
+          description: No. of results to skip.
+          in: query
+          required: false
+          type: integer
+          default: 0
+        - name: limit
+          description: Max No. of subscribers to return. If no value is provided, 100 is the default.
+          in: query
+          required: false
+          type: integer
+          default: 100
+      tags:
+        - Signals
+      responses:
+        '200':
+          description: Signal Subscribers.
+          schema:
+            $ref: '#/definitions/ChannelSubscriberResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/info':
+    get:
+      summary: Get information about the Agent
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      tags:
+        - Signals
+      responses:
+        '200':
+          description: Agent info.
+          schema:
+            $ref: '#/definitions/AgentInfo'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v1/dlp/policies':
+    get:
+      summary: Get all policies
+      description: Get all policies
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: page
+          in: query
+          required: false
+          type: integer
+          format: int32
+          description: Optional parameter to specify which page to return (default is 0)
+        - name: limit
+          in: query
+          required: false
+          type: integer
+          format: int32
+          description: |
+            Optional parameter to specify the number of result to return per page, default is 50. Maximum is 50.
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPPoliciesCollectionResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      summary: Creates a policy
+      description: |
+        Creates a new policy with dictionary references.
+
+        At the time of policy creation, the caller should only provide - contentTypes, name, scopes and type. The rest of the information is populated automatically.
+
+        Note - You need to enable the policy after creation to start enforcing the policy.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/V1DLPPolicyRequest'
+          description: Details about the policy that should be created.
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/dlp/policies/{policyId}':
+    get:
+      summary: Get a policy
+      description: Get a policy
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: policyId
+          in: path
+          required: true
+          type: string
+          description: Unique dictionary identifier.
+        - name: policyVersion
+          in: query
+          required: false
+          type: string
+          description: |
+            Optional parameter, if set to be valid policy version number,  will return policy with specified policyVersion. Otherwise, return the latest policy.
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+    put:
+      summary: Updates a policy. Cannot be used for creation.
+      description: |
+        Update the policy (name, type, contentTypes, scopes) and also the dictionaries for a policy.
+        Warning: If you send empty list of dictionaries during the update operation, then all the
+        dictionaries for this policy are deleted and policy is automatically disabled.
+        Note: The policy should already exist.
+      consumes:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: policyId
+          in: path
+          required: true
+          type: string
+          description: Unique dictionary identifier.
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/V1DLPPolicyRequest'
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      summary: Delete a policy
+      description: |
+        Delete a policy.
+        Note: Only disabled policy can be deleted
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: policyId
+          in: path
+          required: true
+          type: string
+          description: Unique dictionary identifier.
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/dlp/policies/{policyId}/enable':
+    post:
+      summary: Enables a policy.
+      description: Enables a policy.
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: policyId
+          in: path
+          required: true
+          type: string
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/dlp/policies/{policyId}/disable':
+    post:
+      summary: Disables a policy.
+      description: Disables a policy.
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: policyId
+          in: path
+          required: true
+          type: string
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/dlp/dictionaries':
+    get:
+      summary: Get all dictionary metadatas
+      description: |
+        Get all dictionary metadatas with the latest version. Each dictionary object will only contain meta data of the content.
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: page
+          in: query
+          required: false
+          type: integer
+          format: int32
+          description: Optional parameter to specify which page to return (default is 0)
+        - name: limit
+          in: query
+          required: false
+          type: integer
+          format: int32
+          description: |
+            Optional parameter to specify the number of result to return per page, default is 50. Maximum is 50.
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPDictionaryMetadataCollectionResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      summary: Create a dictionary
+      description: |
+        Creates a dictionary with basic metadata and no content. Only "name" and "type" field is used to create a new dictionary entry.
+      consumes:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/V1DLPDictionaryMetadataCreateRequest'
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPDictionaryMetadataResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/dlp/dictionaries/{dictId}':
+    get:
+      summary: Get dictionary metadata
+      description: Get basic information for a dictionary.
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: dictId
+          in: path
+          required: true
+          type: string
+          description: Unique dictionary identifier
+        - name: dictVersion
+          in: query
+          required: false
+          type: string
+          description: |
+            If set to be valid dictionary version number, will return dictionary metadata with specified version. Otherwise, return the latest dictionary metadata.
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPDictionaryMetadataResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+    put:
+      summary: Updates a dictionary
+      description: |
+        Updates the dictionary's basic metadata without content.
+        This API cannot be used for creating a new dictionary.
+        In case of update only "name" can be changed.
+        Note: All related policies will also have versions updated.
+      consumes:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: dictId
+          in: path
+          required: true
+          type: string
+          description: Unique dictionary identifier
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/V1DLPDictionaryMetadataUpdateRequest'
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPDictionaryMetadataResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      summary: Delete a dictionary
+      description: |
+        Deletes a dictionary.
+        Note: All related policies will be affected.
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: dictId
+          in: path
+          required: true
+          type: string
+          description: Unique dictionary identifier
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            # Deleted dictionary's metadata.
+            $ref: '#/definitions/V1DLPDictionaryMetadataResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/dlp/dictionaries/{dictId}/data/download':
+    get:
+      summary: Downloads Base 64 encoded dictionary content.
+      description: Downloads Base 64 encoded dictionary content.
+      consumes:
+        - application/json
+      produces:
+        - application/octet-stream
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: dictId
+          in: path
+          required: true
+          type: string
+          description: Unique dictionary identifier
+        - name: dictVersion
+          in: query
+          required: false
+          type: string
+          description: |
+            If set to be valid dictionary version number, will return dictionary with specified version. Otherwise, return the latest dictionary.
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: 'Attachment body as Base64 encoded string.'
+          schema:
+            type: string
+            format: byte
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/dlp/dictionaries/{dictId}/data/upload':
+    post:
+      summary: Override dictionary content with provided content.
+      description: Override dictionary content with provided content.
+      consumes:
+        - multipart/form-data
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: dictId
+          in: path
+          required: true
+          type: string
+          description: Unique dictionary identifier
+        - name: data
+          in: formData
+          required: true
+          type: file
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V1DLPDictionaryMetadataResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v1/dlp/violations/message':
+    get:
+      summary: Get violations as a result of policy enforcement on messages.
+      description: |
+        TBD
+      produces:
+        - application/json
+      parameters:
+        - name: startTime
+          description: |
+            Timestamp of the first required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+          in: query
+          required: true
+          type: integer
+          format: int64
+        - name: endTime
+          description: |
+            Timestamp of the last required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+            If unspecified, it will default to current time of the request.
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: next
+          description: |
+            Offset of the next chunk of violations. Value is null for the first request.
+          in: query
+          type: string
+          required: false
+        - name: limit
+          description: |
+            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          in: query
+          type: integer
+          required: false
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Violations
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V1DLPViolationMessageResponse'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+
+  '/v1/dlp/violations/stream':
+    get:
+      summary: Get violations as a result of policy enforcement on streams.
+      description: |
+        TBD
+      produces:
+        - application/json
+      parameters:
+        - name: startTime
+          description: |
+            Timestamp of the first required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+          in: query
+          required: true
+          type: integer
+          format: int64
+        - name: endTime
+          description: |
+            Timestamp of the last required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+            If unspecified, it will default to current time of the request.
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: next
+          description: |
+            Offset of the next chunk of violations. Value is null for the first request.
+          in: query
+          type: string
+          required: false
+        - name: limit
+          description: |
+            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          in: query
+          type: integer
+          required: false
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Violations
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V1DLPViolationStreamResponse'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+
+  '/v1/dlp/violations/signal':
+    get:
+      summary: Get violations as a result of policy enforcement on signals.
+      description: |
+        TBD
+      produces:
+        - application/json
+      parameters:
+        - name: startTime
+          description: |
+            Timestamp of the first required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+          in: query
+          required: true
+          type: integer
+          format: int64
+        - name: endTime
+          description: |
+            Timestamp of the last required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+            If unspecified, it will default to current time of the request.
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: next
+          description: |
+            Offset of the next chunk of violations. Value is null for the first request.
+          in: query
+          type: string
+          required: false
+        - name: limit
+          description: |
+            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          in: query
+          type: integer
+          required: false
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Violations
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V1DLPViolationSignalResponse'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+
+  '/v3/dlp/policies':
+    get:
+      summary: Get all policies
+      description: Get all policies
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: page
+          in: query
+          required: false
+          type: integer
+          format: int32
+          description: Optional parameter to specify which page to return (default is 0)
+        - name: limit
+          in: query
+          required: false
+          type: integer
+          format: int32
+          description: |
+            Optional parameter to specify the number of result to return per page, default is 50. Maximum is 50.
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V3DLPPoliciesCollectionResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      summary: Creates a policy
+      description: |
+        Creates a new policy with dictionary references.
+        At the time of policy creation, the caller should only provide - contentTypes, name, scopes and type.
+        The rest of the information is populated automatically.
+        Note - You need to enable the policy after creation to start enforcing the policy.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/V3DLPPolicyRequest'
+          description: Details about the policy that should be created.
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V3DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v3/dlp/policies/{policyId}':
+    get:
+      summary: Get a policy
+      description: Get a policy
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: policyId
+          in: path
+          required: true
+          type: string
+          description: Unique dictionary identifier.
+        - name: policyVersion
+          in: query
+          required: false
+          type: string
+          description: |
+            Optional parameter, if set to be valid policy version number,  will return policy with specified policyVersion. Otherwise, return the latest policy.
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V3DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v3/dlp/policies/{policyId}/update':
+    post:
+      summary: Updates a policy. Cannot be used for creation.
+      description: |
+        Update the policy (name, type, contentTypes, scopes) and also the dictionaries for a policy.
+        Warning: If you send empty list of dictionaries during the update operation, then all the
+        dictionaries for this policy are deleted and policy is automatically disabled.
+        Note: The policy should already exist.
+      consumes:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: policyId
+          in: path
+          required: true
+          type: string
+          description: Unique dictionary identifier.
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/V3DLPPolicyRequest'
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V3DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v3/dlp/policies/{policyId}/delete':
+    post:
+      summary: Delete a policy
+      description: |
+        Delete a policy.
+        Note: Only disabled policy can be deleted
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: policyId
+          in: path
+          required: true
+          type: string
+          description: Unique dictionary identifier.
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V3DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v3/dlp/policies/{policyId}/enable':
+    post:
+      summary: Enables a policy.
+      description: Enables a policy.
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: policyId
+          in: path
+          required: true
+          type: string
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V3DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v3/dlp/policies/{policyId}/disable':
+    post:
+      summary: Disables a policy.
+      description: Disables a policy.
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: policyId
+          in: path
+          required: true
+          type: string
+      tags:
+        - DLP Policies and Dictionary Management
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/V3DLPPolicyResponse'
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+  '/v3/dlp/violations/message':
+    get:
+      summary: Get violations as a result of policy enforcement on messages.
+      description: Retrieves DLP v3 message related violations for a given time range
+      produces:
+        - application/json
+      parameters:
+        - name: startTime
+          description: |
+            Timestamp of the first required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+          in: query
+          required: true
+          type: integer
+          format: int64
+        - name: endTime
+          description: |
+            Timestamp of the last required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+            If unspecified, it will default to current time of the request.
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: next
+          description: |
+            Offset of the next chunk of violations. Value is null for the first request.
+          in: query
+          type: string
+          required: false
+        - name: limit
+          description: |
+            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          in: query
+          type: integer
+          required: false
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Violations
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V3DLPViolationMessageResponse'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+
+  '/v3/dlp/violations/stream':
+    get:
+      summary: Get violations as a result of policy enforcement on streams.
+      description: Retrieves DLP v3 signal related violations for a given time range
+      produces:
+        - application/json
+      parameters:
+        - name: startTime
+          description: |
+            Timestamp of the first required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+          in: query
+          required: true
+          type: integer
+          format: int64
+        - name: endTime
+          description: |
+            Timestamp of the last required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+            If unspecified, it will default to current time of the request.
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: next
+          description: |
+            Offset of the next chunk of violations. Value is null for the first request.
+          in: query
+          type: string
+          required: false
+        - name: limit
+          description: |
+            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          in: query
+          type: integer
+          required: false
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Violations
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V3DLPViolationStreamResponse'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+
+  '/v3/dlp/violations/signal':
+    get:
+      summary: Get violations as a result of policy enforcement on signals.
+      description: Retrieves DLP v3 signal related violations for a given time range
+      produces:
+        - application/json
+      parameters:
+        - name: startTime
+          description: |
+            Timestamp of the first required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+          in: query
+          required: true
+          type: integer
+          format: int64
+        - name: endTime
+          description: |
+            Timestamp of the last required violation.
+            This is a long integer value representing milliseconds since Jan 1 1970
+            If unspecified, it will default to current time of the request.
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: next
+          description: |
+            Offset of the next chunk of violations. Value is null for the first request.
+          in: query
+          type: string
+          required: false
+        - name: limit
+          description: |
+            Max No. of violations to return. If no value is provided, 50 is the default. The maximum supported value is 500.
+          in: query
+          type: integer
+          required: false
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Violations
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V3DLPViolationSignalResponse'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+
+  '/v3/dlp/violation/attachment':
+    get:
+      summary: Get attachments that were sent as part of messages that were flagged by the DLP System.
+      description: Retrieves attachments from related message violations as a base64 encoded String.
+      produces:
+        - application/octet-stream
+      parameters:
+        - name: fileId
+          description: |
+            ID of attachment that will be downloaded.
+          in: query
+          required: true
+          type: string
+        - name: violationId
+          description: |
+            ID of violation that corresponds to the flagged message that contains the attachment
+          in: query
+          required: true
+          type: string
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      tags:
+        - Violations
+      responses:
+        '200':
+          description: Attachment body as Base64 encoded string.
+          schema:
+            type: string
+            format: byte
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: 'Resource not found.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+
+  '/v1/audittrail/privilegeduser':
+    get:
+      summary: Get a list of  actions performed by a privileged account acting as privileged user given a period of time.
+      description: Get a list of actions performed by a privileged account acting as privileged user given a period of time.
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: startTimestamp
+          description: |
+            Start timestamp in unix timestamp in millseconds.
+          in: query
+          required: true
+          type: integer
+          format: int64
+        - name: endTimestamp
+          description: |
+            End timestamp in unix timestamp in millseconds.
+            If not specified, it assumes to be current time.
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: before
+          description: |
+            Return results from an opaque “before” cursor value as presented via a response cursor.
+          in: query
+          type: string
+          required: false
+        - name: after
+          description: |
+            Return results from an opaque “after” cursor value as presented via a response cursor.
+          in: query
+          type: string
+          required: false
+        - name: limit
+          description: |
+            Max No. of violations to return. If no value is provided, 50 is the default.
+            Some maximums for limit may be enforced for performance reasons.
+            The maximum supported value is 500.
+          in: query
+          type: integer
+          required: false
+        - name: initiatorId
+          description: |
+            If present, only the initiator with this initiator <user id> will be returned.
+          in: query
+          type: integer
+          format: int64
+        - name: role
+          description: |
+            If present, only the audit trail initiated by s user with privileged role acting as
+            privileged user will be returned.
+            Privileged eliglible roles:
+            User Provisioning (USER_PROVISIONING),
+            Content Management (CONTENT_MANAGEMENT),
+            Expression Filter Policy Management (EF_POLICY_MANAGEMENT),
+            SCO (SUPER_COMPLIANCE_OFFICER),
+            CO (COMPLIANCE_OFFICER),
+            Super admin (SUPER_ADMINISTRATOR),
+            Admin (ADMINISTRATOR),
+            L1 (L1_SUPPORT),
+            L2 (L2_SUPPORT),
+            Scope Manager (SCOPE_MANAGEMENT)
+          in: query
+          type: string
+          required: false
+      tags:
+        - AuditTrail
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V1AuditTrailInitiatorList'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/Error'
+
+  '/v5/datafeeds':
+    post:
+      tags:
+        - Datafeed
+      summary: Create a new real time messages / events stream ("datafeed").
+      description: |
+        _Available on Agent 2.57.0 and above._
+
+        The datafeed provides messages and events from all conversations that the user
+        is in. The types of events surfaced in the datafeed can be found in the Real Time Events list.
+        (see definition on top of the file)
+
+        Returns the ID of the datafeed that has just been created.
+        This ID should then be used as input to the Read Messages/Events Stream v4 endpoint.
+      operationId: createDatafeed
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: false
+          schema:
+            $ref: '#/definitions/V5DatafeedCreateBody'
+      produces:
+        - application/json
+      responses:
+        201:
+          description: Datafeed sucessfully created.
+          schema:
+            $ref: '#/definitions/V5Datafeed'
+        400:
+          description: Bad request.
+          schema:
+            $ref: '#/definitions/V2Error'
+        401:
+          description: Unauthorized.
+          schema:
+            $ref: '#/definitions/V2Error'
+        500:
+          description: Internal server error.
+          schema:
+            $ref: '#/definitions/V2Error'
+
+    get:
+      tags:
+        - Datafeed
+      summary: Read list of real time messages / events stream ("datafeed").
+      description: |
+        _Available on Agent 2.57.0 and above._
+
+        The datafeed provides messages and events from all conversations that the user
+        is in. The types of events surfaced in the datafeed can be found in the [Real Time Events](./docs/real-time-events.md) list.
+
+        Returns the list of the datafeeds for the user.
+        Any datafeed ID of the list can then be used as input to the Read Messages/Events Stream v4 endpoint.
+      operationId: listDatafeed
+      produces:
+        - application/json
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: tag
+          maxLength: 100
+          required: false
+          description: A unique identifier to ensure uniqueness of the datafeed. Used to restrict search.
+          in: query
+          type: string
+      responses:
+        200:
+          description: Datafeed sucessfully created.
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/V5Datafeed'
+          examples:
+            application/json:
+              - id: '8e7c8672-220...'
+                createdAt: 1536346282592
+              - id: '8e7c8672-221...'
+                createdAt: 1536346282500
+
+        400:
+          description: Bad request.
+          schema:
+            $ref: '#/definitions/V2Error'
+        401:
+          description: Unauthorized.
+          schema:
+            $ref: '#/definitions/V2Error'
+        500:
+          description: Internal server error.
+          schema:
+            $ref: '#/definitions/V2Error'
+  '/v5/datafeeds/{datafeedId}':
+    delete:
+      tags:
+        - Datafeed
+      summary: Delete the specified real time message / event stream ("datafeed").
+      description: |
+        _Available on Agent 2.57.0 and above._
+
+        The datafeed provides messages and events from all conversations that the user
+        is in. The types of events surfaced in the datafeed can be found in the Real Time Events list.
+        (see definition on top of the file)
+
+        Delete the specified datafeed.
+      operationId: deleteDatafeed
+      parameters:
+        - in: path
+          name: datafeedId
+          required: true
+          type: string
+          description: ID of the datafeed
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+      responses:
+        204:
+          description: Datafeed successfully deleted.
+          schema:
+            $ref: '#/definitions/V2Error'
+        400:
+          description: Bad request.
+          schema:
+            $ref: '#/definitions/V2Error'
+        401:
+          description: Unauthorized.
+          schema:
+            $ref: '#/definitions/V2Error'
+        500:
+          description: Internal server error.
+          schema:
+            $ref: '#/definitions/V2Error'
+
+  '/v5/datafeeds/{datafeedId}/read':
+    post:
+      tags:
+        - Datafeed
+      summary: Read the specified real time message / event stream ("datafeed").
+      description: |
+        _Available on Agent 2.57.0 and above._
+
+        The datafeed provides messages and events from all conversations that the user
+        is in. The types of events surfaced in the datafeed can be found in the Real Time Events list.
+        (see definition on top of the file)
+
+        Read the specified datafeed.
+
+        The ackId sent as parameter can be empty for the first call. In the response an ackId will be sent back and it can be used for
+        the next call: in this way you acknowledge that you have received the events that came with that ackId; datafeed will remove the events
+        associated with that ackId from your queue
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      operationId: readDatafeed
+      parameters:
+        - in: path
+          name: datafeedId
+          required: true
+          type: string
+          description: ID of the datafeed
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: ackId
+          description: ackId received from last POST Base64 encoded.
+          in: body
+          required: false
+          schema:
+            $ref: '#/definitions/AckId'
+      responses:
+        200:
+          description: Datafeed successfully read.
+          schema:
+            $ref: '#/definitions/V5EventList'
+        400:
+          description: Bad request.
+          schema:
+            $ref: '#/definitions/V2Error'
+        401:
+          description: Unauthorized.
+          schema:
+            $ref: '#/definitions/V2Error'
+        403:
+          description: Forbidden.
+          schema:
+            $ref: '#/definitions/V2Error'
+        500:
+          description: Internal server error.
+          schema:
+            $ref: '#/definitions/V2Error'
+
+  '/v5/events/read':
+    post:
+      tags:
+        - Datafeed
+      summary: Read Real Time Events from an event stream (aka datafeed)
+      x-since: 22.5
+      description: |
+        _Available on Agent 22.5 and above._
+
+        This endpoint provides messages and events from all conversations that the user
+        is in or events from the whole pod depending on the "type" field value.
+        When "type": "fanout" is provided in the body, then only events from streams the account belongs to are returned.
+        Otherwise, if "type": "datahose" is provided in the body, then events returned are not limited to the streams user
+        belongs to. In this case, at least one event type must be provided in the "filters" field. 
+        In case you are using a datahose feed and retrieving SOCIALMESSAGE events, ceservice account must be properly
+        configured in the Agent.
+
+        The types of events returned can be found in the Real Time Events list (see definition on top of the file).
+
+        The ackId sent as parameter can be empty for the first call. In the response an ackId will be sent back and it can be used for
+        the next call: in this way you acknowledge that you have received the events that came with that ackId.
+
+        If you have several instances of the same bot, they must share the same feed so that events are spread across
+        all bot instances. To do so, you must:
+        * share the same service account
+        * provide the same "tag" and same "filters" values
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      operationId: readEvents
+      parameters:
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: true
+          type: string
+        - name: body
+          description: body containing all information of events to be fetched
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/V5EventsReadBody'
+      responses:
+        200:
+          description: Datafeed successfully read.
+          schema:
+            $ref: '#/definitions/V5EventList'
+        400:
+          description: Bad request.
+          schema:
+            $ref: '#/definitions/V2Error'
+        401:
+          description: Unauthorized.
+          schema:
+            $ref: '#/definitions/V2Error'
+        403:
+          description: Forbidden.
+          schema:
+            $ref: '#/definitions/V2Error'
+        500:
+          description: Internal server error.
+          schema:
+            $ref: '#/definitions/V2Error'
+definitions:
+  Error:
+    type: object
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+  V2Error:
+    type: object
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+      details:
+        type: object
+    required:
+    - code
+    - message
+  SuccessResponse:
+    type: object
+    properties:
+      format:
+        type: string
+        enum:
+          - TEXT
+          - XML
+      message:
+        type: string
+  V2BaseMessage:
+    type: object
+    discriminator: v2messageType
+    properties:
+      id:
+        type: string
+        description: The messageId is assigned by the ingestor service when a message is sent.
+      timestamp:
+        type: string
+      v2messageType:
+        type: string
+      streamId:
+        type: string
+    required:
+    - v2messageType
+    - timestamp
+    - streamId
+  V2Message:
+    type: object
+    description: A representation of a message sent by a user of Symphony.
+    allOf:
+    - $ref: '#/definitions/V2BaseMessage'
+    - type: object
+      properties:
+        message:
+          type: string
+          format: MessageML
+          description: Message text in MessageML
+        fromUserId:
+          type: integer
+          format: int64
+          description: the Symphony userId of the user who sent the message. This will be populated by the server (and actually ignored if included when sending a message).
+        attachments:
+          type: array
+          items:
+            $ref: '#/definitions/AttachmentInfo'
+      required:
+      - message
+      - fromUserId
+  RoomCreatedMessage:
+    type: object
+    description: Generated when a room is created.
+    allOf:
+    - $ref: '#/definitions/V2BaseMessage'
+    - type: object
+      properties:
+        creationDate:
+          type: integer
+          format: int64
+        name:
+          type: string
+        keywords:
+          type: array
+          items:
+            $ref: '#/definitions/RoomTag'
+        description:
+          type: string
+        createdByUserId:
+          type: integer
+          format: int64
+          description: The Symphony userId of the user who created the room.
+        readOnly:
+          type: boolean
+        discoverable:
+          type: boolean
+        public:
+          type: boolean
+        membersCanInvite:
+          type: boolean
+        copyProtected:
+          type: boolean
+  RoomDeactivatedMessage:
+    type: object
+    description: Generated when a room is deactivated.
+    allOf:
+    - $ref: '#/definitions/V2BaseMessage'
+    - type: object
+      properties:
+        deactivatedByUserId:
+          type: integer
+          format: int64
+  RoomReactivatedMessage:
+    type: object
+    description: Generated when a room is reactivated.
+    allOf:
+    - $ref: '#/definitions/V2BaseMessage'
+    - type: object
+      properties:
+        reactivatedByUserId:
+          type: integer
+          format: int64
+  RoomUpdatedMessage:
+    type: object
+    description: Generated when a room is updated.
+    allOf:
+    - $ref: '#/definitions/V2BaseMessage'
+    - type: object
+      properties:
+        oldName:
+          type: string
+        newName:
+          type: string
+        keywords:
+          type: array
+          items:
+            $ref: '#/definitions/RoomTag'
+        oldDescription:
+          type: string
+        newDescription:
+          type: string
+        membersCanInvite:
+          type: boolean
+        discoverable:
+          type: boolean
+        readOnly:
+          type: boolean
+        copyProtected:
+          type: boolean
+  UserJoinedRoomMessage:
+    type: object
+    description: Generated when a user joins a room.
+    allOf:
+    - $ref: '#/definitions/V2BaseMessage'
+    - type: object
+      properties:
+        addedByUserId:
+          type: integer
+          format: int64
+        memberAddedUserId:
+          type: integer
+          format: int64
+  UserLeftRoomMessage:
+    type: object
+    description: Generated when a user leaves a room.
+    allOf:
+    - $ref: '#/definitions/V2BaseMessage'
+    - type: object
+      properties:
+        removedByUserId:
+          type: integer
+          format: int64
+        memberLeftUserId:
+          type: integer
+          format: int64
+        informationBarrierRemediation:
+          type: boolean
+  RoomMemberPromotedToOwnerMessage:
+    type: object
+    description: Generated when a room member is promoted to owner.
+    allOf:
+    - $ref: '#/definitions/V2BaseMessage'
+    - type: object
+      properties:
+        promotedByUserId:
+          type: integer
+          format: int64
+        promotedUserId:
+          type: integer
+          format: int64
+  RoomMemberDemotedFromOwnerMessage:
+    type: object
+    description: Generated when a room member is promoted to owner.
+    allOf:
+    - $ref: '#/definitions/V2BaseMessage'
+    - type: object
+      properties:
+        demotedByUserId:
+          type: integer
+          format: int64
+        demotedUserId:
+          type: integer
+          format: int64
+  ConnectionRequestMessage:
+    type: object
+    description: Generated when a connection request is sent.
+    allOf:
+    - $ref: '#/definitions/V2BaseMessage'
+    - type: object
+      properties:
+        requestingUserId:
+          type: integer
+          format: int64
+        targetUserId:
+          type: integer
+          format: int64
+        firstRequestedAt:
+          type: integer
+          format: int64
+        updatedAt:
+          type: integer
+          format: int64
+        requestCounter:
+          type: integer
+        status:
+          type: string
+  AttachmentInfo:
+    type: object
+    properties:
+      id:
+        type: string
+        description: The attachment ID.
+      name:
+        type: string
+        description: The file name.
+      size:
+        type: integer
+        format: int64
+        description: Size in bytes.
+    required:
+    - id
+    - name
+    - size
+  V2MessageList:
+    type: array
+    items:
+      $ref: '#/definitions/V2BaseMessage'
+  SimpleMessage:
+    description: A string wrapped in a JSON object.
+    type: object
+    properties:
+      message:
+        type: string
+
+  RoomTag:
+    description: Room Tag object. A key:value pair describing additional properties of the room.
+    properties:
+      key:
+        description: A unique label of the Tag.
+        type: string
+      value:
+        description: The value of this Tag's label.
+        type: string
+    required:
+    - key
+    - value
+  ShareArticle:
+    type: object
+    properties:
+      articleId:
+        type: string
+        description: An ID for this article that should be unique to the calling application. Either an articleId or an articleUrl is required.
+      title:
+        type: string
+        description: The title of the article
+      subTitle:
+        type: string
+        description: The subtitle of the article
+      message:
+        type: string
+        description: The message text that can be send along with the shared article
+      publisher:
+        type: string
+        description: Publisher of the article
+      publishDate:
+        type: integer
+        format: int64
+        description: Article publish date in unix timestamp
+      thumbnailUrl:
+        type: string
+        description: Url to the thumbnail image
+      author:
+        type: string
+        description: Author of the article
+      articleUrl:
+        type: string
+        description: Url to the article
+      summary:
+        type: string
+        description: Preview summary of the article
+      appId:
+        type: string
+        description: App ID of the calling application
+      appName:
+        type: string
+        description: App name of the calling application
+      appIconUrl:
+        type: string
+        description: App icon url of the calling application
+    required:
+    - title
+    - publisher
+    - author
+    - appId
+  ShareContent:
+    type: object
+    properties:
+      type:
+        type: string
+        description: Type of content to be shared.  Currently only support "com.symphony.sharing.article"
+      content:
+        $ref: '#/definitions/ShareArticle'
+  V2HealthCheckResponse:
+     type: object
+     properties:
+       podConnectivity:
+         type: boolean
+         description: Indicates whether the Agent server can connect to the Pod
+       podConnectivityError:
+         type: string
+         description: Error details in case of no Pod connectivity
+       keyManagerConnectivity:
+         type: boolean
+         description: Indicates whether the Agent server can connect to the Key Manager
+       keyManagerConnectivityError:
+         type: string
+         description: Error details in case of no Key Manager connectivity
+       firehoseConnectivity:
+         type: boolean
+         description: Indicates whether the Agent server can connect to Firehose Service
+       firehoseConnectivityError:
+         type: string
+         description: Error details in case of no Firehose connectivity
+       encryptDecryptSuccess:
+         type: boolean
+         description: Indicates whether the Agent can successfully decrypt and encrypt messages
+       encryptDecryptError:
+         type: string
+         description: Error details in case of the encryption or decryption of the message fails
+       podVersion:
+         type: string
+         description: The version number of the pod
+       agentVersion:
+         type: string
+         description: The version number of the Agent server
+       agentServiceUser:
+         type: boolean
+         description: Indicates whether agent service user is setup correctly.
+       agentServiceUserError:
+         type: string
+         description: Error details in case agent service user is setup incorrectly.
+       ceServiceUser:
+         type: boolean
+         description: Indicates whether CEService user is setup correctly.
+       ceServiceUserError:
+         type: string
+         description: Error details in case CEService user is setup incorrectly.
+  MessageSearchQuery:
+    type: object
+    properties:
+      text:
+        type: string
+        description: Search for messages containing this text. Requires streamId to be specified.
+      streamId:
+        type: string
+        description: Search for messages sent to this stream
+      streamType:
+        type: string
+        description: |
+          Search for messages sent to this type of streams. Accepted values are CHAT, IM, MIM, ROOM, POST.
+      author:
+        type: integer
+        format: int64
+        description: Search for messages sent by this user ID
+      hashtag:
+        type: string
+        description: Search for messages containing this hashtag
+      cashtag:
+        type: string
+        description: Search for messages containing this cashtag
+      mention:
+        type: integer
+        format: int64
+        description: Search for messages mentioning this user ID
+      signal:
+        type: string
+        description: |
+          Search for messages matching this signal. Can only be combined with date filtering and paging parameters.
+      fromDate:
+        type: integer
+        format: int64
+        description: Search for messages sent on or after this timestamp
+      toDate:
+        type: integer
+        format: int64
+        description: Search for messages sent before this timestamp
+  V4MessageImportList:
+    description: |
+      An ordered list of historic messages to be imported.
+      A list of import responsees will be returned in the same order.
+    type: array
+    items:
+      $ref: '#/definitions/V4ImportedMessage'
+  V4ImportedMessage:
+    description: |
+      A historic message to be imported into the system.
+      The importing user must have the Content Management role.
+      Also, the importing user must be a member of the conversation it is importing into.
+      The user that the message is intended to have come from must also be present in the conversation.
+      The intended message timestamp must be a valid time from the past. It cannot be a future timestamp.
+      By design, imported messages do not stream to datafeed or firehose endpoints.
+    type: object
+    properties:
+      message:
+        type: string
+        format: MessageML
+        description: Message text in MessageMLV2
+      data:
+        type: string
+        format: JSON
+        description: Entity data in EntityJSON
+      intendedMessageTimestamp:
+        description: |
+          The timestamp representing the time when the message was sent in the original system
+          in milliseconds since Jan 1st 1970.
+        type: integer
+        format: int64
+      intendedMessageFromUserId:
+        description: |
+          The long integer userid of the Symphony user who you intend to show sent the message.
+        type: integer
+        format: int64
+      originatingSystemId:
+        description: |
+          The ID of the system through which the message was originally sent.
+        type: string
+      originalMessageId:
+        description: |
+          The ID of the message in the original system.
+        type: string
+      streamId:
+        type: string
+      attachments:
+        description: List of message attachments. Since Agent 20.14.
+        type: array
+        items:
+          $ref: '#/definitions/V4ImportedMessageAttachment'
+        x-since: 20.14
+      previews:
+        description: List of attachments previews. Since Agent 20.14.
+        type: array
+        items:
+          $ref: '#/definitions/V4ImportedMessageAttachment'
+        x-since: 20.14
+    required:
+    - message
+    - intendedMessageTimestamp
+    - intendedMessageFromUserId
+    - originatingSystemId
+    - streamId
+  V4ImportedMessageAttachment:
+    type: object
+    properties:
+      filename:
+        description: Attachment filename
+        type: string
+        example: 'car.png'
+      content:
+        description: Attachment content as Base64 encoded string
+        type: string
+  V4ImportResponseList:
+    type: array
+    items:
+      $ref: '#/definitions/V4ImportResponse'
+  V4ImportResponse:
+    type: object
+    properties:
+      messageId:
+        description: |
+          If the message was successfully imported then the message ID in the system
+          of the newly created message.
+        type: string
+      originatingSystemId:
+        description: |
+          The ID of the system through which the message was originally sent.
+        type: string
+      originalMessageId:
+        description: |
+          The ID of the message in the original system.
+        type: string
+      diagnostic:
+        description: |
+          A diagnostic message containing an error message in the event that the
+          message import failed. May also be present in the case of a successful
+          call if there is useful narrative to return.
+        type: string
+  V4AttachmentInfo:
+    type: object
+    properties:
+      id:
+        type: string
+        description: The attachment ID.
+      name:
+        type: string
+        description: The file name.
+      size:
+        type: integer
+        format: int64
+        description: Size in bytes.
+      images:
+        type: array
+        items:
+          $ref: '#/definitions/V4ThumbnailInfo'
+    required:
+    - id
+    - name
+    - size
+  V4ThumbnailInfo:
+    type: object
+    properties:
+      id:
+        type: string
+        description: The thumbnail ID.
+      dimension:
+        type: string
+        description: The thumbnail pixel size.
+  V4MessageList:
+    type: array
+    items:
+      $ref: '#/definitions/V4Message'
+  V4Message:
+    type: object
+    description: A representation of a message sent by a user of Symphony
+    properties:
+      messageId:
+        type: string
+        description: Id of the message
+      parentMessageId:
+        type: string
+        description: Id of the parent message, set when the message is a reply to another message or a forwarded message. Since Agent 20.14.
+        x-since: 20.14
+      timestamp:
+        type: integer
+        format: int64
+        description: Timestamp of the message in milliseconds since Jan 1 1970
+      message:
+        type: string
+        format: MessageMLV2
+        description: Message content in MessageMLV2
+      sharedMessage:
+        description: Only present when the message represented by this class is a wall post sharing another message.
+        $ref: '#/definitions/V4Message'
+      data:
+        type: string
+        format: JSON
+        description: Message data in EntityJSON
+      attachments:
+        description: Message attachments
+        type: array
+        items:
+          $ref: '#/definitions/V4AttachmentInfo'
+      user:
+        $ref: '#/definitions/V4User'
+      stream:
+        $ref: '#/definitions/V4Stream'
+      externalRecipients:
+        description: Indicates if the message have external recipients. Only present on real time messaging.
+        type: boolean
+      diagnostic:
+        type: string
+        description: |
+          Details if event failed to parse for any reason.  The contents of this field may not be useful,
+          depending on the nature of the error. Only present when error occurs.
+      userAgent:
+        type: string
+        description: |
+          User agent string for client that sent the message.  Allows callers to identify which client sent the
+          origin message (e.g. API Agent, SFE Client, mobile, etc)
+      originalFormat:
+        type: string
+        description: |
+          Indicates the format in which the message was originally sent.  This could have been either:
+          - com.symphony.markdown - Markdown OR Message ML V1
+          - com.symphony.messageml.v2 - Message ML V2
+      disclaimer:
+        type: string
+        description: |
+          Message that may be sent along with a regular message if configured for the POD,
+          usually the first message sent in a room that day.
+      sid:
+        type: string
+        description: |
+          Unique session identifier from where the message was created.
+        example: 'fa691cd3-484a-4109-aeb2-57c05b78c95b'
+      replacing:
+        type: string
+        description: Id of the message that the current message is replacing (present only if set)
+      replacedBy:
+        type: string
+        description: Id of the message that the current message is being replaced with (present only if set)
+      initialTimestamp:
+        type: integer
+        format: int64
+        description: Timestamp of when the initial message has been created in milliseconds since Jan 1 1970 (present only if set)
+      initialMessageId:
+        type: string
+        description: Id the the initial message that has been updated (present only if set)
+      silent:
+        type: boolean
+        description: When false the user/s will receive the message update as unread (true by default). Since Agent 20.14.
+        x-since: 20.14
+  V4MessageBlastResponse:
+    type: object
+    description: Wrapper response for a single message sent to multiple streams
+    properties:
+      messages:
+        type: array
+        description: List of messages successfully sent
+        items:
+          $ref: '#/definitions/V4Message'
+      errors:
+        type: object
+        description: List of streams where the messages ingestion has failed
+        additionalProperties:
+          $ref: '#/definitions/Error'
+  V4User:
+    type: object
+    properties:
+      userId:
+        type: integer
+        format: int64
+        description: Id of user
+      firstName:
+        type: string
+        description: First name of user
+      lastName:
+        type: string
+        description: Last name of user
+      displayName:
+        type: string
+        description: User display name
+      email:
+        type: string
+        description: Email of user
+      username:
+        type: string
+        description: Applicable only to internal users
+  V4Stream:
+    type: object
+    properties:
+      streamId:
+        type: string
+        description: Id of stream
+      streamType:
+        type: string
+        description: |
+          Stream type, possible values are:
+            - IM
+            - MIM
+            - ROOM
+            - POST
+      roomName:
+        type: string
+        description: Applicable only to rooms
+      members:
+        description: Applicable only to IM Created
+        type: array
+        items:
+          $ref: '#/definitions/V4User'
+      external:
+        type: boolean
+      crossPod:
+        type: boolean
+  V4RoomProperties:
+    type: object
+    properties:
+      name:
+        type: string
+      description:
+        type: string
+      creatorUser:
+        $ref: '#/definitions/V4User'
+      createdDate:
+        type: integer
+        format: int64
+        description: Timestamp
+      external:
+        type: boolean
+      crossPod:
+        type: boolean
+      public:
+        type: boolean
+      copyProtected:
+        type: boolean
+      readOnly:
+        type: boolean
+      discoverable:
+        type: boolean
+      membersCanInvite:
+        type: boolean
+      keywords:
+        type: array
+        items:
+          $ref: '#/definitions/V4KeyValuePair'
+      canViewHistory:
+        type: boolean
+  V4KeyValuePair:
+    type: object
+    properties:
+      key:
+        type: string
+      value:
+        type: string
+  V4MessageSent:
+    type: object
+    properties:
+      message:
+        $ref: '#/definitions/V4Message'
+  V4Initiator:
+    type: object
+    properties:
+      user:
+        $ref: '#/definitions/V4User'
+  V4SharedPost:
+    type: object
+    properties:
+      message:
+        $ref: '#/definitions/V4Message'
+      sharedMessage:
+        $ref: '#/definitions/V4Message'
+  V4InstantMessageCreated:
+    type: object
+    properties:
+      stream:
+        $ref: '#/definitions/V4Stream'
+  V4RoomCreated:
+    type: object
+    properties:
+      stream:
+        $ref: '#/definitions/V4Stream'
+      roomProperties:
+        $ref: '#/definitions/V4RoomProperties'
+  V4RoomUpdated:
+    type: object
+    properties:
+      stream:
+        $ref: '#/definitions/V4Stream'
+      newRoomProperties:
+        $ref: '#/definitions/V4RoomProperties'
+  V4RoomDeactivated:
+    type: object
+    properties:
+      stream:
+        $ref: '#/definitions/V4Stream'
+  V4RoomReactivated:
+    type: object
+    properties:
+      stream:
+        $ref: '#/definitions/V4Stream'
+  V4UserJoinedRoom:
+    type: object
+    properties:
+      stream:
+        $ref: '#/definitions/V4Stream'
+      affectedUser:
+        # User who was affected by the action (i.e. added to the room)
+        $ref: '#/definitions/V4User'
+  V4UserLeftRoom:
+    type: object
+    properties:
+      stream:
+        $ref: '#/definitions/V4Stream'
+      affectedUser:
+        # User who was affected by the action (i.e. left the room)
+        $ref: '#/definitions/V4User'
+  V4RoomMemberPromotedToOwner:
+    type: object
+    properties:
+      stream:
+        $ref: '#/definitions/V4Stream'
+      affectedUser:
+        # User who was affected by the action (i.e. promoted to owner)
+        $ref: '#/definitions/V4User'
+  V4RoomMemberDemotedFromOwner:
+    type: object
+    properties:
+      stream:
+        $ref: '#/definitions/V4Stream'
+      affectedUser:
+        # User who was affected by the action (i.e. demoted from owner)
+        $ref: '#/definitions/V4User'
+  V4ConnectionRequested:
+    type: object
+    properties:
+      toUser:
+        # User who received the connection request
+        $ref: '#/definitions/V4User'
+  V4ConnectionAccepted:
+    type: object
+    properties:
+      fromUser:
+        # User who sent the connection request
+        $ref: '#/definitions/V4User'
+  V4MessageSuppressed:
+    type: object
+    properties:
+      messageId:
+        type: string
+      stream:
+        # the stream holding the suppressed message
+        $ref: '#/definitions/V4Stream'
+  V4SymphonyElementsAction:
+    type: object
+    properties:
+      stream:
+        description: "The stream where the Form message was posted"
+        $ref: '#/definitions/V4Stream'
+      formMessageId:
+        description: "The id of the message that contains the Form"
+        type: string
+      formId:
+        description: "The id of the Form element"
+        type: string
+      formValues:
+        description: "The values (in JSON format) answered on the Form"
+        type: object
+  V4UserRequestedToJoinRoom:
+    type: object
+    properties:
+      stream:
+        description: "The stream that the user requested to join"
+        $ref: '#/definitions/V4Stream'
+      affectedUsers:
+        type: array
+        description: "List of affected users by the action (i.e. owners of the room)"
+        items:
+          $ref: '#/definitions/V4User'
+  V4Payload:
+    type: object
+    properties:
+      messageSent:
+        $ref: '#/definitions/V4MessageSent'
+      sharedPost:
+        $ref: '#/definitions/V4SharedPost'
+      instantMessageCreated:
+        $ref: '#/definitions/V4InstantMessageCreated'
+      roomCreated:
+        $ref: '#/definitions/V4RoomCreated'
+      roomUpdated:
+        $ref: '#/definitions/V4RoomUpdated'
+      roomDeactivated:
+        $ref: '#/definitions/V4RoomDeactivated'
+      roomReactivated:
+        $ref: '#/definitions/V4RoomReactivated'
+      userJoinedRoom:
+        $ref: '#/definitions/V4UserJoinedRoom'
+      userLeftRoom:
+        $ref: '#/definitions/V4UserLeftRoom'
+      roomMemberPromotedToOwner:
+        $ref: '#/definitions/V4RoomMemberPromotedToOwner'
+      roomMemberDemotedFromOwner:
+        $ref: '#/definitions/V4RoomMemberDemotedFromOwner'
+      connectionRequested:
+        $ref: '#/definitions/V4ConnectionRequested'
+      connectionAccepted:
+        $ref: '#/definitions/V4ConnectionAccepted'
+      messageSuppressed:
+        $ref: '#/definitions/V4MessageSuppressed'
+      symphonyElementsAction:
+        $ref: '#/definitions/V4SymphonyElementsAction'
+      userRequestedToJoinRoom:
+        $ref: '#/definitions/V4UserRequestedToJoinRoom'
+  V4Event:
+    type: object
+    properties:
+      id:
+        type: string
+        description: Event ID
+      messageId:
+        type: string
+        description: Message ID
+      timestamp:
+        type: integer
+        format: int64
+        description: Timestamp of event
+      type:
+        type: string
+        description: |
+          Event type, possible events are:
+            - MESSAGESENT
+            - SHAREDPOST
+            - INSTANTMESSAGECREATED
+            - ROOMCREATED
+            - ROOMUPDATED
+            - ROOMDEACTIVATED
+            - ROOMREACTIVATED
+            - USERJOINEDROOM
+            - USERLEFTROOM
+            - ROOMMEMBERPROMOTEDTOOWNER
+            - ROOMMEMBERDEMOTEDFROMOWNER
+            - CONNECTIONREQUESTED
+            - CONNECTIONACCEPTED
+            - MESSAGESUPPRESSED
+            - SYMPHONYELEMENTSACTION
+            - USERREQUESTEDTOJOINROOM
+      diagnostic:
+        type: string
+        description: |
+          Details if event failed to parse for any reason.  The contents of this field may not be useful,
+          depending on the nature of the error. Only present when error occurs.
+      initiator:
+        # Actor who initiated the event
+        $ref: '#/definitions/V4Initiator'
+      payload:
+        # Holds payload for all event types
+        $ref: '#/definitions/V4Payload'
+  V4EventList:
+    type: array
+    items:
+      $ref: '#/definitions/V4Event'
+  BaseSignal:
+    type: object
+    properties:
+      name:
+        type: string
+        description: Signal name
+      query:
+        type: string
+        description: |
+          The query used to define this signal. The query is defined as "field:value" pairs combined by the operators
+          "AND" or "OR". Supported fields are (case-insensitive): "author", "hashtag" and "cashtag".
+          MUST contain at least one "hashtag" or "cashtag" definition.
+      visibleOnProfile:
+        type: boolean
+        description: Whether the signal is visible on its creator's profile
+      companyWide:
+        type: boolean
+        description: Whether the signal is a push signal
+  Signal:
+    allOf:
+      - $ref: '#/definitions/BaseSignal'
+      - type: object
+        properties:
+          id:
+            type: string
+            description: Signal ID
+          timestamp:
+            type: integer
+            format: int64
+            description: Timestamp when the signal was created, in milliseconds since Jan 1 1970
+          companyWide:
+            type: boolean
+            description: Whether the signal is a push signal
+  SignalList:
+    type: array
+    items:
+      $ref: '#/definitions/Signal'
+  ChannelSubscriptionResponse:
+    type: object
+    properties:
+      requestedSubscription:
+        type: integer
+        format: int64
+        description: The number of requested userIds to subscribe
+      successfulSubscription:
+        type: integer
+        format: int64
+        description: The number of successful subscriptions done
+      failedSubscription:
+        type: integer
+        format: int64
+        description: The number of subscription failures
+      subscriptionErrors:
+        type: array
+        items:
+          $ref: '#/definitions/ChannelSubscriptionError'
+  ChannelSubscriptionError:
+    type: object
+    properties:
+      userId:
+        type: integer
+        format: int64
+        description: The userId on which failure happened
+      code:
+        type: string
+        description: subscription failure code
+      message:
+        type: string
+        description: subscription failure message
+  ChannelSubscriberResponse:
+    type: object
+    properties:
+      offset:
+        type: integer
+        format: int64
+        description: The number of subscribers skipped
+      hasMore:
+        type: boolean
+        description: True if there are more subscribers
+      total:
+        type: integer
+        description: The total number of subscribers
+      data:
+        type: array
+        items:
+          $ref: '#/definitions/ChannelSubscriber'
+  ChannelSubscriber:
+    type: object
+    properties:
+      subscriptionId:
+        type: string
+      pushed:
+        type: boolean
+        description: True if the subscriber is allowed to unsubscribe
+      owner:
+        type: boolean
+        description: True if the subscriber is the creator
+      subscriberName:
+        type: string
+        description: User display name
+      userId:
+        type: integer
+        format: int64
+        description: The user ID of the subscriber
+      timestamp:
+        type: integer
+        format: int64
+        description: Timestamp when the signal was subscribed, in milliseconds since Jan 1 1970
+  AgentInfo:
+    type: object
+    properties:
+      ipAddress:
+        type: string
+        description: The IP address of the Agent server.
+      hostname:
+        type: string
+        description: The hostname of the Agent server.
+      serverFqdn:
+        type: string
+        description: The fully-qualified domain name of the Agent server. Must be set by the user at startup.
+      version:
+        type: string
+        description: The version of the Agent.
+      url:
+        type: string
+        description: The URL under which the Agent is available.
+      onPrem:
+        type: boolean
+        description: Whether this is an on-prem or cloud installation.
+      commitId:
+        type: string
+        description: The Git commit ID of the running revision.
+  V1DLPPoliciesCollectionResponse:
+    type: object
+    properties:
+      policies:
+        type: array
+        description: List of policies
+        items:
+          $ref: '#/definitions/V1DLPPolicy'
+      page:
+        type: integer
+        format: int32
+        description: Page number of current page
+      pageCount:
+        type: integer
+        format: int32
+        description: Total number of pages available
+    description: List of policies
+  V1DLPPolicy:
+    type: object
+    required:
+    - "contentTypes"
+    - "name"
+    - "scopes"
+    - "type"
+    properties:
+      active:
+        type: boolean
+        description: Indicate whether the policy is active or not
+      contentTypes:
+        type: array
+        description: |
+          The list of content types that policy should apply to. Cannot be empty. Policy content types could be either of "Messages", "RoomMeta", "SignalMeta".
+          Default is set to ["Messages"] if not specified.
+        items:
+          type: string
+      creationDate:
+        type: integer
+        format: int64
+        description: |
+          Creation time of the policy in milliseconds elapsed as of epoch time.
+      creatorId:
+        type: string
+        description: Numeric userId of the creator
+      dictionaryRefs:
+        type: array
+        description: List of dictionaries.
+        items:
+          $ref: '#/definitions/V1DLPDictionaryRef'
+      lastDisabledDate:
+        type: integer
+        format: int64
+        description: |
+          Recent disable time of the policy in milliseconds elapsed as of epoch time.
+      lastUpdatedDate:
+        type: integer
+        format: int64
+        description: Recent update time of the policy in milliseconds elapsed as of epoch time.
+      name:
+        type: string
+        description: Unique name of a policy, max 30 characters. Cannot be empty. All the leading and trailing blank spaces are trimmed.
+      policyId:
+        type: string
+        description: Policy Id
+      scopes:
+        type: array
+        description: |
+          List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
+          You can apply both scopes if you set it to ["Internal", "External"].
+        items:
+          type: string
+      type:
+        type: string
+        description: Type of policy. Possible values "Block" or "Warn".
+      version:
+        type: string
+        description: |
+          The version of a dictionary, in format "major.minor". Initial value will set by backend as "1.0" when created.
+          Whenever the dictionary version needs to be changed, the minor version by 1 unless minor == 999, then the major version is increased by 1 until it reaches 999.
+    description: The policy object for expression filter, one policy can have multiple dictionaries
+  V1DLPPolicyRequest:
+    type: object
+    required:
+    - "contentTypes"
+    - "name"
+    - "scopes"
+    - "type"
+    properties:
+      contentTypes:
+        type: array
+        description: |
+          The list of content types that policy should apply to. Cannot be empty. Policy content types could be either of "Messages", "RoomMeta", "SignalMeta".
+          Default is set to ["Messages"] if not specified.
+        items:
+          type: string
+      dictionaryIds:
+        type: array
+        description: List of dictionaries Ids for the policy.
+        items:
+          type: string
+      name:
+        type: string
+        description: Unique name of a policy, max 30 characters. Cannot be empty. All the leading and trailing blank spaces are trimmed.
+      scopes:
+        type: array
+        description: |
+          List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
+          You can apply both scopes if you set it to ["Internal", "External"].
+        items:
+          type: string
+      type:
+        type: string
+        description: Type of policy. Possible values "Block" or "Warn".
+    description: The policy object to use for creating/updating a policy.
+  V1DLPPolicyResponse:
+    type: object
+    properties:
+      data:
+        $ref: '#/definitions/V1DLPPolicy'
+    description: Policy Response
+  V1DLPDictionary:
+    type: object
+    required:
+    - dictionaryMetadata
+    properties:
+      content:
+        $ref: '#/definitions/V1DLPDictionaryContent'
+      dictionaryMetadata:
+        $ref: '#/definitions/V1DLPDictionaryMetadata'
+    description: Dictionary object
+  V1DLPDictionaryContent:
+    type: object
+    properties:
+      data:
+        type: string
+        description: |
+          A comma separated string which contains a lot of keywords/regexes.
+      numKeywords:
+        type: integer
+        format: int32
+        description: Number of Keywords in dictionary
+      md5:
+        type: string
+        description: MD5 value of the content
+    description: Content of a dictionary
+  V1DLPDictionaryMetadataCollectionResponse:
+    type: object
+    properties:
+      items:
+        type: array
+        description: List of dictionary metadata
+        items:
+          $ref: '#/definitions/V1DLPDictionaryMetadata'
+      page:
+        type: integer
+        format: int32
+        description: Page number of current page
+      pageCount:
+        type: integer
+        format: int32
+        description: Total number of pages available
+    description: List of dictionary metadata.
+  V1DLPDictionaryMetadataResponse:
+    type: object
+    required:
+    - data
+    properties:
+      data:
+        $ref: '#/definitions/V1DLPDictionaryMetadata'
+    description: Dictionary response containing dictionary metadata.
+  V1DLPDictionaryMetadataCreateRequest:
+    type: object
+    required:
+    - name
+    - type
+    properties:
+      name:
+        type: string
+        description: |
+          The name of dictionary
+      type:
+        type: string
+        description: |
+          The type of dictionary, which specify the content is a list of words or a list of regexes.
+          By default set to "Word" if not specified. Possible values - Word, Regex
+    description: Dictionary's metadata (excluding content) to use for dictionary create operations.
+  V1DLPDictionaryMetadataUpdateRequest:
+    type: object
+    required:
+    - name
+    properties:
+      name:
+        type: string
+        description: |
+          The name of dictionary
+    description: Dictionary's metadata (excluding content) to use for dictionary update operations.
+  V1DLPDictionaryMetadata:
+    type: object
+    required:
+    - dictRef
+    - type
+    properties:
+      creationDate:
+        type: integer
+        format: int64
+        description: Creation time of the dictionary in milliseconds elapsed as of epoch time.
+      creatorId:
+        type: string
+        description: Numeric userId of the creator
+      dictRef:
+        $ref: '#/definitions/V1DLPDictionaryRef'
+      lastUpdatedDate:
+        type: integer
+        format: int64
+        description: The recent update time of the dictionary in milliseconds
+      type:
+        type: string
+        description: |
+          The type of dictionary, which specify the content is a list of words or a list of regexes.
+          By default set to "Word" if not specified. Possible values - Word, Regex
+    description: Dictionary's metadata (excluding content)
+  V1DLPDictionaryRef:
+    type: object
+    required:
+    - name
+    properties:
+      dictId:
+        type: string
+        description: Unique dictionary id
+      name:
+        type: string
+        description: Unique name of a dictionary, max 30 characters, with trimmed leading and trailing blank spaces.
+      version:
+        type: string
+        description: |
+          The version of a dictionary, in format "major.minor".
+          Initial value will set by backend as "1.0" when created.
+          Whenever the dictionary version needs to be changed, the minor version by 1 unless minor == 999, then the major version is increased by 1 until it reaches 999.
+    description: Basic information needed to identify a dictionary
+  V1DLPViolationMessageResponse:
+    type: object
+    properties:
+      violations:
+        type: array
+        description: A representation of list of violations due to messages sent by a user of Symphony
+        items:
+          $ref: '#/definitions/V1DLPViolationMessage'
+      nextOffset:
+        type: string
+        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
+  V1DLPViolationStreamResponse:
+    type: object
+    properties:
+      violations:
+        type: array
+        items:
+          # A representation of list of violations due to rooms creation/update sent by a user of Symphony
+          $ref: '#/definitions/V1DLPViolationStream'
+      nextOffset:
+        type: string
+        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
+  V1DLPViolationSignalResponse:
+    type: object
+    properties:
+      violations:
+        type: array
+        description: A representation of list of violations due to signal creation/update sent by a user of Symphony
+        items:
+          $ref: '#/definitions/V1DLPViolationSignal'
+      nextOffset:
+        type: string
+        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
+  V1DLPViolationMessage:
+    type: object
+    properties:
+      violation:
+        # A representation of a violation due to a message sent by a user of Symphony
+        $ref: '#/definitions/V1DLPViolation'
+      message:
+        # Message details when DLP was enforced
+        $ref: '#/definitions/V4Message'
+      diagnostic:
+        type: string
+        description: |
+            A diagnostic message containing an error message in the event there are parsing errors.
+            May also be present in the case of a successful call if there is useful narrative to return.
+  V1DLPViolationStream:
+    type: object
+    properties:
+      violation:
+        # A representation of a violation due to rooms creation/update sent by a user of Symphony
+        $ref: '#/definitions/V1DLPViolation'
+      stream:
+        # Room details when DLP was enforced
+        $ref: '#/definitions/V1DLPStream'
+  V1DLPViolationSignal:
+    type: object
+    properties:
+      violation:
+        # A representation of a violation due to signal creation/update sent by a user of Symphony
+        $ref: '#/definitions/V1DLPViolation'
+      signal:
+        # Signal details when DLP was enforced
+        $ref: '#/definitions/V1DLPSignal'
+  V1DLPViolation:
+    type: object
+    description: A representation of a violation due to a message sent by a user of Symphony
+    properties:
+      enforcementEventID:
+        type: string
+        description: Enforcement event ID. Unique ID that identifies this enforcement.
+      entityID:
+        type: string
+        description: Entity ID is the content Id of the violation, for example, for messages, its the Id of the message
+      createTime:
+        type: integer
+        format: int64
+        description: Timestamp of the violation in milliseconds since Jan 1 1970
+      lastModified:
+        type: integer
+        format: int64
+        description: Timestamp of the last modification of violation in milliseconds since Jan 1 1970
+      requesterId:
+        type: integer
+        format: int64
+        description: Id of the requester responsible for the message/stream/signal
+      matchedPolicies:
+        # Policies that matched when DLP was enforced and the list of matched terms decrypted.
+        $ref: '#/definitions/V1DLPMatchedPolicyList'
+      action:
+        type: string
+        description: action taken such as BLOCK or WARN.  See outcome for a more detailed description of the outcome this action.
+      outcome:
+        # Detailed outcome of the DLP enforcement such as REJECTED_VIOLATION, ACCEPTED_WARNING, ACCEPTED_LEGACY_CLIENT etc.
+        $ref: '#/definitions/V1DLPOutcome'
+      version:
+        type: string
+        description: Version of application which processed the message and produced this violation.
+      ignoreDLPwarning:
+          type: boolean
+          description: Did the user chose to ignore DLP warning that was presented?
+  V1DLPMatchedPolicyList:
+    type: array
+    items:
+      $ref: '#/definitions/V1DLPMatchedPolicy'
+    description: List of policies that matched the violation.
+  V1DLPMatchedPolicy:
+    type: object
+    description: A representation of policy that matched the violation with a list of matched keywords in the policy
+    properties:
+      id:
+        type: string
+        description: Id of the policy
+      version:
+        type: string
+        description: Version of the policy
+      policyName:
+        type: string
+        description: Name of the policy
+      type:
+        type: string
+        description: Whether BLOCK or WARN
+      terms:
+        type: string
+        description: List of decrypted matched keywords in the policy
+      diagnostic:
+        type: string
+        description: |
+            A diagnostic message containing an error message in the event that the
+            decryption of terms failed. May also be present in the case of a successful
+            call if there is useful narrative to return.
+  V1DLPOutcome:
+    type: object
+    description: A representation of outcome of DLP message/stream/signal sent by a user of Symphony
+    properties:
+      type:
+        type: string
+        description: Outcome of DLP enforcement
+  V1DLPContentType:
+    type: object
+    description: A representation of content type of message sent by a user of Symphony (message/stream/signal)
+    properties:
+      type:
+        type: string
+        description: content type
+  V1DLPStream:
+    type: object
+    description: Room details in the context of violation.
+    properties:
+        name:
+          type: string
+          description:  Name of the Stream/Room.
+        creatorPrettyName:
+          type: string
+          description:  Name of the creator of the Room.
+        publicRoom:
+          type: boolean
+          description:  Is this a public room?
+        crossPod:
+          type: boolean
+          description:  Is this a cross pod scenario?
+        allowExternal:
+          type: boolean
+          description:  Is external messaging allowed
+        creatorId:
+          type: string
+          description:  Id of the creator of the Room.
+        roomDescription:
+          type: string
+          description:  Description of the Room.
+        streamId:
+          type: string
+          description:  ThreadId of the Room.
+        state:
+          type: string
+          description:  State of the Room (example CREATED etc)
+        type:
+          type: string
+          description:  Type of the Room (example ROOM (or IM or Wall))
+        lastDisabled:
+          type: integer
+          format: int64
+          description: Timestamp of last time the room is Disabled
+        memberAddUserEnabled:
+          type: boolean
+          description:  Is memberAddUserEnabled
+        active:
+          type: boolean
+          description:  Is Room Active
+        discoverable:
+          type: boolean
+          description:  Is Room discoverable
+        readOnly:
+          type: boolean
+          description:  Is Room read-only
+        copyDisabled:
+          type: boolean
+          description:  Is Room copyDisabled
+        externalOwned:
+          type: boolean
+          description:  Is Room externalOwned
+        sendMessageDisabled:
+          type: boolean
+          description:  Is sendMessage Disabled for this Room
+        moderated:
+          type: boolean
+          description:  Is room moderated
+        shareHistoryEnabled:
+          type: boolean
+          description:  Is room shareHistoryEnabled
+        diagnostic:
+          type: string
+          description: |
+              A diagnostic message containing an error message in the event that the
+              stream retrieval failed. May also be present in the case of a successful
+              call if there is useful narrative to return.
+  V1DLPSignal:
+    type: object
+    description: Signal details
+    properties:
+        name:
+          type: string
+          description:  Name of the Signal
+        rules:
+          type: string
+          description:  Signal rules decrypted.
+        diagnostic:
+          type: string
+          description: |
+              A diagnostic message containing an error message in the event that the
+              signal decryption failed. May also be present in the case of a successful
+              call if there is useful narrative to return.
+
+#
+# V3 Policies definitions
+#
+  V3DLPPolicyRequest:
+    type: object
+    required:
+      - "name"
+      - "scopes"
+      - "appliesTo"
+    properties:
+      name:
+        type: string
+        description: |
+          Unique name of a policy, max 30 characters. Cannot be empty. All the leading and trailing blank spaces are trimmed.
+      scopes:
+        type: array
+        description: |
+          List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
+          You can apply both scopes if you set it to ["Internal", "External"].
+        items:
+          type: string
+      appliesTo:
+        type: array
+        items:
+          $ref: '#/definitions/V3DLPPolicyAppliesTo'
+    description: Request to be used to get policies.
+  V3DLPPolicy:
+    type: object
+    properties:
+      id:
+        type: string
+        description: Unique identifier for policy.
+      policyId:
+        type: string
+        description: Policy Id.
+      version:
+        type: string
+        description: |
+          The version of the policy, in format "major.minor". Initial value will set by backend as "3.0" when created.
+          Whenever the policy version needs to be changed, the minor version by 1 unless minor == 999,
+          then the major version is increased by 1 until it reaches 999.
+      name:
+        type: string
+        description: |
+          Unique name of policy, max 30 characters. Cannot be empty. All the leading and trailing blank spaces are trimmed.
+      creatorId:
+        type: integer
+        format: int64
+        description: Numeric userId of the creator.
+      scopes:
+        type: array
+        description: |
+          List of communication scopes. Possible values are "Internal" (for Internal conversations) or "External" (for External conversations).
+          You can apply both scopes if you set it to ["Internal", "External"].
+        items:
+          type: string
+      appliesTo:
+        type: array
+        items:
+          $ref: '#/definitions/V3DLPPolicyAppliesTo'
+      active:
+        type: boolean
+        description: Indicate whether the policy is active or not.
+      deleted:
+        type: boolean
+        description: Indicate whether the policy is deleted or not.
+      creationDate:
+        type: integer
+        format: int64
+        description: |
+          Creation time of the policy in milliseconds elapsed as of epoch time.
+      lastUpdatedDate:
+        type: integer
+        format: int64
+        description: |
+          Recent update time of the policy in milliseconds elapsed as of epoch.
+          time.
+      lastDisabledDate:
+        type: integer
+        format: int64
+        description: |
+          Recent disable time of the policy in milliseconds elapsed as of epoch.
+          time.
+      systemPolicy:
+        type: boolean
+    description : |
+      A policy is the main entity of V3 policy/rule system. It is responsible to define rules and add scope constraints to the engine.
+  V3DLPRule:
+    type: object
+    required:
+     - "type"
+     - "name"
+    properties:
+      id:
+        type: string
+      type:
+        type: string
+        description: Type of a rule used by policy. Can be ["UNKNOWN", "TEXT_MATCH", "FILE_EXTENSION", "FILE_SIZE", "FILE_PASSWORD", "FILE_CLASSIFIER"].
+      name:
+        type: string
+        description: Name for rule.
+      textMatchConfig:
+        $ref: '#/definitions/V3DLPTextMatchConfig'
+      fileSizeConfig:
+        $ref: '#/definitions/V3DLPFileSizeConfig'
+      fileExtensionConfig:
+        $ref: '#/definitions/V3DLPFileExtensionConfig'
+      filePasswordConfig:
+        $ref: '#/definitions/V3DLPFilePasswordConfig'
+      fileClassifierConfig:
+        $ref: '#/definitions/V3DLPFileClassifierConfig'
+    description: |
+     A Rule defines the actual matching specification for policies. It holds a type and a configuration
+     for the rule, these properties should be used to build the corresponding matching implementation.
+     Only one of the configuration property should be set [textMatchConfig, fileSizeConfig, fileExtensionConfig, filePasswordConfig, fileClassifierConfig].
+  V3DLPFilePasswordConfig:
+    type: object
+    required:
+      - "applicableFileTypes"
+      - "matchCriteria"
+    properties:
+        applicableFileTypes:
+          type: array
+          items:
+            type: string
+          description: File types that can be applied. Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
+        matchCriteria:
+          type: string
+          description: |
+           Based on the criteria, whether a file is password protected or not means a match.
+           Can be ["PASSWORD_PROTECTED", "NOT_PASSWORD_PROTECTED"]. The default is "NOT_PASSWORD_PROTECTED".
+    description: Password protected detection config for files that are password protected or not.
+  V3DLPFileExtensionConfig:
+    type: object
+    required:
+      - "allowLists"
+    properties:
+      allowLists:
+        type: array
+        items:
+          type: string
+        description: File extensions that are allowed.
+      blockLists:
+        type: array
+        items:
+          type: string
+        description: File extensions that are blocked.
+    description: Extension detection config for allowed and blocked types of file extensions.
+  V3DLPFileSizeConfig:
+    type: object
+    properties:
+      sizeLimit:
+        type: integer
+        format: int32
+    description: File size config defines maximum allowed size of file. Default max size limit is 20 MB.
+  V3DLPTextMatchConfig:
+    type: object
+    properties:
+      dictionaries:
+        type: array
+        items:
+         $ref: '#/definitions/V3DLPDictionaryMeta'
+      countUniqueOccurrences:
+        type: integer
+        format: int32
+      applicableFileTypes:
+        type: array
+        items:
+         type: string
+        description: |
+          File types must be applied only for rule type "FileContent", otherwise must be empty.
+          Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
+    description: |
+      This is a configuration that can be used to match text or regex.
+      Configuration that can be used by a rule. This is a configuration that can be used to match text or regex.
+      This configuration also corresponds to V2 TextMatch/RegexMatch of dictionaries.
+  V3DLPDictionaryMeta:
+    type: object
+    required:
+      - "dictId"
+      - "version"
+      - "name"
+    properties:
+      dictId:
+        type: string
+      version:
+        type: string
+      name:
+        type: string
+    description: Identity of a dictionary.
+  V3DLPFileClassifierConfig:
+    type: object
+    required:
+      - "classifiers"
+      - "applicableFileTypes"
+    properties:
+      classifiers:
+        type: object
+        additionalProperties:
+         type: string
+        description: |
+         Classifier is defined as a Key and its Value: e.g.: "classification": "Internal".
+         Name and value can contain UTF-8 characters. Neither the name nor value cannot be left empty.
+         Maximum 30 characters for the name and value, case insensitive.
+         If files contains k-v pairs in the classifers map, it means a match. Maximum 30 classifiers per policy.
+      applicableFileTypes:
+        type: array
+        items:
+         type: string
+        description: |
+          File types that can be applied. Can be ["PDF", "WORD", "EXCEL", "POWERPOINT", "ZIP", "CSV", "TXT"].
+  V3DLPPolicyAppliesTo:
+    type: object
+    required:
+      - "dataType"
+      - "action"
+      - "rules"
+    properties:
+      dataType:
+        type: string
+        description: |
+          The list of data types that policy should apply to. Can't be empty.
+          Can be ["Messages","RoomMeta", "SignalMeta", "FileContent", "FileMeta"].
+      action:
+        type: string
+        description: |
+          Action to be taken on violation detection.
+          Can be ["Block", "Warn", "LogOnly"]. The default is "LogOnly".
+      rules:
+        type: array
+        items:
+          $ref: '#/definitions/V3DLPRule'
+  V3DLPPolicyResponse:
+    type: object
+    properties:
+      data:
+        $ref: '#/definitions/V3DLPPolicy'
+    description: Policy Response.
+  V3DLPPoliciesCollectionResponse:
+    type: object
+    properties:
+      policies:
+        type: array
+        description: List of policies.
+        items:
+          $ref: '#/definitions/V3DLPPolicy'
+      page:
+        type: integer
+        format: int32
+        description: The starting page for pagination.
+      size:
+        type: integer
+        format: int32
+        description: Size of policies displayed per page.
+      pageCount:
+        type: integer
+        format: int32
+        description: Total number of pages available.
+    description: List of policies.
+  V3DLPViolationMessageResponse:
+    type: object
+    properties:
+      violations:
+        type: array
+        description: A representation of list of violations due to messages sent by a user of Symphony
+        items:
+          $ref: '#/definitions/V3DLPViolationMessage'
+      nextOffset:
+        type: string
+        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
+  V3DLPViolationStreamResponse:
+    type: object
+    properties:
+      violations:
+        type: array
+        items:
+          # A representation of list of violations due to rooms creation/update sent by a user of Symphony
+          $ref: '#/definitions/V3DLPViolationStream'
+      nextOffset:
+        type: string
+        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
+  V3DLPViolationSignalResponse:
+    type: object
+    properties:
+      violations:
+        type: array
+        description: A representation of list of violations due to signal creation/update sent by a user of Symphony
+        items:
+          $ref: '#/definitions/V3DLPViolationSignal'
+      nextOffset:
+        type: string
+        description: Offset for the next chunk of violations to be submitted in the next request.  Value is null if there are no further violations.
+  V3DLPViolationMessage:
+    type: object
+    properties:
+      violation:
+        # A representation of a violation due to a message sent by a user of Symphony
+        $ref: '#/definitions/V3DLPViolation'
+      message:
+        # Message details when DLP was enforced
+        $ref: '#/definitions/V4Message'
+      sharedMessage:
+              description: Shared message details if present in message.
+              $ref: '#/definitions/V4Message'
+      diagnostic:
+        type: string
+        description: |
+          A diagnostic message containing an error message in the event there are parsing errors.
+          May also be present in the case of a successful call if there is useful narrative to return.
+  V3DLPViolationStream:
+    type: object
+    properties:
+      violation:
+        # A representation of a violation due to rooms creation/update sent by a user of Symphony
+        $ref: '#/definitions/V3DLPViolation'
+      stream:
+        # Room details when DLP was enforced
+        $ref: '#/definitions/V1DLPStream'
+  V3DLPViolationSignal:
+    type: object
+    properties:
+      violation:
+        # A representation of a violation due to signal creation/update sent by a user of Symphony
+        $ref: '#/definitions/V3DLPViolation'
+      signal:
+        # Signal details when DLP was enforced
+        $ref: '#/definitions/V1DLPSignal'
+  V3DLPViolation:
+    type: object
+    description: A representation of a violation due to an event created by a user of Symphony
+    properties:
+      enforcementEventID:
+        type: string
+        description: Enforcement event ID. Unique ID that identifies this enforcement.
+      entityID:
+        type: string
+        description: Entity ID is the content Id of the violation, for example, for messages, its the Id of the message
+      createTime:
+        type: integer
+        format: int64
+        description: Timestamp of the violation in milliseconds since Jan 1 1970
+      lastModified:
+        type: integer
+        format: int64
+        description: Timestamp of the last modification of violation in milliseconds since Jan 1 1970
+      requesterId:
+        type: integer
+        format: int64
+        description: Id of the requester responsible for the message/stream/signal
+      details:
+        type: array
+        description: JSON representation of the details of the violation.
+        items:
+          type: object
+      action:
+        type: string
+        description: action taken such as BLOCK or WARN.  See outcome for a more detailed description of the outcome this action.
+      outcome:
+        # Detailed outcome of the DLP enforcement such as REJECTED_VIOLATION, ACCEPTED_WARNING, ACCEPTED_LEGACY_CLIENT etc.
+        $ref: '#/definitions/V1DLPOutcome'
+      version:
+        type: string
+        description: Version of application which processed the message and produced this violation.
+      ignoreDLPwarning:
+          type: boolean
+          description: Did the user chose to ignore DLP warning that was presented?
+  Pagination:
+    type: object
+    required:
+      - cursors
+    properties:
+      cursors:
+        type: object
+        properties:
+          before:
+            type: string
+            description: |
+              This is the opaque url-safe string that points to the start of the page of data
+              that has been returned.
+            example: "MTAxNTExOTQ1MjAwNzI5NDE="
+          after:
+            type: string
+            description: |
+              This is the opaque url-safe string that points to the end of the page of data
+              that has been returned.
+            example: "NDMyNzQyODI3OTQw"
+      previous:
+        type: string
+        description: |
+          API endpoint that will return the previous page of data. If not included, this is
+          the first page of data.
+        example: "https://tenantapi.d.isym.io/v1/tenantinfo?limit=25&before=MTAxNTExOTQ1MjAwNzI5NDE="
+      next:
+        type: string
+        description: |
+          API endpoint that will return the next page of data. If not included, this is the
+          last page of data. Due to how pagination works with visibility and privacy, it is
+          possible that a page may be empty but contain a 'next' paging link. Stop paging when
+          the 'next' link no longer appears.
+        example: "https://tenantapi.d.isym.io/v1/tenantinfo?limit=25&after=NDMyNzQyODI3OTQw"
+  V1AuditTrailInitiatorResponse:
+    description: |
+      Audit Trail Initiator object response.
+      The attributes may vary according to the action.
+      There are different types of action and each action could have specific attributes.
+    type: object
+    properties:
+      action:
+        description: The audit trail action that has peformed
+        type: string
+      actionName:
+        description: The audit trail action name that has peformed
+        type: string
+      timestamp:
+        description: The timestamp when the action has occurred
+        type: string
+      initiatorId:
+        description: The user's id that has performed the action
+        type: string
+      initiatorUsername:
+        description: The username that has performed the action
+        type: string
+      initiatorEmailAddress:
+        description: The user's e-mail address that has performed the action
+        type: string
+    additionalProperties: true
+  V1AuditTrailInitiatorList:
+    type: object
+    properties:
+      items:
+        type: array
+        items:
+          $ref: '#/definitions/V1AuditTrailInitiatorResponse'
+      pagination:
+        type: object
+        $ref: "#/definitions/Pagination"
+  V5Datafeed:
+    type: object
+    properties:
+      id:
+        type: string
+        description: ID of the datafeed
+      createdAt:
+        type: integer
+        format: int64
+        description: Datafeed creation timestamp
+    description: Container for the feed ID
+    example:
+      id: '8e7c8672-220...'
+  V5DatafeedCreateBody:
+    type: object
+    properties:
+      tag:
+        type: string
+        maxLength: 100
+        description: A unique identifier to ensure uniqueness of the datafeed.
+  AckId:
+    description: An object containing the ackId (and parameters) associated with events that the
+      client has received through an individual feed.
+    type: object
+    properties:
+      ackId:
+        type: string
+        description: A unique id for events that can be deleted from a client's. Empty for the first read. If set to null or missing, it will be considered empty.
+          feed.
+      updatePresence:
+        type: boolean
+        default: true
+        description: Set to false to avoid updating the user's presence when reading events. Default is true.
+  V5EventList:
+    type: object
+    properties:
+      events:
+        type: array
+        items:
+          $ref: '#/definitions/V4Event'
+      ackId:
+        type: string
+        description: The ackId which acknowledges that the current batch of messages have been successfully received by the client
+  V5EventsReadBody:
+    type: object
+    properties:
+      type:
+        type: string
+        description: type of the feed. Allowed values are "fanout" and "datahose"
+      tag:
+        type: string
+        minLength: 1
+        maxLength: 80
+        description: A unique identifier to ensure uniqueness of the datafeed.
+      eventTypes:
+        type: array
+        description: |
+          At least one value is required if the type of feed is "datahose". Values must be a valid Real-Time Event type, i.e. one of:
+          * MESSAGESENT
+          * MESSAGESUPPRESSED
+          * SYMPHONYELEMENTSACTION
+          * SHAREDPOST
+          * INSTANTMESSAGECREATED
+          * ROOMCREATED
+          * ROOMUPDATED
+          * ROOMDEACTIVATED
+          * ROOMREACTIVATED
+          * USERREQUESTEDTOJOINROOM
+          * USERJOINEDROOM
+          * USERLEFTROOM
+          * ROOMMEMBERPROMOTEDTOOWNER
+          * ROOMMEMBERDEMOTEDFROMOWNER
+          * CONNECTIONREQUESTED
+          * CONNECTIONACCEPTED
+        items:
+          type: string
+        x-since: 22.7
+      ackId:
+        type: string
+        description: should be empty for the first call, acknowledges that the current batch of messages have been successfully received by the client.
+      updatePresence:
+        type: boolean
+        description: whether to update the presence status of the account to AVAILABLE when calling the endpoint. Default value is true.
+    required:
+      - type
+      - tag
+  V3Health:
+      properties:
+        services:
+          additionalProperties:
+            $ref: '#/definitions/V3HealthComponent'
+          type: object
+        status:
+          $ref: '#/definitions/V3HealthStatus'
+        users:
+          additionalProperties:
+            $ref: '#/definitions/V3HealthComponent'
+          type: object
+        version:
+          description: Required Agent verison
+          type: string
+      type: object
+  V3HealthAuthType:
+    description: Type of authentication
+    enum:
+      - RSA
+      - CERT
+    type: string
+  V3HealthComponent:
+    properties:
+      authType:
+        $ref: '#/definitions/V3HealthAuthType'
+      message:
+        description: 'An error message, if the component status is DOWN'
+        type: string
+      status:
+        $ref: '#/definitions/V3HealthStatus'
+      version:
+        description: Optional component version
+        type: string
+    type: object
+  V3HealthStatus:
+    description: Application health status.
+    enum:
+      - UP
+      - DOWN
+    type: string


### PR DESCRIPTION
Goal of this commit is to migrate Agent APIs to start using OpenAPI 3 instead of swagger 2.
Swagger 2 version is still available to maintain compatibility with existing systems that are using the specs to generate code but it will not be updated with the new coming features. Only OpenApi 3 version will be kept up to date with new implementations from now on.