### PR TITLE
Tagging createdAt field as deprecated in V5Datafeed

### DIFF
--- a/agent/agent-api-public-deprecated.yaml
+++ b/agent/agent-api-public-deprecated.yaml
@@ -3482,11 +3482,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/V5Datafeed'
-              example:
-                - id: 8e7c8672-220...
-                  createdAt: 1536346282592
-                - id: 8e7c8672-221...
-                  createdAt: 1536346282500
         400:
           description: Bad request.
           content:
@@ -7241,14 +7236,17 @@ components:
           description: ID of the datafeed
         createdAt:
           type: integer
-          description: Datafeed creation timestamp
+          description: |
+            [deprecated] Datafeed creation timestamp
           format: int64
+          deprecated: true
         type:
           type: string
           description: type of the feed. Known values are "fanout" and "datahose"
       description: Container for the feed ID
       example:
-        id: 8e7c8672-220...
+        id: 371f465fb97b5d1027d20a5e7085863a_f
+        type: fanout
     V5DatafeedCreateBody:
       type: object
       properties:

--- a/agent/agent-api-public.yaml
+++ b/agent/agent-api-public.yaml
@@ -3482,11 +3482,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/V5Datafeed'
-              example:
-                - id: 8e7c8672-220...
-                  createdAt: 1536346282592
-                - id: 8e7c8672-221...
-                  createdAt: 1536346282500
         400:
           description: Bad request.
           content:
@@ -5795,14 +5790,17 @@ components:
           description: ID of the datafeed
         createdAt:
           type: integer
-          description: Datafeed creation timestamp
+          description: |
+            [deprecated] Datafeed creation timestamp
           format: int64
+          deprecated: true
         type:
           type: string
           description: type of the feed. Known values are "fanout" and "datahose"
       description: Container for the feed ID
       example:
-        id: 8e7c8672-220...
+        id: 371f465fb97b5d1027d20a5e7085863a_f
+        type: fanout
     V5DatafeedCreateBody:
       type: object
       properties:


### PR DESCRIPTION
The agent is not setting the createdAt field, is not something we receive from DFv2. In this commit we are going to tag it as deprecated, since it cannot be removed now without breaking backward compatibility.