### PR TITLE
Fix logout response payload

### DIFF
--- a/authenticator/authenticator-api-public-deprecated.yaml
+++ b/authenticator/authenticator-api-public-deprecated.yaml
@@ -86,7 +86,7 @@ paths:
         '200':
           description: OK.
           schema:
-            $ref: '#/definitions/Token'
+            $ref: '#/definitions/SuccessResponse'
         '400':
           description: 'Client error.'
           schema:
@@ -290,6 +290,11 @@ definitions:
     properties:
       certificate:
         description: Certificate in PEM format
+        type: string
+  SuccessResponse:
+    type: object
+    properties:
+      message:
         type: string
 
 #

--- a/authenticator/authenticator-api-public.yaml
+++ b/authenticator/authenticator-api-public.yaml
@@ -86,7 +86,7 @@ paths:
         '200':
           description: OK.
           schema:
-            $ref: '#/definitions/Token'
+            $ref: '#/definitions/SuccessResponse'
         '400':
           description: 'Client error.'
           schema:
@@ -133,4 +133,8 @@ definitions:
       certificate:
         description: Certificate in PEM format
         type: string
-
+  SuccessResponse:
+    type: object
+    properties:
+      message:
+        type: string


### PR DESCRIPTION
There was an issue in the swagger specs for the logout endpoint. The API is actually returning a simple json response with a successful message in case of a 200, instead of a Token.