### PR TITLE
Set default empty array instead of making the field as required for non-required fields

### DIFF
--- a/agent/agent-api-public-deprecated.yaml
+++ b/agent/agent-api-public-deprecated.yaml
@@ -5861,7 +5861,6 @@ components:
             $ref: '#/components/schemas/V4Message'
         errors:
           type: object
-          default: []
           additionalProperties:
             $ref: '#/components/schemas/Error'
           description: List of streams where the messages ingestion has failed

--- a/agent/agent-api-public-deprecated.yaml
+++ b/agent/agent-api-public-deprecated.yaml
@@ -5855,6 +5855,7 @@ components:
       properties:
         messages:
           type: array
+          default: []
           description: List of messages successfully sent
           items:
             $ref: '#/components/schemas/V4Message'

--- a/agent/agent-api-public-deprecated.yaml
+++ b/agent/agent-api-public-deprecated.yaml
@@ -5855,7 +5855,6 @@ components:
       properties:
         messages:
           type: array
-          default: []
           description: List of messages successfully sent
           items:
             $ref: '#/components/schemas/V4Message'

--- a/agent/agent-api-public-deprecated.yaml
+++ b/agent/agent-api-public-deprecated.yaml
@@ -5295,8 +5295,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/V2BaseMessage'
         - type: object
-          required:
-            - keywords
           properties:
             creationDate:
               type: integer
@@ -5305,6 +5303,7 @@ components:
               type: string
             keywords:
               type: array
+              default: []
               items:
                 $ref: '#/components/schemas/RoomTag'
             description:
@@ -5346,8 +5345,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/V2BaseMessage'
         - type: object
-          required:
-            - keywords
           properties:
             oldName:
               type: string
@@ -5355,6 +5352,7 @@ components:
               type: string
             keywords:
               type: array
+              default: []
               items:
                 $ref: '#/components/schemas/RoomTag'
             oldDescription:
@@ -5766,8 +5764,6 @@ components:
         $ref: '#/components/schemas/V4Message'
     V4Message:
       type: object
-      required:
-        - attachments
       properties:
         messageId:
           type: string
@@ -5793,6 +5789,7 @@ components:
           format: JSON
         attachments:
           type: array
+          default: []
           description: Message attachments
           items:
             $ref: '#/components/schemas/V4AttachmentInfo'
@@ -5858,11 +5855,13 @@ components:
       properties:
         messages:
           type: array
+          default: []
           description: List of messages successfully sent
           items:
             $ref: '#/components/schemas/V4Message'
         errors:
           type: object
+          default: []
           additionalProperties:
             $ref: '#/components/schemas/Error'
           description: List of streams where the messages ingestion has failed
@@ -5917,8 +5916,6 @@ components:
           type: boolean
     V4RoomProperties:
       type: object
-#      required:
-#        - keywords
       properties:
         name:
           type: string
@@ -7272,11 +7269,10 @@ components:
         events that the client has received through an individual feed.
     V5EventList:
       type: object
-      required:
-        - events
       properties:
         events:
           type: array
+          default: []
           items:
             $ref: '#/components/schemas/V4Event'
         ackId:
@@ -7387,8 +7383,6 @@ components:
           type: string
     V2MessageSubmission:
       type: object
-      required:
-        - attachments
       properties:
         format:
           type: string
@@ -7399,6 +7393,7 @@ components:
           type: string
         attachments:
           type: array
+          default: []
           items:
             $ref: '#/components/schemas/AttachmentInfo'
     MessageImportList:

--- a/agent/agent-api-public-deprecated.yaml
+++ b/agent/agent-api-public-deprecated.yaml
@@ -5917,8 +5917,8 @@ components:
           type: boolean
     V4RoomProperties:
       type: object
-      required:
-        - keywords
+#      required:
+#        - keywords
       properties:
         name:
           type: string
@@ -5946,6 +5946,7 @@ components:
           type: boolean
         keywords:
           type: array
+          default: []
           items:
             $ref: '#/components/schemas/V4KeyValuePair'
         canViewHistory:

--- a/agent/agent-api-public.yaml
+++ b/agent/agent-api-public.yaml
@@ -3827,7 +3827,6 @@ components:
         - required:
             - fromUserId
             - message
-            - attachments
           type: object
           properties:
             message:
@@ -3842,6 +3841,7 @@ components:
               format: int64
             attachments:
               type: array
+              default: []
               items:
                 $ref: '#/components/schemas/AttachmentInfo'
     RoomCreatedMessage:
@@ -3849,8 +3849,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/V2BaseMessage'
         - type: object
-          required:
-            - keywords
           properties:
             creationDate:
               type: integer
@@ -3859,6 +3857,7 @@ components:
               type: string
             keywords:
               type: array
+              default: []
               items:
                 $ref: '#/components/schemas/RoomTag'
             description:
@@ -3900,8 +3899,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/V2BaseMessage'
         - type: object
-          required:
-            - keywords
           properties:
             oldName:
               type: string
@@ -3909,6 +3906,7 @@ components:
               type: string
             keywords:
               type: array
+              default: []
               items:
                 $ref: '#/components/schemas/RoomTag'
             oldDescription:
@@ -4320,8 +4318,6 @@ components:
         $ref: '#/components/schemas/V4Message'
     V4Message:
       type: object
-      required:
-        - attachments
       properties:
         messageId:
           type: string
@@ -4347,6 +4343,7 @@ components:
           format: JSON
         attachments:
           type: array
+          default: []
           description: Message attachments
           items:
             $ref: '#/components/schemas/V4AttachmentInfo'
@@ -4412,11 +4409,13 @@ components:
       properties:
         messages:
           type: array
+          default: []
           description: List of messages successfully sent
           items:
             $ref: '#/components/schemas/V4Message'
         errors:
           type: object
+          default: []
           additionalProperties:
             $ref: '#/components/schemas/Error'
           description: List of streams where the messages ingestion has failed
@@ -4471,8 +4470,6 @@ components:
           type: boolean
     V4RoomProperties:
       type: object
-#      required:
-#        - keywords
       properties:
         name:
           type: string
@@ -5826,11 +5823,10 @@ components:
         events that the client has received through an individual feed.
     V5EventList:
       type: object
-      required:
-        - events
       properties:
         events:
           type: array
+          default: []
           items:
             $ref: '#/components/schemas/V4Event'
         ackId:

--- a/agent/agent-api-public.yaml
+++ b/agent/agent-api-public.yaml
@@ -4471,8 +4471,8 @@ components:
           type: boolean
     V4RoomProperties:
       type: object
-      required:
-        - keywords
+#      required:
+#        - keywords
       properties:
         name:
           type: string
@@ -4500,6 +4500,7 @@ components:
           type: boolean
         keywords:
           type: array
+          default: []
           items:
             $ref: '#/components/schemas/V4KeyValuePair'
         canViewHistory:

--- a/agent/agent-api-public.yaml
+++ b/agent/agent-api-public.yaml
@@ -4415,7 +4415,6 @@ components:
             $ref: '#/components/schemas/V4Message'
         errors:
           type: object
-          default: []
           additionalProperties:
             $ref: '#/components/schemas/Error'
           description: List of streams where the messages ingestion has failed


### PR DESCRIPTION
In last update,  array fields have been made as required in specs, maybe in order to avoid NPs. This causes issue in code generation in BDK Python. 
This PR is just a test to check if setting a default empty array value for those fields could be a compromise.