### PR TITLE
Tag AuthorizationToken as beta

### DIFF
--- a/agent/swagger2/agent-api-public-deprecated.yaml
+++ b/agent/swagger2/agent-api-public-deprecated.yaml
@@ -10,9 +10,6 @@ info:
     - sessionToken and keyManagerToken can be obtained by calling the
     authenticationAPI on the symphony back end and the key manager
     respectively. Refer to the methods described in authenticatorAPI.yaml.
-    - A new authorizationToken has been introduced in the authenticationAPI
-    response payload. It can be used to replace the sessionToken in any of
-    the API calls and can be passed as "Authorization" header.
     - Actions are defined to be atomic, ie will succeed in their entirety
     or fail and have changed nothing.
     - If it returns a 40X status then it will have sent no message to any

--- a/agent/swagger2/agent-api-public.yaml
+++ b/agent/swagger2/agent-api-public.yaml
@@ -10,9 +10,6 @@ info:
     - sessionToken and keyManagerToken can be obtained by calling the
     authenticationAPI on the symphony back end and the key manager
     respectively. Refer to the methods described in authenticatorAPI.yaml.
-    - A new authorizationToken has been introduced in the authenticationAPI
-    response payload. It can be used to replace the sessionToken in any of
-    the API calls and can be passed as "Authorization" header.
     - Actions are defined to be atomic, ie will succeed in their entirety
     or fail and have changed nothing.
     - If it returns a 40X status then it will have sent no message to any

--- a/authenticator/authenticator-api-public-deprecated.yaml
+++ b/authenticator/authenticator-api-public-deprecated.yaml
@@ -277,16 +277,14 @@ definitions:
       token:
         type: string
         description: |
-          Token that can be passed as header, it can be considered a refresh token along with the
-          idm/tokens ("authorizationToken").
+          Authentication token that should be passed as header in each API rest calls.
           This should be considered opaque data by the client. It is not intended to contain any data interpretable by the
           client. The format is secret and subject to change without notice.
       authorizationToken:
         type: string
         description: |
-          Short lived access token built from a user session. It can be used for the same purposes as the sessionToken
-          and it should be passed as an header named "Authorization". At least either one of SessionToken or
-          Authorization header must me provided on subsequent API calls.
+          (Beta) Short lived access token built from a user session. This field is still on Beta, please continue using 
+          the returned "token" instead.
   PodCertificate:
     type: object
     properties:

--- a/authenticator/authenticator-api-public.yaml
+++ b/authenticator/authenticator-api-public.yaml
@@ -119,16 +119,14 @@ definitions:
       token:
         type: string
         description: |
-          Token that can be passed as header, it can be considered a refresh token along with the
-          idm/tokens ("authorizationToken").
+          Authentication token that should be passed as header in each API rest calls.
           This should be considered opaque data by the client. It is not intended to contain any data interpretable by the
           client. The format is secret and subject to change without notice.
       authorizationToken:
         type: string
         description: |
-          Short lived access token built from a user session. It can be used for the same purposes as the sessionToken
-          and it should be passed as an header named "Authorization". At least either one of SessionToken or
-          Authorization header must me provided on subsequent API calls.
+          (Beta) Short lived access token built from a user session. This field is still on Beta, please continue using 
+          the returned "token" instead.
   PodCertificate:
     type: object
     properties:

--- a/login/login-api-public.yaml
+++ b/login/login-api-public.yaml
@@ -281,16 +281,14 @@ definitions:
       token:
         type: string
         description: |
-          Token that can be passed as header, it can be considered a refresh token along with the
-          idm/tokens ("authorizationToken").
+          Authentication token that should be passed as header in each API rest calls.
           This should be considered opaque data by the client. It is not intended to contain any data interpretable by the
           client. The format is secret and subject to change without notice.
       authorizationToken:
         type: string
         description: |
-          Short lived access token built from a user session. It can be used for the same purposes as the sessionToken
-          and It should be passed as an header named "Authorization". At least one between SessionToken or Authorization
-          header must me provided on subsequent API calls.
+          (Beta) Short lived access token built from a user session. This field is still on Beta, please continue using 
+          the returned "token" instead.
   AuthenticateRequest:
       type: object
       description: Request body for pubkey authentication


### PR DESCRIPTION
Tagging AuthorizationToken field as still in beta, therefore not to be used for now.

AuthorizationToken is a new field returned in the response payload of the following endpoints:
- [Session Authenticate](https://symphony.readme.io/restapi/reference/rsa-session-authenticate) 
- [Session Authenticate (Cert)](https://symphony.readme.io/restapi/reference/session-authenticate)
