### PR TITLE
BE-7992: introduce userMetadata property

### DIFF
--- a/pod/pod-api-public.yaml
+++ b/pod/pod-api-public.yaml
@@ -8517,6 +8517,16 @@ definitions:
         example:
           - INDIVIDUAL
           - SUPER_ADMINISTRATOR
+      userMetadata:
+        type: object
+        description: 'Metadata map of key/values'
+        additionalProperties:
+          type: object
+        example:
+          com_symphony_metadataKey1: "value"
+          com_symphony_metadataKey2:
+            - "value1"
+            - "value2"
   V2UserList:
     description: List of User record version 2
     type: object
@@ -9735,6 +9745,16 @@ definitions:
         $ref: '#/definitions/V2UserKeyRequest'
       previousKey:
         $ref: '#/definitions/V2UserKeyRequest'
+      userMetadata:
+        type: object
+        description: 'Metadata map of key/values'
+        additionalProperties:
+          type: object
+        example:
+          com_symphony_metadataKey1: "value"
+          com_symphony_metadataKey2:
+            - "value1"
+            - "value2"
   V2UserKeyRequest:
     description: User RSA key information.
     type: object


### PR DESCRIPTION
`userMetadata` is a newly introduced field to bind flexible metadata key/values to users. Symphony internal use only for now.