### PR TITLE
SEARCH-2772 - Add searchFields to RoomSearchCriteria

### DIFF
--- a/pod/pod-api-public.yaml
+++ b/pod/pod-api-public.yaml
@@ -8774,7 +8774,7 @@ definitions:
         example:
           - industry
       searchFields:
-        description: The room fields on which to search
+        description: The room fields on which to search. Parameter introduced in sbe-25.10.0
         type: array
         items:
           type: string


### PR DESCRIPTION
Adding new body parameter `searchFields` to allow searching for rooms only based on certain fields 