### PR TITLE
SEARCH-3102 : agent - adds new semantic search endpoint

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -9,7 +9,7 @@ jobs:
     container:
       image: returntocorp/semgrep
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7
       - run: semgrep scan --error --config auto
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/agent/agent-api-public-deprecated.yaml
+++ b/agent/agent-api-public-deprecated.yaml
@@ -537,6 +537,79 @@ paths:
               schema:
                 $ref: '#/components/schemas/V2Error'
       x-codegen-request-body-name: query
+  /v4/message/search/semantic:
+    post:
+      tags:
+        - Messages
+      summary: Semantic search for messages
+      description: |
+        Disclaimer : Internal use only. This is not officially supported yet.
+        Search messages semantically according to the natural-language query provided in the request body.
+        The "text" field holds the query and the optional "threadId" field restricts the search to a single stream.
+      parameters:
+        - name: skip
+          in: query
+          description: No. of results to skip.
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: Max no. of results to return. If no value is provided, 25 is the default.
+          schema:
+            type: integer
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          schema:
+            type: string
+      requestBody:
+        description: The semantic search query.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SemanticSearchQuery'
+        required: true
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V4MessageList'
+        204:
+          description: No Messages.
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+      x-codegen-request-body-name: query
   /v1/stream/{sid}/attachment:
     get:
       tags:
@@ -5678,6 +5751,15 @@ components:
           type: integer
           description: Search for messages sent before this timestamp
           format: int64
+    SemanticSearchQuery:
+      type: object
+      properties:
+        text:
+          type: string
+          description: The natural-language query to search for semantically.
+        threadId:
+          type: string
+          description: Restrict the semantic search to this stream/thread.
     V4MessageImportList:
       type: array
       description: |

--- a/agent/agent-api-public.yaml
+++ b/agent/agent-api-public.yaml
@@ -537,6 +537,79 @@ paths:
               schema:
                 $ref: '#/components/schemas/V2Error'
       x-codegen-request-body-name: query
+  /v4/message/search/semantic:
+    post:
+      tags:
+        - Messages
+      summary: Semantic search for messages
+      description: |
+        Disclaimer : Internal use only. This is not officially supported yet.
+        Search messages semantically according to the natural-language query provided in the request body.
+        The "text" field holds the query and the optional "threadId" field restricts the search to a single stream.
+      parameters:
+        - name: skip
+          in: query
+          description: No. of results to skip.
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          description: Max no. of results to return. If no value is provided, 25 is the default.
+          schema:
+            type: integer
+        - name: sessionToken
+          in: header
+          description: Session authentication token.
+          required: true
+          schema:
+            type: string
+        - name: keyManagerToken
+          in: header
+          description: Key Manager authentication token.
+          schema:
+            type: string
+      requestBody:
+        description: The semantic search query.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SemanticSearchQuery'
+        required: true
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V4MessageList'
+        204:
+          description: No Messages.
+          content: {}
+        400:
+          description: Client error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        401:
+          description: 'Unauthorized: Session tokens invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        403:
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+        500:
+          description: Server error, see response body for further details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V2Error'
+      x-codegen-request-body-name: query
   /v1/stream/{sid}/attachment:
     get:
       tags:
@@ -4246,6 +4319,15 @@ components:
           type: integer
           description: Search for messages sent before this timestamp
           format: int64
+    SemanticSearchQuery:
+      type: object
+      properties:
+        text:
+          type: string
+          description: The natural-language query to search for semantically.
+        threadId:
+          type: string
+          description: Restrict the semantic search to this stream/thread.
     V4MessageImportList:
       type: array
       description: |

--- a/agent/swagger2/agent-api-public-deprecated.yaml
+++ b/agent/swagger2/agent-api-public-deprecated.yaml
@@ -421,6 +421,70 @@ paths:
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/V2Error'
+  '/v4/message/search/semantic':
+    post:
+      summary: Semantic search for messages
+      description: |
+          Disclaimer : Internal use only. This is not officially supported yet.
+          Search messages semantically according to the natural-language query provided in the request body.
+          The "text" field holds the query and the optional "threadId" field restricts the search to a single stream.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: query
+          description: The semantic search query.
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/SemanticSearchQuery'
+        - name: skip
+          description: |
+            No. of results to skip.
+          in: query
+          type: integer
+        - name: limit
+          description: |
+            Max no. of results to return. If no value is provided, 25 is the default.
+          in: query
+          type: integer
+          required: false
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: false
+          type: string
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V4MessageList'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
   '/v1/stream/{sid}/attachment':
     get:
       summary: Download an attachment.
@@ -4849,6 +4913,15 @@ definitions:
         type: integer
         format: int64
         description: Search for messages sent before this timestamp
+  SemanticSearchQuery:
+    type: object
+    properties:
+      text:
+        type: string
+        description: The natural-language query to search for semantically.
+      threadId:
+        type: string
+        description: Restrict the semantic search to this stream/thread.
   V4MessageImportList:
     description: |
       An ordered list of historic messages to be imported.

--- a/agent/swagger2/agent-api-public.yaml
+++ b/agent/swagger2/agent-api-public.yaml
@@ -421,6 +421,70 @@ paths:
           description: 'Server error, see response body for further details.'
           schema:
             $ref: '#/definitions/V2Error'
+  '/v4/message/search/semantic':
+    post:
+      summary: Semantic search for messages
+      description: |
+          Disclaimer : Internal use only. This is not officially supported yet.
+          Search messages semantically according to the natural-language query provided in the request body.
+          The "text" field holds the query and the optional "threadId" field restricts the search to a single stream.
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: query
+          description: The semantic search query.
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/SemanticSearchQuery'
+        - name: skip
+          description: |
+            No. of results to skip.
+          in: query
+          type: integer
+        - name: limit
+          description: |
+            Max no. of results to return. If no value is provided, 25 is the default.
+          in: query
+          type: integer
+          required: false
+        - name: sessionToken
+          description: Session authentication token.
+          in: header
+          required: true
+          type: string
+        - name: keyManagerToken
+          description: Key Manager authentication token.
+          in: header
+          required: false
+          type: string
+      tags:
+        - Messages
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/V4MessageList'
+        '204':
+          description: No Messages.
+        '400':
+          description: 'Client error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '401':
+          description: 'Unauthorized: Session tokens invalid.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '403':
+          description: 'Forbidden: Caller lacks necessary entitlement.'
+          schema:
+            $ref: '#/definitions/V2Error'
+        '500':
+          description: 'Server error, see response body for further details.'
+          schema:
+            $ref: '#/definitions/V2Error'
   '/v1/stream/{sid}/attachment':
     get:
       summary: Download an attachment.
@@ -3618,6 +3682,15 @@ definitions:
         type: integer
         format: int64
         description: Search for messages sent before this timestamp
+  SemanticSearchQuery:
+    type: object
+    properties:
+      text:
+        type: string
+        description: The natural-language query to search for semantically.
+      threadId:
+        type: string
+        description: Restrict the semantic search to this stream/thread.
   V4MessageImportList:
     description: |
       An ordered list of historic messages to be imported.


### PR DESCRIPTION
introduces `/v4/message/search/semantic` -   Search messages semantically according to the natural-language query provided in the request body.

> Disclaimer : Internal use only. This is not officially supported yet.